### PR TITLE
Add Bible reference tokenizer/parser pipeline

### DIFF
--- a/src/Pipeline/Ast/BibleQuery.php
+++ b/src/Pipeline/Ast/BibleQuery.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BibleGet\Api\Pipeline\Ast;
+
+final class BibleQuery
+{
+    /**
+     * @param array<VerseRef|VerseRange> $segments Non-consecutive segments joined by "."
+     */
+    public function __construct(
+        public readonly int $book,
+        public readonly array $segments,
+    ) {
+    }
+}

--- a/src/Pipeline/Ast/VerseRange.php
+++ b/src/Pipeline/Ast/VerseRange.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BibleGet\Api\Pipeline\Ast;
+
+final class VerseRange
+{
+    public function __construct(
+        public readonly VerseRef $from,
+        public readonly VerseRef $to,
+    ) {
+    }
+}

--- a/src/Pipeline/Ast/VerseRef.php
+++ b/src/Pipeline/Ast/VerseRef.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BibleGet\Api\Pipeline\Ast;
+
+final class VerseRef
+{
+    public function __construct(
+        public readonly int $book,
+        public readonly int $chapter,
+        public readonly ?int $alternateChapter = null,
+        public readonly ?int $verse = null,
+        public readonly ?string $partialSuffix = null,
+    ) {
+    }
+}

--- a/src/Pipeline/Ast/VerseRef.php
+++ b/src/Pipeline/Ast/VerseRef.php
@@ -6,12 +6,16 @@ namespace BibleGet\Api\Pipeline\Ast;
 
 final class VerseRef
 {
+    /**
+     * @param int $position Byte offset in the original input string for error reporting
+     */
     public function __construct(
         public readonly int $book,
         public readonly int $chapter,
         public readonly ?int $alternateChapter = null,
         public readonly ?int $verse = null,
         public readonly ?string $partialSuffix = null,
+        public readonly int $position = -1,
     ) {
     }
 }

--- a/src/Pipeline/Compiler/SqlCompiler.php
+++ b/src/Pipeline/Compiler/SqlCompiler.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BibleGet\Api\Pipeline\Compiler;
+
+use BibleGet\Api\Pipeline\Ast\BibleQuery;
+use BibleGet\Api\Pipeline\Ast\VerseRange;
+use BibleGet\Api\Pipeline\Ast\VerseRef;
+
+/**
+ * Walks the BibleQuery AST to produce SQL WHERE clauses.
+ *
+ * Handles:
+ * - Single verse, whole chapter, verse ranges (same-chapter and cross-chapter)
+ * - Non-consecutive verses (multiple segments → multiple SQL queries)
+ * - preferorigin annotation for Psalms
+ * - Copyright-limited verse count (LIMIT 30)
+ * - ORDER BY verseID
+ */
+final class SqlCompiler
+{
+    /**
+     * Compile a BibleQuery AST into one or more SQL SELECT statements.
+     *
+     * Non-consecutive segments (separated by "." in the original notation)
+     * produce separate SQL queries, each independently finalized with
+     * ORDER BY and optional LIMIT.
+     *
+     * @param array<int, string> $copyrightVersions
+     * @param array<int, string> $requestedCopyrightedVersions
+     * @return array<int, string> SQL queries
+     */
+    public function compile(
+        BibleQuery $query,
+        string $version,
+        string $preferOrigin,
+        array $copyrightVersions,
+        array $requestedCopyrightedVersions,
+    ): array {
+        $sqlBase = 'SELECT * FROM ' . $version . ' WHERE book = ' . $query->book;
+        $queries = [];
+
+        foreach ($query->segments as $segment) {
+            $sql = $sqlBase;
+
+            if ($segment instanceof VerseRange) {
+                $sql .= $this->compileVerseRange($segment);
+            } elseif ($segment instanceof VerseRef) {
+                $sql .= $this->compileVerseRef($segment);
+            }
+
+            $sql .= $preferOrigin;
+            $sql .= ' ORDER BY verseID';
+
+            if (
+                in_array($version, $copyrightVersions)
+                || in_array($version, $requestedCopyrightedVersions)
+            ) {
+                $sql .= ' LIMIT 30';
+            }
+
+            $queries[] = $sql;
+        }
+
+        return $queries;
+    }
+
+    private function compileVerseRef(VerseRef $ref): string
+    {
+        if ($ref->verse === null) {
+            // Whole chapter
+            return ' AND chapter = ' . $ref->chapter;
+        }
+        return ' AND chapter = ' . $ref->chapter . ' AND verse = ' . $ref->verse;
+    }
+
+    private function compileVerseRange(VerseRange $range): string
+    {
+        $from = $range->from;
+        $to   = $range->to;
+
+        // Chapter range (no verses specified)
+        if ($from->verse === null && $to->verse === null) {
+            return ' AND chapter >= ' . $from->chapter . ' AND chapter <= ' . $to->chapter;
+        }
+
+        // Same chapter verse range
+        if ($from->chapter === $to->chapter) {
+            $sql = ' AND chapter = ' . $from->chapter;
+            if ($from->verse !== null) {
+                $sql .= ' AND verse >= ' . $from->verse;
+            }
+            if ($to->verse !== null) {
+                $sql .= ' AND verse <= ' . $to->verse;
+            }
+            return $sql;
+        }
+
+        // Cross-chapter range
+        return $this->compileCrossChapterRange($from, $to);
+    }
+
+    private function compileCrossChapterRange(VerseRef $from, VerseRef $to): string
+    {
+        $sql = ' AND ( ( chapter = ' . $from->chapter;
+        if ($from->verse !== null) {
+            $sql .= ' AND verse >= ' . $from->verse;
+        }
+        $sql .= ' )';
+
+        // Intermediate chapters (full chapters between from and to)
+        for ($ch = $from->chapter + 1; $ch < $to->chapter; $ch++) {
+            $sql .= ' OR ( chapter = ' . $ch . ' )';
+        }
+
+        $sql .= ' OR ( chapter = ' . $to->chapter;
+        if ($to->verse !== null) {
+            $sql .= ' AND verse <= ' . $to->verse;
+        }
+        $sql .= ' ) )';
+
+        return $sql;
+    }
+}

--- a/src/Pipeline/Compiler/SqlCompiler.php
+++ b/src/Pipeline/Compiler/SqlCompiler.php
@@ -27,6 +27,8 @@ final class SqlCompiler
      * produce separate SQL queries, each independently finalized with
      * ORDER BY and optional LIMIT.
      *
+     * @param string|array<int, string> $preferOrigin  Single string (applied to all segments)
+     *                                                  or per-segment array of preferOrigin suffixes
      * @param array<int, string> $copyrightVersions
      * @param array<int, string> $requestedCopyrightedVersions
      * @return array<int, string> SQL queries
@@ -34,14 +36,16 @@ final class SqlCompiler
     public function compile(
         BibleQuery $query,
         string $version,
-        string $preferOrigin,
+        string|array $preferOrigin,
         array $copyrightVersions,
         array $requestedCopyrightedVersions,
     ): array {
-        $sqlBase = 'SELECT * FROM ' . $version . ' WHERE book = ' . $query->book;
-        $queries = [];
+        $sqlBase  = 'SELECT * FROM ' . $version . ' WHERE book = ' . $query->book;
+        $queries  = [];
+        $isCopied = in_array($version, $copyrightVersions)
+            || in_array($version, $requestedCopyrightedVersions);
 
-        foreach ($query->segments as $segment) {
+        foreach ($query->segments as $i => $segment) {
             $sql = $sqlBase;
 
             if ($segment instanceof VerseRange) {
@@ -50,13 +54,13 @@ final class SqlCompiler
                 $sql .= $this->compileVerseRef($segment);
             }
 
-            $sql .= $preferOrigin;
-            $sql .= ' ORDER BY verseID';
+            $segmentOrigin = is_array($preferOrigin)
+                ? ( $preferOrigin[$i] ?? '' )
+                : $preferOrigin;
+            $sql          .= $segmentOrigin;
+            $sql          .= ' ORDER BY verseID';
 
-            if (
-                in_array($version, $copyrightVersions)
-                || in_array($version, $requestedCopyrightedVersions)
-            ) {
+            if ($isCopied) {
                 $sql .= ' LIMIT 30';
             }
 

--- a/src/Pipeline/Parser/ParseException.php
+++ b/src/Pipeline/Parser/ParseException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BibleGet\Api\Pipeline\Parser;
+
+final class ParseException extends \RuntimeException
+{
+    public function __construct(
+        string $message,
+        public readonly int $tokenPosition,
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/src/Pipeline/Parser/ReferenceParser.php
+++ b/src/Pipeline/Parser/ReferenceParser.php
@@ -1,0 +1,266 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BibleGet\Api\Pipeline\Parser;
+
+use BibleGet\Api\Pipeline\Ast\BibleQuery;
+use BibleGet\Api\Pipeline\Ast\VerseRange;
+use BibleGet\Api\Pipeline\Ast\VerseRef;
+use BibleGet\Api\Pipeline\Tokenizer\Token;
+use BibleGet\Api\Pipeline\Tokenizer\TokenType;
+
+/**
+ * Recursive-descent parser that converts a Token[] stream into AST nodes.
+ *
+ * Grammar (post-tokenization, numbers already classified):
+ *
+ *   query       → bookRef segments EOF
+ *   bookRef     → BOOK_NUMERIC_PREFIX? BOOK_NAME
+ *   segments    → segment (EXPLICIT_VERSE_SEPARATOR verseRef)*
+ *   segment     → chapterRef (RANGE_SEPARATOR rangeTarget)?
+ *   chapterRef  → CHAPTER_NUMBER altChapter? (CHAPTER_VERSE_SEPARATOR verse)?
+ *   rangeTarget → CHAPTER_NUMBER altChapter? (CHAPTER_VERSE_SEPARATOR verse)?
+ *               | verse
+ *   verseRef    → verse (RANGE_SEPARATOR verse)?
+ *   verse       → VERSE_NUMBER PARTIAL_VERSE_SUFFIX?
+ *   altChapter  → OPEN_PARENTHESIS ALTERNATE_CHAPTER CLOSE_PARENTHESIS
+ */
+final class ReferenceParser
+{
+    /** @var Token[] */
+    private array $tokens;
+    private int $pos;
+    private int $book;
+
+    /**
+     * @param Token[] $tokens
+     */
+    public function parse(array $tokens): BibleQuery
+    {
+        $this->tokens = $tokens;
+        $this->pos    = 0;
+        $this->book   = 0;
+
+        $this->parseBookRef();
+        $segments = $this->parseSegments();
+
+        return new BibleQuery($this->book, $segments);
+    }
+
+    private function parseBookRef(): void
+    {
+        // The book index is not resolved here — we store 0 as a placeholder.
+        // The validator resolves the book name to its numeric index.
+        if ($this->check(TokenType::BOOK_NUMERIC_PREFIX)) {
+            $this->advance(); // consume prefix
+        }
+
+        $this->expect(TokenType::BOOK_NAME);
+    }
+
+    /**
+     * @return array<VerseRef|VerseRange>
+     */
+    private function parseSegments(): array
+    {
+        $segments = [];
+
+        // First segment starts with a chapter
+        $segment = $this->parseSegment();
+        if ($segment !== null) {
+            $segments[] = $segment;
+        }
+
+        // Additional segments after EXPLICIT_VERSE_SEPARATOR
+        while ($this->check(TokenType::EXPLICIT_VERSE_SEPARATOR)) {
+            $this->advance(); // consume "."
+            $verseOrRange = $this->parseVerseRef();
+            if ($verseOrRange !== null) {
+                $segments[] = $verseOrRange;
+            }
+        }
+
+        return $segments;
+    }
+
+    private function parseSegment(): VerseRef|VerseRange|null
+    {
+        if (!$this->check(TokenType::CHAPTER_NUMBER)) {
+            return null;
+        }
+
+        $chapter = (int) $this->current()->value;
+        $this->advance();
+
+        $alternateChapter = $this->parseAltChapter();
+
+        $verse       = null;
+        $verseSuffix = null;
+
+        if ($this->check(TokenType::CHAPTER_VERSE_SEPARATOR)) {
+            $this->advance(); // consume ","
+            [$verse, $verseSuffix] = $this->parseVerse();
+        }
+
+        $fromRef = new VerseRef($this->book, $chapter, $alternateChapter, $verse, $verseSuffix);
+
+        // Check for range
+        if ($this->check(TokenType::RANGE_SEPARATOR)) {
+            $this->advance(); // consume "-"
+            $toRef = $this->parseRangeTarget($chapter, $alternateChapter, $verse);
+            if ($toRef !== null) {
+                return new VerseRange($fromRef, $toRef);
+            }
+        }
+
+        return $fromRef;
+    }
+
+    private function parseRangeTarget(int $fromChapter, ?int $fromAltChapter, ?int $fromVerse): ?VerseRef
+    {
+        // rangeTarget → CHAPTER_NUMBER altChapter? (CHAPTER_VERSE_SEPARATOR verse)? | verse
+        if ($this->check(TokenType::CHAPTER_NUMBER)) {
+            $chapter = (int) $this->current()->value;
+            $this->advance();
+
+            $alternateChapter = $this->parseAltChapter();
+
+            $verse       = null;
+            $verseSuffix = null;
+
+            if ($this->check(TokenType::CHAPTER_VERSE_SEPARATOR)) {
+                $this->advance();
+                [$verse, $verseSuffix] = $this->parseVerse();
+            }
+
+            return new VerseRef($this->book, $chapter, $alternateChapter, $verse, $verseSuffix);
+        }
+
+        if ($this->check(TokenType::VERSE_NUMBER)) {
+            [$verse, $verseSuffix] = $this->parseVerse();
+            // Same chapter as the "from" side
+            return new VerseRef($this->book, $fromChapter, $fromAltChapter, $verse, $verseSuffix);
+        }
+
+        return null;
+    }
+
+    /**
+     * Parse a verse reference (after EXPLICIT_VERSE_SEPARATOR), which may itself be a range.
+     */
+    private function parseVerseRef(): VerseRef|VerseRange|null
+    {
+        if (!$this->check(TokenType::VERSE_NUMBER)) {
+            return null;
+        }
+
+        // We need the current chapter context from the first segment.
+        // The chapter is inherited from the last segment's chapter.
+        $chapter = $this->inferCurrentChapter();
+
+        [$verse, $verseSuffix] = $this->parseVerse();
+        $fromRef               = new VerseRef($this->book, $chapter, null, $verse, $verseSuffix);
+
+        if ($this->check(TokenType::RANGE_SEPARATOR)) {
+            $this->advance();
+            if ($this->check(TokenType::VERSE_NUMBER)) {
+                [$toVerse, $toSuffix] = $this->parseVerse();
+                $toRef                = new VerseRef($this->book, $chapter, null, $toVerse, $toSuffix);
+                return new VerseRange($fromRef, $toRef);
+            }
+        }
+
+        return $fromRef;
+    }
+
+    /**
+     * Parse a VERSE_NUMBER optionally followed by PARTIAL_VERSE_SUFFIX.
+     *
+     * @return array{int, ?string}
+     */
+    private function parseVerse(): array
+    {
+        $verse = (int) $this->current()->value;
+        $this->advance();
+
+        $suffix = null;
+        if ($this->check(TokenType::PARTIAL_VERSE_SUFFIX)) {
+            $suffix = $this->current()->value;
+            $this->advance();
+        }
+
+        return [$verse, $suffix];
+    }
+
+    private function parseAltChapter(): ?int
+    {
+        if (!$this->check(TokenType::OPEN_PARENTHESIS)) {
+            return null;
+        }
+        $this->advance(); // consume "("
+
+        $alt = null;
+        if ($this->check(TokenType::ALTERNATE_CHAPTER)) {
+            $alt = (int) $this->current()->value;
+            $this->advance();
+        }
+
+        if ($this->check(TokenType::CLOSE_PARENTHESIS)) {
+            $this->advance(); // consume ")"
+        }
+
+        return $alt;
+    }
+
+    /**
+     * Infer the current chapter from previously parsed tokens.
+     * Walks backward through the token stream to find the last CHAPTER_NUMBER.
+     */
+    private function inferCurrentChapter(): int
+    {
+        for ($i = $this->pos - 1; $i >= 0; $i--) {
+            if ($this->tokens[$i]->type === TokenType::CHAPTER_NUMBER) {
+                return (int) $this->tokens[$i]->value;
+            }
+        }
+        return 1;
+    }
+
+    private function current(): Token
+    {
+        return $this->tokens[$this->pos];
+    }
+
+    private function check(TokenType $type): bool
+    {
+        return $this->pos < count($this->tokens) && $this->tokens[$this->pos]->type === $type;
+    }
+
+    private function advance(): void
+    {
+        if ($this->pos < count($this->tokens)) {
+            $this->pos++;
+        }
+    }
+
+    private function expect(TokenType $type): Token
+    {
+        if (!$this->check($type)) {
+            $actual   = $this->pos < count($this->tokens)
+                ? $this->tokens[$this->pos]->type->value
+                : 'end of input';
+            $position = $this->pos < count($this->tokens)
+                ? $this->tokens[$this->pos]->position
+                : -1;
+            throw new ParseException(
+                sprintf('Expected %s but found %s at position %d', $type->value, $actual, $position),
+                $position
+            );
+        }
+
+        $token = $this->tokens[$this->pos];
+        $this->advance();
+        return $token;
+    }
+}

--- a/src/Pipeline/Parser/ReferenceParser.php
+++ b/src/Pipeline/Parser/ReferenceParser.php
@@ -111,7 +111,8 @@ final class ReferenceParser
             return null;
         }
 
-        $chapter = (int) $this->current()->value;
+        $chapterPos = $this->current()->position;
+        $chapter    = (int) $this->current()->value;
         $this->advance();
 
         $alternateChapter = $this->parseAltChapter();
@@ -130,7 +131,7 @@ final class ReferenceParser
             [$verse, $verseSuffix] = $this->parseVerse();
         }
 
-        $fromRef = new VerseRef($this->book, $chapter, $alternateChapter, $verse, $verseSuffix);
+        $fromRef = new VerseRef($this->book, $chapter, $alternateChapter, $verse, $verseSuffix, $chapterPos);
 
         // Check for range
         if ($this->check(TokenType::RANGE_SEPARATOR)) {
@@ -153,7 +154,8 @@ final class ReferenceParser
     {
         // rangeTarget → CHAPTER_NUMBER altChapter? (CHAPTER_VERSE_SEPARATOR verse)? | verse
         if ($this->check(TokenType::CHAPTER_NUMBER)) {
-            $chapter = (int) $this->current()->value;
+            $chapterPos = $this->current()->position;
+            $chapter    = (int) $this->current()->value;
             $this->advance();
 
             $alternateChapter = $this->parseAltChapter();
@@ -172,13 +174,14 @@ final class ReferenceParser
                 [$verse, $verseSuffix] = $this->parseVerse();
             }
 
-            return new VerseRef($this->book, $chapter, $alternateChapter, $verse, $verseSuffix);
+            return new VerseRef($this->book, $chapter, $alternateChapter, $verse, $verseSuffix, $chapterPos);
         }
 
         if ($this->check(TokenType::VERSE_NUMBER)) {
+            $versePos              = $this->current()->position;
             [$verse, $verseSuffix] = $this->parseVerse();
             // Same chapter as the "from" side
-            return new VerseRef($this->book, $fromChapter, $fromAltChapter, $verse, $verseSuffix);
+            return new VerseRef($this->book, $fromChapter, $fromAltChapter, $verse, $verseSuffix, $versePos);
         }
 
         return null;
@@ -195,10 +198,11 @@ final class ReferenceParser
 
         // We need the current chapter context from the first segment.
         // The chapter is inherited from the last segment's chapter.
-        $chapter = $this->inferCurrentChapter();
+        $chapter  = $this->inferCurrentChapter();
+        $versePos = $this->current()->position;
 
         [$verse, $verseSuffix] = $this->parseVerse();
-        $fromRef               = new VerseRef($this->book, $chapter, null, $verse, $verseSuffix);
+        $fromRef               = new VerseRef($this->book, $chapter, null, $verse, $verseSuffix, $versePos);
 
         if ($this->check(TokenType::RANGE_SEPARATOR)) {
             $sepPos = $this->current()->position;
@@ -209,8 +213,9 @@ final class ReferenceParser
                     $sepPos
                 );
             }
+            $toPos                = $this->current()->position;
             [$toVerse, $toSuffix] = $this->parseVerse();
-            $toRef                = new VerseRef($this->book, $chapter, null, $toVerse, $toSuffix);
+            $toRef                = new VerseRef($this->book, $chapter, null, $toVerse, $toSuffix, $toPos);
             return new VerseRange($fromRef, $toRef);
         }
 

--- a/src/Pipeline/Parser/ReferenceParser.php
+++ b/src/Pipeline/Parser/ReferenceParser.php
@@ -125,11 +125,16 @@ final class ReferenceParser
 
         // Check for range
         if ($this->check(TokenType::RANGE_SEPARATOR)) {
+            $sepPos = $this->current()->position;
             $this->advance(); // consume "-"
             $toRef = $this->parseRangeTarget($chapter, $alternateChapter, $verse);
-            if ($toRef !== null) {
-                return new VerseRange($fromRef, $toRef);
+            if ($toRef === null) {
+                throw new ParseException(
+                    sprintf('Expected chapter or verse number after range separator at position %d', $sepPos),
+                    $sepPos
+                );
             }
+            return new VerseRange($fromRef, $toRef);
         }
 
         return $fromRef;
@@ -187,12 +192,17 @@ final class ReferenceParser
         $fromRef               = new VerseRef($this->book, $chapter, null, $verse, $verseSuffix);
 
         if ($this->check(TokenType::RANGE_SEPARATOR)) {
+            $sepPos = $this->current()->position;
             $this->advance();
-            if ($this->check(TokenType::VERSE_NUMBER)) {
-                [$toVerse, $toSuffix] = $this->parseVerse();
-                $toRef                = new VerseRef($this->book, $chapter, null, $toVerse, $toSuffix);
-                return new VerseRange($fromRef, $toRef);
+            if (!$this->check(TokenType::VERSE_NUMBER)) {
+                throw new ParseException(
+                    sprintf('Expected verse number after range separator at position %d', $sepPos),
+                    $sepPos
+                );
             }
+            [$toVerse, $toSuffix] = $this->parseVerse();
+            $toRef                = new VerseRef($this->book, $chapter, null, $toVerse, $toSuffix);
+            return new VerseRange($fromRef, $toRef);
         }
 
         return $fromRef;
@@ -222,17 +232,25 @@ final class ReferenceParser
         if (!$this->check(TokenType::OPEN_PARENTHESIS)) {
             return null;
         }
+        $openPos = $this->current()->position;
         $this->advance(); // consume "("
 
-        $alt = null;
-        if ($this->check(TokenType::ALTERNATE_CHAPTER)) {
-            $alt = (int) $this->current()->value;
-            $this->advance();
+        if (!$this->check(TokenType::ALTERNATE_CHAPTER)) {
+            throw new ParseException(
+                sprintf('Expected alternate chapter number after opening parenthesis at position %d', $openPos),
+                $openPos
+            );
         }
+        $alt = (int) $this->current()->value;
+        $this->advance();
 
-        if ($this->check(TokenType::CLOSE_PARENTHESIS)) {
-            $this->advance(); // consume ")"
+        if (!$this->check(TokenType::CLOSE_PARENTHESIS)) {
+            throw new ParseException(
+                sprintf('Expected closing parenthesis after alternate chapter number at position %d', $this->current()->position),
+                $this->current()->position
+            );
         }
+        $this->advance(); // consume ")"
 
         return $alt;
     }

--- a/src/Pipeline/Parser/ReferenceParser.php
+++ b/src/Pipeline/Parser/ReferenceParser.php
@@ -78,19 +78,28 @@ final class ReferenceParser
     {
         $segments = [];
 
-        // First segment starts with a chapter
+        // First segment must start with a chapter number
         $segment = $this->parseSegment();
-        if ($segment !== null) {
-            $segments[] = $segment;
+        if ($segment === null) {
+            throw new ParseException(
+                sprintf('Expected chapter number at position %d', $this->current()->position),
+                $this->current()->position
+            );
         }
+        $segments[] = $segment;
 
         // Additional segments after EXPLICIT_VERSE_SEPARATOR
         while ($this->check(TokenType::EXPLICIT_VERSE_SEPARATOR)) {
+            $dotPos = $this->current()->position;
             $this->advance(); // consume "."
             $verseOrRange = $this->parseVerseRef();
-            if ($verseOrRange !== null) {
-                $segments[] = $verseOrRange;
+            if ($verseOrRange === null) {
+                throw new ParseException(
+                    sprintf('Expected verse number after verse separator at position %d', $dotPos),
+                    $dotPos
+                );
             }
+            $segments[] = $verseOrRange;
         }
 
         return $segments;

--- a/src/Pipeline/Parser/ReferenceParser.php
+++ b/src/Pipeline/Parser/ReferenceParser.php
@@ -56,7 +56,10 @@ final class ReferenceParser
             $this->advance(); // consume prefix
         }
 
-        $this->expect(TokenType::BOOK_NAME);
+        if ($this->check(TokenType::BOOK_NAME)) {
+            $this->advance();
+        }
+        // If no book name found, book stays at 0 (inherited from previous query)
     }
 
     /**
@@ -242,25 +245,5 @@ final class ReferenceParser
         if ($this->pos < count($this->tokens)) {
             $this->pos++;
         }
-    }
-
-    private function expect(TokenType $type): Token
-    {
-        if (!$this->check($type)) {
-            $actual   = $this->pos < count($this->tokens)
-                ? $this->tokens[$this->pos]->type->value
-                : 'end of input';
-            $position = $this->pos < count($this->tokens)
-                ? $this->tokens[$this->pos]->position
-                : -1;
-            throw new ParseException(
-                sprintf('Expected %s but found %s at position %d', $type->value, $actual, $position),
-                $position
-            );
-        }
-
-        $token = $this->tokens[$this->pos];
-        $this->advance();
-        return $token;
     }
 }

--- a/src/Pipeline/Parser/ReferenceParser.php
+++ b/src/Pipeline/Parser/ReferenceParser.php
@@ -45,6 +45,15 @@ final class ReferenceParser
         $this->parseBookRef();
         $segments = $this->parseSegments();
 
+        // Reject trailing tokens that were not consumed by the grammar
+        if (!$this->check(TokenType::EOF)) {
+            $token = $this->current();
+            throw new ParseException(
+                sprintf('Unexpected token %s at position %d', $token->type->value, $token->position),
+                $token->position
+            );
+        }
+
         return new BibleQuery($this->book, $segments);
     }
 

--- a/src/Pipeline/Parser/ReferenceParser.php
+++ b/src/Pipeline/Parser/ReferenceParser.php
@@ -112,6 +112,12 @@ final class ReferenceParser
 
         if ($this->check(TokenType::CHAPTER_VERSE_SEPARATOR)) {
             $this->advance(); // consume ","
+            if (!$this->check(TokenType::VERSE_NUMBER)) {
+                throw new ParseException(
+                    sprintf('Expected verse number after chapter-verse separator at position %d', $this->current()->position),
+                    $this->current()->position
+                );
+            }
             [$verse, $verseSuffix] = $this->parseVerse();
         }
 
@@ -143,6 +149,12 @@ final class ReferenceParser
 
             if ($this->check(TokenType::CHAPTER_VERSE_SEPARATOR)) {
                 $this->advance();
+                if (!$this->check(TokenType::VERSE_NUMBER)) {
+                    throw new ParseException(
+                        sprintf('Expected verse number after chapter-verse separator at position %d', $this->current()->position),
+                        $this->current()->position
+                    );
+                }
                 [$verse, $verseSuffix] = $this->parseVerse();
             }
 

--- a/src/Pipeline/Parser/ReferenceParser.php
+++ b/src/Pipeline/Parser/ReferenceParser.php
@@ -137,7 +137,7 @@ final class ReferenceParser
         if ($this->check(TokenType::RANGE_SEPARATOR)) {
             $sepPos = $this->current()->position;
             $this->advance(); // consume "-"
-            $toRef = $this->parseRangeTarget($chapter, $alternateChapter, $verse);
+            $toRef = $this->parseRangeTarget($chapter, $alternateChapter);
             if ($toRef === null) {
                 throw new ParseException(
                     sprintf('Expected chapter or verse number after range separator at position %d', $sepPos),
@@ -150,7 +150,7 @@ final class ReferenceParser
         return $fromRef;
     }
 
-    private function parseRangeTarget(int $fromChapter, ?int $fromAltChapter, ?int $fromVerse): ?VerseRef
+    private function parseRangeTarget(int $fromChapter, ?int $fromAltChapter): ?VerseRef
     {
         // rangeTarget → CHAPTER_NUMBER altChapter? (CHAPTER_VERSE_SEPARATOR verse)? | verse
         if ($this->check(TokenType::CHAPTER_NUMBER)) {

--- a/src/Pipeline/QueryFormulator.php
+++ b/src/Pipeline/QueryFormulator.php
@@ -4,441 +4,91 @@ declare(strict_types=1);
 
 namespace BibleGet\Api\Pipeline;
 
+use BibleGet\Api\Pipeline\Compiler\SqlCompiler;
+use BibleGet\Api\Pipeline\Transform\PsalmRemapper;
+
 /**
  * Translates validated Bible references into SQL queries.
- * Ported from the legacy QUERY_FORMULATOR class.
+ *
+ * Delegates to PsalmRemapper → SqlCompiler internally using the parsed ASTs
+ * from QuoteContext. Public API (formulateSQLQueries) and its effects on
+ * QuoteContext remain unchanged.
  */
 class QueryFormulator
 {
     private QuoteContext $ctx;
-    private int $nn                         = 0;
-    private int $i                          = -1;
-    private string $currentQuery            = '';
-    private string $currentFullQuery        = '';
-    private string $currentChapter          = '';
-    private string $sqlQuery                = '';
-    private int $previousBook               = 0;
-    private int $currentBook                = 0;
-    private string $currentVariant          = '';
-    private string $currentRequestedVariant = '';
-    private string $currentPreferOrigin     = '';
+    private SqlCompiler $compiler;
+    private PsalmRemapper $remapper;
+
     /** @var array<int, string> */
     public array $sqlQueries = [];
     /** @var array<int, string> */
     public array $queriesVersions = [];
     /** @var array<int, string> */
     public array $originalQueries = [];
-    /** @var array<int, string> */
-    public array $queries = [];
 
     public function __construct(QuoteContext $ctx)
     {
-        $this->ctx     = $ctx;
-        $this->queries = $ctx->validatedQueries;
-    }
-
-    private static function queryContainsNonConsecutiveVerses(string $query): bool
-    {
-        return strpos($query, '.') !== false;
-    }
-
-    /**
-     * @return array<int, string>
-     */
-    private static function getNonConsecutiveChunks(string $query): array
-    {
-        return preg_split('/\./', $query) ?: [$query];
-    }
-
-    private static function chunkContainsRange(string $chunk): bool
-    {
-        return strpos($chunk, '-') !== false;
-    }
-
-    private static function chunkContainsChapterVerseConstruct(string $chunk): bool
-    {
-        return strpos($chunk, ',') !== false;
-    }
-
-    /**
-     * @return array<string, string>
-     */
-    private static function getRange(string $chunk): array
-    {
-        $parts = preg_split('/\-/', $chunk) ?: [$chunk, ''];
-        return ['from' => $parts[0], 'to' => $parts[1] ?? ''];
-    }
-
-    /**
-     * @return array<string, string>
-     */
-    private static function getChapterVerseFromConstruct(string $construct): array
-    {
-        $parts = preg_split('/,/', $construct) ?: [$construct, ''];
-        return ['chapter' => $parts[0], 'verse' => $parts[1] ?? ''];
-    }
-
-    /**
-     * @return array<int, string>|false
-     */
-    private function captureBookIndicator(): array|false
-    {
-        if (QuoteContext::stringWithUpperAndLowerCaseVariants($this->currentQuery)) {
-            if (preg_match('/^([1-4]{0,1}((\p{Lu}\p{Ll}*)+))/u', $this->currentQuery, $res)) {
-                $this->currentQuery = substr($this->currentQuery, strlen($res[0]));
-                return $res;
-            }
-            return false;
-        }
-        if (preg_match('/^([1-4]{0,1}((\p{L}\p{M}*)+))/u', $this->currentQuery, $res)) {
-            $this->currentQuery = preg_replace('/^[1-4]{0,1}(\p{L}\p{M}*)+/u', '', $this->currentQuery) ?? $this->currentQuery;
-            return $res;
-        }
-        return false;
-    }
-
-    private function validateVerseOriginPreference(): void
-    {
-        $this->currentPreferOrigin = '';
-        if ($this->currentBook === 19) {
-            if (in_array($this->currentRequestedVariant, $this->ctx->CATHOLIC_VERSIONS)) {
-                $preferOrigin              = $this->ctx->DATA['preferorigin'] ?? '';
-                $origin                    = in_array($preferOrigin, QuoteContext::ALLOWED_PREFER_ORIGINS, true) ? $preferOrigin : 'GREEK';
-                $this->currentPreferOrigin = " AND verseorigin = '" . $origin . "'";
-            }
-        }
-    }
-
-    private function initSQLStatement(): void
-    {
-        $this->sqlQuery = 'SELECT * FROM ' . $this->currentRequestedVariant . ' WHERE book = ' . (int) $this->currentBook;
-    }
-
-    private function setSQLLimit(): void
-    {
-        if (
-            in_array($this->currentRequestedVariant, $this->ctx->COPYRIGHT_VERSIONS)
-            || in_array($this->currentRequestedVariant, $this->ctx->REQUESTED_COPYRIGHTED_VERSIONS)
-        ) {
-            $this->sqlQueries[$this->nn] .= ' LIMIT 30';
-        }
-    }
-
-    private function finalizeQuery(): void
-    {
-        $this->sqlQueries[$this->nn]     .= $this->currentPreferOrigin;
-        $this->queriesVersions[$this->nn] = $this->currentRequestedVariant;
-        $this->sqlQueries[$this->nn]     .= ' ORDER BY verseID';
-        $this->setSQLLimit();
-    }
-
-    /**
-     * @param array<int, string> $matchedBook
-     */
-    private function bestGuessBookIdx(array $matchedBook): int
-    {
-        $key1 = $this->currentVariant != '' ? array_search($matchedBook[0], $this->ctx->INDEXES[$this->currentVariant]['biblebooks']) : false;
-        $key2 = $this->currentVariant != '' ? array_search($matchedBook[0], $this->ctx->INDEXES[$this->currentVariant]['abbreviations']) : false;
-        $key3 = QuoteContext::idxOf($matchedBook[0], $this->ctx->BIBLEBOOKS);
-
-        if ($key1 !== false) {
-            return $this->ctx->INDEXES[$this->currentVariant]['book_num'][$key1];
-        } elseif ($key2 !== false) {
-            return $this->ctx->INDEXES[$this->currentVariant]['book_num'][$key2];
-        } elseif ($key3 !== false) {
-            return $key3 + 1;
-        }
-        return 0;
-    }
-
-    /**
-     * @param array<int, string>|false $matchedBook
-     */
-    private function setBook(array|false $matchedBook): void
-    {
-        if ($matchedBook) {
-            $this->currentBook  = $this->bestGuessBookIdx($matchedBook);
-            $this->previousBook = $this->currentBook;
-        } else {
-            $this->currentBook = $this->previousBook;
-        }
-        if ($this->currentBook === 0) {
-            $this->ctx->logger->warning('No valid book indicator found for query', [
-                'query' => $this->currentFullQuery,
-            ]);
-        }
-    }
-
-    /**
-     * @param array<string, string|null> $cvConstructLeft
-     * @param array<string, string|null> $cvConstructRight
-     */
-    private function accountForMultipleChapterDifference(array $cvConstructLeft, array $cvConstructRight): void
-    {
-        $rightChapter = (int) $cvConstructRight['chapter'];
-        $leftChapter  = (int) $cvConstructLeft['chapter'];
-        if ($rightChapter - $leftChapter > 1) {
-            for ($d = 1; $d < ( $rightChapter - $leftChapter ); $d++) {
-                $this->sqlQueries[$this->nn] .= ' OR ( chapter = ' . ( $leftChapter + $d ) . ' )';
-            }
-        }
-    }
-
-    /**
-     * Build a range predicate for two chapter,verse endpoints.
-     * When both endpoints are in the same chapter, uses a simple AND range.
-     * When they span chapters, uses OR with intermediate chapter coverage.
-     *
-     * @param array<string, string|null> $cvConstructLeft
-     * @param array<string, string|null> $cvConstructRight
-     */
-    private function buildRangePredicate(array $cvConstructLeft, array $cvConstructRight): void
-    {
-        if ((int) $cvConstructLeft['chapter'] === (int) $cvConstructRight['chapter']) {
-            $this->sqlQueries[$this->nn] = $this->sqlQuery
-                . ' AND chapter = ' . (int) $cvConstructLeft['chapter']
-                . ' AND verse >= ' . (int) $cvConstructLeft['verse']
-                . ' AND verse <= ' . (int) $cvConstructRight['verse'];
-        } else {
-            $this->sqlQueries[$this->nn] = $this->sqlQuery . ' AND ( ( chapter = ' . (int) $cvConstructLeft['chapter'] . ' AND verse >= ' . (int) $cvConstructLeft['verse'] . ' )';
-            $this->accountForMultipleChapterDifference($cvConstructLeft, $cvConstructRight);
-            $this->sqlQueries[$this->nn] .= ' OR ( chapter = ' . (int) $cvConstructRight['chapter'] . ' AND verse <= ' . (int) $cvConstructRight['verse'] . ' ) )';
-        }
-    }
-
-    /**
-     * Psalm verse-mapping rules for VGCL/DRB versions.
-     * Each entry: [[chapter, verseMin, verseMax], ...] => [mappedChapter, mappedVerse]
-     * A null verseMin/verseMax means the rule matches when verse is null too.
-     *
-     * @var array<int, array{ranges: array<int, array{int, int|null, int|null}>, map: array{int, int}}>
-     */
-    private const PSALM_VGCL_DRB_MAPPINGS = [
-        ['ranges' => [[10, 4, 13], [11, 1, 1]],       'map' => [10, 3]],
-        ['ranges' => [[11, 2, 12], [12, 1, 6]],       'map' => [1, 1]],
-        ['ranges' => [[13, 1, 7]],                     'map' => [3, 13]],
-        ['ranges' => [[13, 8, 18], [14, 1, 19]],      'map' => [4, 17]],
-        ['ranges' => [[15, 1, 3]],                     'map' => [4, 8]],
-        ['ranges' => [[15, 4, 14]],                    'map' => [5, 1]],
-        ['ranges' => [[15, 15, 19]],                   'map' => [5, 2]],
-        ['ranges' => [[16, null, null]],               'map' => [8, 12]],
-    ];
-
-    /**
-     * @return array{int, int, string}|null  [chapter, verse, preferorigin] or null if no mapping applies
-     */
-    private function matchPsalmMapping(int|string|null $chapter, int|string|null $verse): ?array
-    {
-        foreach (self::PSALM_VGCL_DRB_MAPPINGS as $mapping) {
-            foreach ($mapping['ranges'] as [$rngChapter, $rngMin, $rngMax]) {
-                if ($chapter != $rngChapter) {
-                    continue;
-                }
-                $verseInRange = $rngMin === null
-                    ? $verse === null
-                    : $verse !== null && $verse >= $rngMin && $verse <= ( $rngMax ?? $rngMin );
-                if ($verseInRange) {
-                    return [$mapping['map'][0], $mapping['map'][1], " AND verseorigin = 'GREEK'"];
-                }
-            }
-        }
-        return null;
-    }
-
-    /**
-     * @param-out string $toChapter
-     * @param-out string|null $toVerse
-     */
-    private function mapReference(int|string|null $chapter, int|string|null $verse, string|null &$toChapter, string|null &$toVerse, bool $updatePreferOrigin): void
-    {
-        $preferorigin = $this->currentPreferOrigin;
-
-        if ($this->isPsalmInVgclDrb()) {
-            $mapped = $this->matchPsalmMapping($chapter, $verse);
-            if ($mapped !== null) {
-                [$chapter, $verse, $preferorigin] = $mapped;
-            }
-        }
-
-        if ($updatePreferOrigin) {
-            $this->currentPreferOrigin = $preferorigin;
-        }
-        $toChapter = (string) $chapter;
-        $toVerse   = $verse !== null ? (string) $verse : null;
-    }
-
-    private function isPsalmInVgclDrb(): bool
-    {
-        $version = $this->currentRequestedVariant;
-        $book    = $this->currentBook;
-        return in_array($version, $this->ctx->CATHOLIC_VERSIONS)
-            && $book === 19
-            && ( $version === 'VGCL' || $version === 'DRB' );
-    }
-
-    /**
-     * @param array<string, string> $range
-     */
-    private function formulateRangeWithChapterVerse(array $range): void
-    {
-        $cvConstructLeft      = self::getChapterVerseFromConstruct($range['from']);
-        $this->currentChapter = $cvConstructLeft['chapter'];
-        $this->mapReference($cvConstructLeft['chapter'], $cvConstructLeft['verse'], $cvConstructLeft['chapter'], $cvConstructLeft['verse'], true);
-
-        if (self::chunkContainsChapterVerseConstruct($range['to'])) {
-            $cvConstructRight     = self::getChapterVerseFromConstruct($range['to']);
-            $this->currentChapter = $cvConstructRight['chapter'];
-            $this->mapReference($cvConstructRight['chapter'], $cvConstructRight['verse'], $cvConstructRight['chapter'], $cvConstructRight['verse'], true);
-            $this->buildRangePredicate($cvConstructLeft, $cvConstructRight);
-        } else {
-            $mappedChapter = null;
-            $mappedVerse   = $range['to'];
-            $this->mapReference($this->currentChapter, $range['to'], $mappedChapter, $mappedVerse, true);
-            if ((int) $mappedChapter !== (int) $cvConstructLeft['chapter']) {
-                // Mapping crossed a chapter boundary — emit a cross-chapter predicate
-                $this->sqlQueries[$this->nn] = $this->sqlQuery . ' AND ( ( chapter = ' . (int) $cvConstructLeft['chapter'] . ' AND verse >= ' . (int) $cvConstructLeft['verse'] . ' )';
-                $leftArr                     = ['chapter' => $cvConstructLeft['chapter'], 'verse' => $cvConstructLeft['verse']];
-                $rightArr                    = ['chapter' => $mappedChapter, 'verse' => $mappedVerse];
-                $this->accountForMultipleChapterDifference($leftArr, $rightArr);
-                $this->sqlQueries[$this->nn] .= ' OR ( chapter = ' . (int) $mappedChapter . ' AND verse <= ' . (int) $mappedVerse . ' ) )';
-            } else {
-                $this->sqlQueries[$this->nn] = $this->sqlQuery . ' AND chapter = ' . (int) $cvConstructLeft['chapter'] . ' AND verse >= ' . (int) $cvConstructLeft['verse'] . ' AND verse <= ' . (int) $mappedVerse;
-            }
-        }
-    }
-
-    private function formulateRangeChunk(string $chunk): void
-    {
-        $range = self::getRange($chunk);
-        if (self::chunkContainsChapterVerseConstruct($range['from'])) {
-            $this->formulateRangeWithChapterVerse($range);
-        } else {
-            $mappedChapter   = null;
-            $mappedVerseFrom = $range['from'];
-            $this->mapReference($this->currentChapter, $range['from'], $mappedChapter, $mappedVerseFrom, true);
-            $this->currentChapter = $mappedChapter;
-            $mappedVerseTo        = $range['to'];
-            $unusedChapter        = null;
-            $this->mapReference($this->currentChapter, $range['to'], $unusedChapter, $mappedVerseTo, false);
-            $this->sqlQueries[$this->nn] = $this->sqlQuery . ' AND ( chapter = ' . (int) $this->currentChapter . ' AND verse >= ' . (int) $mappedVerseFrom . ' AND verse <= ' . (int) $mappedVerseTo . ' )';
-        }
-    }
-
-    private function formulateSingleChunk(string $chunk): void
-    {
-        if (self::chunkContainsChapterVerseConstruct($chunk)) {
-            $cvConstruct          = self::getChapterVerseFromConstruct($chunk);
-            $this->currentChapter = $cvConstruct['chapter'];
-            $this->mapReference($cvConstruct['chapter'], $cvConstruct['verse'], $cvConstruct['chapter'], $cvConstruct['verse'], true);
-            $this->sqlQueries[$this->nn] = $this->sqlQuery . ' AND ( chapter = ' . (int) $cvConstruct['chapter'] . ' AND verse = ' . (int) $cvConstruct['verse'] . ' )';
-        } else {
-            $mappedChapter = null;
-            $mappedVerse   = $chunk;
-            $this->mapReference($this->currentChapter, $chunk, $mappedChapter, $mappedVerse, true);
-            $this->currentChapter        = $mappedChapter;
-            $this->sqlQueries[$this->nn] = $this->sqlQuery . ' AND ( chapter = ' . (int) $this->currentChapter . ' AND verse = ' . (int) $mappedVerse . ' )';
-        }
-    }
-
-    private function formulateNonConsecutiveVerses(): void
-    {
-        $nonConsecutiveChunks = self::getNonConsecutiveChunks($this->currentQuery);
-        $basePreferOrigin     = $this->currentPreferOrigin;
-        foreach ($nonConsecutiveChunks as $chunk) {
-            $this->currentPreferOrigin        = $basePreferOrigin;
-            $this->originalQueries[$this->nn] = $this->currentFullQuery;
-            if (self::chunkContainsRange($chunk)) {
-                $this->formulateRangeChunk($chunk);
-            } else {
-                $this->formulateSingleChunk($chunk);
-            }
-            $this->finalizeQuery();
-            $this->nn++;
-        }
-    }
-
-    private function formulateConsecutiveVerses(): void
-    {
-        $this->originalQueries[$this->nn] = $this->currentFullQuery;
-
-        if (self::chunkContainsRange($this->currentQuery)) {
-            $range = self::getRange($this->currentQuery);
-            if (self::chunkContainsChapterVerseConstruct($range['from'])) {
-                $cvConstructLeft      = self::getChapterVerseFromConstruct($range['from']);
-                $this->currentChapter = $cvConstructLeft['chapter'];
-                $this->mapReference($cvConstructLeft['chapter'], $cvConstructLeft['verse'], $cvConstructLeft['chapter'], $cvConstructLeft['verse'], true);
-                if (self::chunkContainsChapterVerseConstruct($range['to'])) {
-                    $cvConstructRight = self::getChapterVerseFromConstruct($range['to']);
-                    $this->mapReference($cvConstructRight['chapter'], $cvConstructRight['verse'], $cvConstructRight['chapter'], $cvConstructRight['verse'], true);
-                    $this->buildRangePredicate($cvConstructLeft, $cvConstructRight);
-                } else {
-                    $mappedChapter = null;
-                    $mappedVerse   = $range['to'];
-                    $this->mapReference($cvConstructLeft['chapter'], $range['to'], $mappedChapter, $mappedVerse, true);
-                    if ((int) $mappedChapter !== (int) $cvConstructLeft['chapter']) {
-                        $this->sqlQueries[$this->nn] = $this->sqlQuery . ' AND ( ( chapter = ' . (int) $cvConstructLeft['chapter'] . ' AND verse >= ' . (int) $cvConstructLeft['verse'] . ' )';
-                        $leftArr                     = ['chapter' => $cvConstructLeft['chapter'], 'verse' => $cvConstructLeft['verse']];
-                        $rightArr                    = ['chapter' => $mappedChapter, 'verse' => $mappedVerse];
-                        $this->accountForMultipleChapterDifference($leftArr, $rightArr);
-                        $this->sqlQueries[$this->nn] .= ' OR ( chapter = ' . (int) $mappedChapter . ' AND verse <= ' . (int) $mappedVerse . ' ) )';
-                    } else {
-                        $this->sqlQueries[$this->nn] = $this->sqlQuery . ' AND chapter = ' . (int) $cvConstructLeft['chapter'] . ' AND verse >= ' . (int) $cvConstructLeft['verse'] . ' AND verse <= ' . (int) $mappedVerse;
-                    }
-                }
-            } else {
-                $nullVerse = null;
-                $this->mapReference($range['from'], null, $range['from'], $nullVerse, true);
-                $this->mapReference($range['to'], null, $range['to'], $nullVerse, false);
-                $this->sqlQueries[$this->nn] = $this->sqlQuery . ' AND chapter >= ' . (int) $range['from'] . ' AND chapter <= ' . (int) $range['to'];
-            }
-        } elseif (self::chunkContainsChapterVerseConstruct($this->currentQuery)) {
-            $cvConstruct          = self::getChapterVerseFromConstruct($this->currentQuery);
-            $this->currentChapter = $cvConstruct['chapter'];
-            $this->mapReference($cvConstruct['chapter'], $cvConstruct['verse'], $cvConstruct['chapter'], $cvConstruct['verse'], true);
-            $this->sqlQueries[$this->nn] = $this->sqlQuery . ' AND chapter = ' . (int) $cvConstruct['chapter'] . ' AND verse = ' . (int) $cvConstruct['verse'];
-        } else {
-            $this->currentChapter = $this->currentQuery;
-            $mappedChapter        = null;
-            $nullVerse            = null;
-            $this->mapReference($this->currentChapter, null, $mappedChapter, $nullVerse, true);
-            $this->sqlQueries[$this->nn] = $this->sqlQuery . ' AND chapter = ' . (int) $mappedChapter;
-        }
-
-        $this->finalizeQuery();
-        $this->nn++;
+        $this->ctx      = $ctx;
+        $this->compiler = new SqlCompiler();
+        $this->remapper = new PsalmRemapper($ctx->CATHOLIC_VERSIONS);
     }
 
     public function formulateSQLQueries(): void
     {
+        $nn = 0;
+
         foreach ($this->ctx->REQUESTED_VERSIONS as $version) {
-            $this->i                       = 0;
-            $this->currentRequestedVariant = $version;
-            foreach ($this->queries as $query) {
-                $this->currentQuery     = $query;
-                $this->currentFullQuery = $query;
-                $this->currentChapter   = '';
-                if (!in_array($version, $this->ctx->validatedVariants[$this->i])) {
-                    $this->i++;
+            foreach ($this->ctx->parsedQueries as $i => $parsedQuery) {
+                // Check if this version was validated for this query
+                if (!in_array($version, $this->ctx->validatedVariants[$i])) {
                     continue;
                 }
-                $this->currentVariant = $version;
 
-                $matchedBook = $this->captureBookIndicator();
-                $this->setBook($matchedBook);
-                $this->initSQLStatement();
-                $this->validateVerseOriginPreference();
+                // Determine preferOrigin
+                $preferOrigin = $this->buildPreferOrigin($parsedQuery->book, $version);
 
-                if (self::queryContainsNonConsecutiveVerses($this->currentQuery)) {
-                    $this->formulateNonConsecutiveVerses();
-                } else {
-                    $this->formulateConsecutiveVerses();
+                // Apply Psalm remapping (AST → AST)
+                [$remappedQuery, $preferOrigin] = $this->remapper->remap(
+                    $parsedQuery,
+                    $version,
+                    $preferOrigin
+                );
+
+                // Compile AST → SQL
+                $sqls = $this->compiler->compile(
+                    $remappedQuery,
+                    $version,
+                    $preferOrigin,
+                    $this->ctx->COPYRIGHT_VERSIONS,
+                    $this->ctx->REQUESTED_COPYRIGHTED_VERSIONS
+                );
+
+                $originalQuery = $this->ctx->validatedQueries[$i];
+
+                foreach ($sqls as $sql) {
+                    $this->sqlQueries[$nn]      = $sql;
+                    $this->queriesVersions[$nn] = $version;
+                    $this->originalQueries[$nn] = $originalQuery;
+                    $nn++;
                 }
-                $this->i++;
             }
         }
 
         $this->ctx->formulatedQueries  = $this->sqlQueries;
         $this->ctx->originalQueries    = $this->originalQueries;
         $this->ctx->formulatedVariants = $this->queriesVersions;
+    }
+
+    private function buildPreferOrigin(int $book, string $version): string
+    {
+        if ($book === 19 && in_array($version, $this->ctx->CATHOLIC_VERSIONS)) {
+            $preferOrigin = $this->ctx->DATA['preferorigin'] ?? '';
+            $origin       = in_array($preferOrigin, QuoteContext::ALLOWED_PREFER_ORIGINS, true)
+                ? $preferOrigin
+                : 'GREEK';
+            return " AND verseorigin = '" . $origin . "'";
+        }
+        return '';
     }
 }

--- a/src/Pipeline/QueryFormulator.php
+++ b/src/Pipeline/QueryFormulator.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace BibleGet\Api\Pipeline;
 
 use BibleGet\Api\Pipeline\Compiler\SqlCompiler;
-use BibleGet\Api\Pipeline\Transform\PsalmRemapper;
+use BibleGet\Api\Pipeline\Transform\EstherRemapper;
+use BibleGet\Api\Pipeline\Transform\PsalmChapterSwapper;
 
 /**
  * Translates validated Bible references into SQL queries.
  *
- * Delegates to PsalmRemapper → SqlCompiler internally using the parsed ASTs
+ * Delegates to EstherRemapper → SqlCompiler internally using the parsed ASTs
  * from QuoteContext. Public API (formulateSQLQueries) and its effects on
  * QuoteContext remain unchanged.
  */
@@ -18,7 +19,8 @@ class QueryFormulator
 {
     private QuoteContext $ctx;
     private SqlCompiler $compiler;
-    private PsalmRemapper $remapper;
+    private EstherRemapper $estherRemapper;
+    private PsalmChapterSwapper $psalmSwapper;
 
     /** @var array<int, string> */
     public array $sqlQueries = [];
@@ -29,9 +31,10 @@ class QueryFormulator
 
     public function __construct(QuoteContext $ctx)
     {
-        $this->ctx      = $ctx;
-        $this->compiler = new SqlCompiler();
-        $this->remapper = new PsalmRemapper($ctx->CATHOLIC_VERSIONS);
+        $this->ctx            = $ctx;
+        $this->compiler       = new SqlCompiler();
+        $this->estherRemapper = new EstherRemapper($ctx->CATHOLIC_VERSIONS);
+        $this->psalmSwapper   = new PsalmChapterSwapper();
     }
 
     public function formulateSQLQueries(): void
@@ -48,12 +51,15 @@ class QueryFormulator
                 // Determine base preferOrigin for this book/version
                 $basePreferOrigin = $this->buildPreferOrigin($parsedQuery->book, $version);
 
-                // Apply Psalm remapping (AST → AST), returns per-segment origins
-                [$remappedQuery, $perSegmentOrigins] = $this->remapper->remap(
+                // Apply Esther Greek additions remapping (AST → AST)
+                [$remappedQuery, $perSegmentOrigins] = $this->estherRemapper->remap(
                     $parsedQuery,
                     $version,
                     $basePreferOrigin
                 );
+
+                // Apply Psalm chapter swap for Vulgate-numbered versions
+                $remappedQuery = $this->psalmSwapper->swap($remappedQuery, $version);
 
                 // Compile AST → SQL with per-segment preferOrigin
                 $sqls = $this->compiler->compile(
@@ -80,9 +86,11 @@ class QueryFormulator
         $this->ctx->formulatedVariants = $this->queriesVersions;
     }
 
+    private const ESTHER_BOOK_NUM = 19;
+
     private function buildPreferOrigin(int $book, string $version): string
     {
-        if ($book === 19 && in_array($version, $this->ctx->CATHOLIC_VERSIONS)) {
+        if ($book === self::ESTHER_BOOK_NUM && in_array($version, $this->ctx->CATHOLIC_VERSIONS)) {
             $preferOrigin = $this->ctx->DATA['preferorigin'] ?? '';
             $origin       = in_array($preferOrigin, QuoteContext::ALLOWED_PREFER_ORIGINS, true)
                 ? $preferOrigin

--- a/src/Pipeline/QueryFormulator.php
+++ b/src/Pipeline/QueryFormulator.php
@@ -45,21 +45,21 @@ class QueryFormulator
                     continue;
                 }
 
-                // Determine preferOrigin
-                $preferOrigin = $this->buildPreferOrigin($parsedQuery->book, $version);
+                // Determine base preferOrigin for this book/version
+                $basePreferOrigin = $this->buildPreferOrigin($parsedQuery->book, $version);
 
-                // Apply Psalm remapping (AST → AST)
-                [$remappedQuery, $preferOrigin] = $this->remapper->remap(
+                // Apply Psalm remapping (AST → AST), returns per-segment origins
+                [$remappedQuery, $perSegmentOrigins] = $this->remapper->remap(
                     $parsedQuery,
                     $version,
-                    $preferOrigin
+                    $basePreferOrigin
                 );
 
-                // Compile AST → SQL
+                // Compile AST → SQL with per-segment preferOrigin
                 $sqls = $this->compiler->compile(
                     $remappedQuery,
                     $version,
-                    $preferOrigin,
+                    $perSegmentOrigins,
                     $this->ctx->COPYRIGHT_VERSIONS,
                     $this->ctx->REQUESTED_COPYRIGHTED_VERSIONS
                 );

--- a/src/Pipeline/QueryValidator.php
+++ b/src/Pipeline/QueryValidator.php
@@ -4,366 +4,36 @@ declare(strict_types=1);
 
 namespace BibleGet\Api\Pipeline;
 
+use BibleGet\Api\Pipeline\Ast\BibleQuery;
+use BibleGet\Api\Pipeline\Parser\ParseException;
+use BibleGet\Api\Pipeline\Parser\ReferenceParser;
+use BibleGet\Api\Pipeline\Tokenizer\ReferenceTokenizer;
+use BibleGet\Api\Pipeline\Tokenizer\TokenType;
+use BibleGet\Api\Pipeline\Validator\AstValidator;
+
 /**
  * Validates Bible reference syntax and structure.
- * Ported from the legacy QUERY_VALIDATOR class.
+ *
+ * Delegates to Tokenizer → Parser → AstValidator internally.
+ * Public API (validateQueries) and its effects on QuoteContext remain unchanged.
  */
 class QueryValidator
 {
-    private const QUERY_MUST_START_WITH_VALID_BOOK_INDICATOR                          = 0;
-    private const VALID_CHAPTER_MUST_FOLLOW_BOOK                                      = 1;
-    private const VERSE_SEPARATOR_MUST_BE_PRECEDED_BY_CHAPTER_VERSE_SEPARATOR         = 3;
-    private const VERSE_SEPARATOR_MUST_BE_PRECEDED_BY_1_TO_3_DIGITS                   = 4;
-    private const CHAPTER_VERSE_SEPARATOR_MUST_BE_PRECEDED_BY_1_TO_3_DIGITS           = 5;
-    private const VERSE_RANGE_MUST_CONTAIN_VALID_VERSE_NUMBERS                        = 6;
-    private const CORRESPONDING_CHAPTER_VERSE_CONSTRUCTS_IN_VERSE_RANGE_OVER_CHAPTERS = 7;
-    private const CORRESPONDING_VERSE_SEPARATORS_FOR_MULTIPLE_VERSE_RANGES            = 8;
-
     private QuoteContext $ctx;
-    private int|false $bookIdxBase   = -1;
-    private int $nonZeroBookIdx      = -1;
-    private string $currentBook      = '';
-    private string $currentQuery     = '';
-    private string $currentFullQuery = '';
-    /** @var array<int, string> */
-    private array $validatedVariants = [];
+    private ReferenceTokenizer $tokenizer;
+    private ReferenceParser $parser;
+
+    /** @var int Previous book index (1-based) for book inheritance across queries */
+    private int $previousBook = 0;
+
+    /** @var string Previous book name for error messages */
+    private string $previousBookName = '';
 
     public function __construct(QuoteContext $ctx)
     {
-        $this->ctx = $ctx;
-    }
-
-    /**
-     * @return array<int, string>|false
-     */
-    private static function matchBookInQuery(string $query): array|false
-    {
-        if (QuoteContext::stringWithUpperAndLowerCaseVariants($query)) {
-            if (preg_match('/^([1-4]{0,1}((\p{Lu}\p{Ll}*)+))/u', $query, $res)) {
-                return $res;
-            }
-            return false;
-        }
-        if (preg_match('/^([1-4]{0,1}((\p{L}\p{M}*)+))/u', $query, $res)) {
-            return $res;
-        }
-        return false;
-    }
-
-    private static function validateRuleAgainstQuery(int $rule, string $query): bool
-    {
-        return match ($rule) {
-            self::QUERY_MUST_START_WITH_VALID_BOOK_INDICATOR =>
-                (bool) ( preg_match('/^[1-4]{0,1}\p{Lu}\p{Ll}*/u', $query) || preg_match('/^[1-4]{0,1}(\p{L}\p{M}*)+/u', $query) ),
-            self::VALID_CHAPTER_MUST_FOLLOW_BOOK =>
-                QuoteContext::stringWithUpperAndLowerCaseVariants($query)
-                    ? ( preg_match('/^[1-3]{0,1}\p{Lu}\p{Ll}*/u', $query) == preg_match('/^[1-3]{0,1}\p{Lu}\p{Ll}*[1-9][0-9]{0,2}/u', $query) )
-                    : ( preg_match('/^[1-3]{0,1}(\p{L}\p{M}*)+/u', $query) == preg_match('/^[1-3]{0,1}(\p{L}\p{M}*)+[1-9][0-9]{0,2}/u', $query) ),
-            self::VERSE_SEPARATOR_MUST_BE_PRECEDED_BY_CHAPTER_VERSE_SEPARATOR =>
-                !( strpos($query, ',') === false || strpos($query, ',') > strpos($query, '.') ),
-            self::VERSE_SEPARATOR_MUST_BE_PRECEDED_BY_1_TO_3_DIGITS =>
-                ( preg_match_all('/(?<![0-9])(?=([1-9][0-9]{0,2}\.[1-9][0-9]{0,2}))/', $query) === substr_count($query, '.') ),
-            self::CHAPTER_VERSE_SEPARATOR_MUST_BE_PRECEDED_BY_1_TO_3_DIGITS =>
-                ( preg_match_all('/[1-9][0-9]{0,2}\,[1-9][0-9]{0,2}/', $query) === substr_count($query, ',') ),
-            self::VERSE_RANGE_MUST_CONTAIN_VALID_VERSE_NUMBERS =>
-                ( preg_match_all('/[1-9][0-9]{0,2}\-[1-9][0-9]{0,2}/', $query) === substr_count($query, '-') ),
-            self::CORRESPONDING_CHAPTER_VERSE_CONSTRUCTS_IN_VERSE_RANGE_OVER_CHAPTERS =>
-                !( preg_match('/\-[1-9][0-9]{0,2}\,/', $query) && ( !preg_match('/\,[1-9][0-9]{0,2}\-/', $query) || preg_match_all('/(?=\,[1-9][0-9]{0,2}\-)/', $query) > preg_match_all('/(?=\-[1-9][0-9]{0,2}\,)/', $query) ) ),
-            self::CORRESPONDING_VERSE_SEPARATORS_FOR_MULTIPLE_VERSE_RANGES =>
-                !( substr_count($query, '-') > 1 && ( strpos($query, '.') === false || ( substr_count($query, '-') - 1 > substr_count($query, '.') ) ) ),
-            default => false,
-        };
-    }
-
-    private static function queryContainsNonConsecutiveVerses(string $query): bool
-    {
-        return strpos($query, '.') !== false;
-    }
-
-    /**
-     * @param array<int, string>|string $element
-     * @return array<int, string>
-     */
-    private static function forceArray(array|string $element): array
-    {
-        return is_array($element) ? $element : [$element];
-    }
-
-    /**
-     * @return array{0: array<int, string>, 1: array<int, string>}
-     */
-    private static function getAllVersesAfterDiscontinuousVerseIndicator(string $query): array
-    {
-        if (preg_match_all('/\.([1-9][0-9]{0,2})/', $query, $discontinuousVerses)) {
-            return [
-                array_map('strval', $discontinuousVerses[0]),
-                array_map('strval', $discontinuousVerses[1]),
-            ];
-        }
-        return [[], []];
-    }
-
-    /**
-     * @return array<int, string|array<never, never>>
-     */
-    private static function getVerseAfterChapterVerseSeparator(string $query): ?array
-    {
-        if (preg_match('/,([1-9][0-9]{0,2})/', $query, $verse)) {
-            return $verse;
-        }
-        return null;
-    }
-
-    private static function chunkContainsChapterVerseConstruct(string $chunk): bool
-    {
-        return strpos($chunk, ',') !== false;
-    }
-
-    /**
-     * @return array{0: array<int, string>, 1: array<int, string>}
-     */
-    private static function getAllChapterIndicators(string $query): array
-    {
-        if (preg_match_all('/([1-9][0-9]{0,2})\,/', $query, $chapterIndicators)) {
-            return [
-                array_map('strval', $chapterIndicators[0]),
-                array_map('strval', $chapterIndicators[1]),
-            ];
-        }
-        return [[], []];
-    }
-
-    /**
-     * @param array<int, string>|false $matchedBook
-     */
-    private function validateAndSetBook(array|false $matchedBook): bool
-    {
-        if ($matchedBook !== false) {
-            $this->currentBook = $matchedBook[0];
-            if ($this->validateBibleBook() === false) {
-                return false;
-            }
-            $this->currentQuery = str_replace($this->currentBook, '', $this->currentQuery);
-            return true;
-        }
-        return $this->validateBibleBook();
-    }
-
-    private function validateChapterVerseConstructs(): bool
-    {
-        $chapterVerseConstructCount = substr_count($this->currentQuery, ',');
-        if ($chapterVerseConstructCount > 1) {
-            return $this->validateMultipleVerseSeparators();
-        } elseif ($chapterVerseConstructCount == 1) {
-            $parts = explode(',', $this->currentQuery);
-            if (strpos($parts[1], '-') !== false) {
-                if ($this->validateRightHandSideOfVerseSeparator($parts) === false) {
-                    return false;
-                }
-            } else {
-                if ($this->validateVersesAfterChapterVerseSeparators($parts) === false) {
-                    return false;
-                }
-            }
-            $discontinuousVerses = self::getAllVersesAfterDiscontinuousVerseIndicator($this->currentQuery);
-            foreach ($discontinuousVerses[1] as $dVerse) {
-                if ($this->highVerseOutOfBounds($dVerse, $parts)) {
-                    return false;
-                }
-            }
-        }
-        return true;
-    }
-
-    /**
-     * @param array<int, int> $rules
-     */
-    private function queryViolatesAnyRuleOf(string $query, array $rules): bool
-    {
-        foreach ($rules as $rule) {
-            if (self::validateRuleAgainstQuery($rule, $query) === false) {
-                $this->ctx->addErrorMessage($rule);
-                $this->ctx->incrementBadQueryCount();
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private function isValidBookForVariant(string $variant): bool
-    {
-        return in_array($this->nonZeroBookIdx, $this->ctx->INDEXES[$variant]['book_num']);
-    }
-
-    private function validateBibleBook(): bool
-    {
-        $this->bookIdxBase = QuoteContext::idxOf($this->currentBook, $this->ctx->BIBLEBOOKS);
-        if ($this->bookIdxBase === false) {
-            $this->ctx->addErrorMessage(sprintf('The book %s is not a valid Bible book. Please check the documentation for a list of correct Bible book names, whether full or abbreviated.', $this->currentBook));
-            $this->ctx->incrementBadQueryCount();
-        } else {
-            $this->nonZeroBookIdx = $this->bookIdxBase + 1;
-            foreach ($this->ctx->REQUESTED_VERSIONS as $variant) {
-                if ($this->isValidBookForVariant($variant)) {
-                    $this->validatedVariants[] = $variant;
-                }
-            }
-        }
-        return $this->bookIdxBase !== false;
-    }
-
-    /**
-     * @param array<int, array<int, string>> $chapterIndicators
-     */
-    private function validateChapterIndicators(array $chapterIndicators): bool
-    {
-        foreach ($chapterIndicators[1] as $chapterIndicator) {
-            foreach ($this->ctx->INDEXES as $jkey => $jindex) {
-                $bookidx = array_search($this->nonZeroBookIdx, $jindex['book_num']);
-                if ($bookidx === false) {
-                    continue;
-                }
-                $chapter_limit = $jindex['chapter_limit'][$bookidx];
-                if ($chapterIndicator > $chapter_limit) {
-                    $msg = 'A chapter in the query is out of bounds: there is no chapter <%1$d> in the book %2$s in the requested version %3$s, the last possible chapter is <%4$d>';
-                    $this->ctx->addErrorMessage(sprintf($msg, $chapterIndicator, $this->currentBook, $jkey, $chapter_limit));
-                    $this->ctx->incrementBadQueryCount();
-                    return false;
-                }
-            }
-        }
-        return true;
-    }
-
-    private function validateMultipleVerseSeparators(): bool
-    {
-        if (strpos($this->currentQuery, '-') === false) {
-            $this->ctx->addErrorMessage('You cannot have more than one comma and not have a dash!');
-            $this->ctx->incrementBadQueryCount();
-            return false;
-        }
-        $parts = explode('-', $this->currentQuery);
-        if (count($parts) != 2) {
-            $this->ctx->addErrorMessage('You seem to have a malformed querystring, there should be only one dash.');
-            $this->ctx->incrementBadQueryCount();
-            return false;
-        }
-        foreach ($parts as $part) {
-            $pp = array_map('intval', explode(',', $part));
-            foreach ($this->ctx->INDEXES as $jkey => $jindex) {
-                $bookidx = array_search($this->nonZeroBookIdx, $jindex['book_num']);
-                if ($bookidx === false) {
-                    continue;
-                }
-                $chapters_verselimit = $jindex['verse_limit'][$bookidx];
-                $verselimit          = intval($chapters_verselimit[$pp[0] - 1]);
-                if ($pp[1] > $verselimit) {
-                    $msg = 'A verse in the query is out of bounds: there is no verse <%1$d> in the book %2$s at chapter <%3$d> in the requested version %4$s, the last possible verse is <%5$d>';
-                    $this->ctx->addErrorMessage(sprintf($msg, $pp[1], $this->currentBook, $pp[0], $jkey, $verselimit));
-                    $this->ctx->incrementBadQueryCount();
-                    return false;
-                }
-            }
-        }
-        return true;
-    }
-
-    /**
-     * @param array<int, string> $parts
-     */
-    private function validateRightHandSideOfVerseSeparator(array $parts): bool
-    {
-        if (preg_match_all('/[,\.][1-9][0-9]{0,2}\-([1-9][0-9]{0,2})/', $this->currentQuery, $matches)) {
-            $matches[1] = self::forceArray($matches[1]);
-            $highverse  = intval(array_pop($matches[1]));
-            foreach ($this->ctx->INDEXES as $jkey => $jindex) {
-                $bookidx = array_search($this->nonZeroBookIdx, $jindex['book_num']);
-                if ($bookidx === false) {
-                    continue;
-                }
-                $chapters_verselimit = $jindex['verse_limit'][$bookidx];
-                $verselimit          = intval($chapters_verselimit[intval($parts[0]) - 1]);
-                if ($highverse > $verselimit) {
-                    $msg = 'A verse in the query is out of bounds: there is no verse <%1$d> in the book %2$s at chapter <%3$d> in the requested version %4$s, the last possible verse is <%5$d>';
-                    $this->ctx->addErrorMessage(sprintf($msg, $highverse, $this->currentBook, $parts[0], $jkey, $verselimit));
-                    $this->ctx->incrementBadQueryCount();
-                    return false;
-                }
-            }
-        }
-        return true;
-    }
-
-    /**
-     * @param array<int, string> $parts
-     */
-    private function validateVersesAfterChapterVerseSeparators(array $parts): bool
-    {
-        $versesAfterChapterVerseSeparators = self::getVerseAfterChapterVerseSeparator($this->currentQuery);
-        if ($versesAfterChapterVerseSeparators === null) {
-            return true;
-        }
-        $highverse = intval($versesAfterChapterVerseSeparators[1]);
-        foreach ($this->ctx->INDEXES as $jkey => $jindex) {
-            $bookidx = array_search($this->nonZeroBookIdx, $jindex['book_num']);
-            if ($bookidx === false) {
-                continue;
-            }
-            $chapters_verselimit = $jindex['verse_limit'][$bookidx];
-            $verselimit          = intval($chapters_verselimit[intval($parts[0]) - 1]);
-            if ($highverse > $verselimit) {
-                $msg = 'A verse in the query is out of bounds: there is no verse <%1$d> in the book %2$s at chapter <%3$d> in the requested version %4$s, the last possible verse is <%5$d>';
-                $this->ctx->addErrorMessage(sprintf($msg, $highverse, $this->currentBook, $parts[0], $jkey, $verselimit));
-                $this->ctx->incrementBadQueryCount();
-                return false;
-            }
-        }
-        return true;
-    }
-
-    /**
-     * @param array<int, string> $parts
-     */
-    private function highVerseOutOfBounds(int|string|null $highverse, array $parts): bool
-    {
-        foreach ($this->ctx->INDEXES as $jkey => $jindex) {
-            $bookidx = array_search($this->nonZeroBookIdx, $jindex['book_num']);
-            if ($bookidx === false) {
-                continue;
-            }
-            $chapters_verselimit = $jindex['verse_limit'][$bookidx];
-            $verselimit          = intval($chapters_verselimit[intval($parts[0]) - 1]);
-            if ($highverse > $verselimit) {
-                $msg = 'A verse in the query is out of bounds: there is no verse <%1$d> in the book %2$s at chapter <%3$d> in the requested version %4$s, the last possible verse is <%5$d>';
-                $this->ctx->addErrorMessage(sprintf($msg, $highverse, $this->currentBook, $parts[0], $jkey, $verselimit));
-                $this->ctx->incrementBadQueryCount();
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * @param array<int, string> $chapters
-     */
-    private function chapterOutOfBounds(array $chapters): bool
-    {
-        foreach ($chapters as $zchapter) {
-            foreach ($this->ctx->INDEXES as $jkey => $jindex) {
-                $bookidx = array_search($this->nonZeroBookIdx, $jindex['book_num']);
-                if ($bookidx === false) {
-                    continue;
-                }
-                $chapter_limit = $jindex['chapter_limit'][$bookidx];
-                if (intval($zchapter) > $chapter_limit) {
-                    $msg = 'A chapter in the query is out of bounds: there is no chapter <%1$d> in the book %2$s in the requested version %3$s, the last possible chapter is <%4$d>';
-                    $this->ctx->addErrorMessage(sprintf($msg, $zchapter, $this->currentBook, $jkey, $chapter_limit));
-                    $this->ctx->incrementBadQueryCount();
-                    return true;
-                }
-            }
-        }
-        return false;
+        $this->ctx       = $ctx;
+        $this->tokenizer = new ReferenceTokenizer();
+        $this->parser    = new ReferenceParser();
     }
 
     public function validateQueries(): bool
@@ -372,67 +42,168 @@ class QueryValidator
             return false;
         }
 
-        if ($this->queryViolatesAnyRuleOf($this->ctx->queries[0], [self::QUERY_MUST_START_WITH_VALID_BOOK_INDICATOR])) {
+        // First query must start with a valid book indicator
+        if (!$this->startsWithBookIndicator($this->ctx->queries[0])) {
+            $this->ctx->addErrorMessage(0);
+            $this->ctx->incrementBadQueryCount();
             return false;
         }
 
         foreach ($this->ctx->queries as $query) {
-            $this->currentFullQuery  = $query;
-            $this->currentQuery      = $query;
-            $this->validatedVariants = [];
-
-            if ($this->queryViolatesAnyRuleOf($this->currentQuery, [self::VALID_CHAPTER_MUST_FOLLOW_BOOK])) {
-                return false;
-            }
-
-            $matchedBook = self::matchBookInQuery($this->currentQuery);
-            if ($this->validateAndSetBook($matchedBook) === false) {
-                continue;
-            }
-
-            if (self::queryContainsNonConsecutiveVerses($this->currentQuery)) {
-                $rules = [
-                    self::VERSE_SEPARATOR_MUST_BE_PRECEDED_BY_CHAPTER_VERSE_SEPARATOR,
-                    self::VERSE_SEPARATOR_MUST_BE_PRECEDED_BY_1_TO_3_DIGITS,
-                ];
-                if ($this->queryViolatesAnyRuleOf($this->currentQuery, $rules)) {
-                    continue;
-                }
-            }
-
-            if (self::chunkContainsChapterVerseConstruct($this->currentQuery)) {
-                if ($this->queryViolatesAnyRuleOf($this->currentQuery, [self::CHAPTER_VERSE_SEPARATOR_MUST_BE_PRECEDED_BY_1_TO_3_DIGITS])) {
-                    continue;
-                }
-                $chapterIndicators = self::getAllChapterIndicators($this->currentQuery);
-                if ($this->validateChapterIndicators($chapterIndicators) === false) {
-                    continue;
-                }
-                if ($this->validateChapterVerseConstructs() === false) {
-                    continue;
-                }
-            } else {
-                $chapters = explode('-', $this->currentQuery);
-                if ($this->chapterOutOfBounds($chapters)) {
-                    continue;
-                }
-            }
-
-            if (strpos($this->currentQuery, '-') !== false) {
-                $rules = [
-                    self::VERSE_RANGE_MUST_CONTAIN_VALID_VERSE_NUMBERS,
-                    self::CORRESPONDING_CHAPTER_VERSE_CONSTRUCTS_IN_VERSE_RANGE_OVER_CHAPTERS,
-                    self::CORRESPONDING_VERSE_SEPARATORS_FOR_MULTIPLE_VERSE_RANGES,
-                ];
-                if ($this->queryViolatesAnyRuleOf($this->currentQuery, $rules)) {
-                    continue;
-                }
-            }
-
-            $this->ctx->validatedQueries[]  = $this->currentFullQuery;
-            $this->ctx->validatedVariants[] = $this->validatedVariants;
+            $this->validateSingleQuery($query);
         }
 
         return true;
+    }
+
+    private function validateSingleQuery(string $query): void
+    {
+        // Tokenize
+        $tokens = $this->tokenizer->tokenize($query);
+
+        // Check that a chapter number follows the book
+        if (!$this->hasChapterAfterBook($tokens)) {
+            $this->ctx->addErrorMessage(1);
+            $this->ctx->incrementBadQueryCount();
+            return;
+        }
+
+        // Parse
+        try {
+            $ast = $this->parser->parse($tokens);
+        } catch (ParseException) {
+            $this->ctx->addErrorMessage(9);
+            $this->ctx->incrementBadQueryCount();
+            return;
+        }
+
+        // Determine the book name for this query
+        $bookName = $this->extractBookName($tokens);
+
+        // Handle book inheritance: if no book in this query, use previous
+        if ($ast->book === 0 && $bookName === null) {
+            if ($this->previousBook === 0) {
+                $this->ctx->addErrorMessage(0);
+                $this->ctx->incrementBadQueryCount();
+                return;
+            }
+            // Rebuild AST with inherited book
+            $ast      = new BibleQuery($this->previousBook, $ast->segments);
+            $bookName = $this->previousBookName;
+        }
+
+        // Validate against DB metadata
+        $validator = new AstValidator(
+            $this->ctx->BIBLEBOOKS,
+            $this->ctx->INDEXES,
+            $this->ctx->REQUESTED_VERSIONS
+        );
+
+        if ($ast->book !== 0) {
+            // Book already resolved (inherited) — just validate bounds
+            $validated = $this->validatePreResolved($ast, $validator);
+        } else {
+            // Resolve book from name via AstValidator
+            $validated = $validator->validate($ast, $tokens);
+        }
+
+        if ($validated === null) {
+            foreach ($validator->getErrors() as $error) {
+                $this->ctx->addErrorMessage($error->message);
+                $this->ctx->incrementBadQueryCount();
+            }
+            return;
+        }
+
+        // Update book context for subsequent queries
+        $this->previousBook     = $validated->book;
+        $this->previousBookName = $bookName ?? $this->previousBookName;
+
+        // Populate context outputs (same as old implementation)
+        $this->ctx->validatedQueries[]  = $query;
+        $this->ctx->validatedVariants[] = $validator->getValidatedVariants();
+        $this->ctx->parsedQueries[]     = $validated;
+    }
+
+    /**
+     * Validate a BibleQuery that already has its book resolved (inherited from previous query).
+     */
+    private function validatePreResolved(BibleQuery $ast, AstValidator $validator): ?BibleQuery
+    {
+        // Create a temporary token stream with just the book for the validator
+        $dummyTokens = [
+            new \BibleGet\Api\Pipeline\Tokenizer\Token(
+                TokenType::BOOK_NAME,
+                $this->previousBookName,
+                0
+            ),
+            new \BibleGet\Api\Pipeline\Tokenizer\Token(
+                TokenType::EOF,
+                '',
+                0
+            ),
+        ];
+        // Use the validator but pass our pre-resolved book
+        $result = $validator->validate(new BibleQuery(0, $ast->segments), $dummyTokens);
+        if ($result === null) {
+            return null;
+        }
+        // The validator resolved the book from the dummy tokens, but we want our inherited book
+        return new BibleQuery($ast->book, $result->segments);
+    }
+
+    private function startsWithBookIndicator(string $query): bool
+    {
+        return (bool) ( preg_match('/^[1-4]{0,1}\p{Lu}\p{Ll}*/u', $query)
+            || preg_match('/^[1-4]{0,1}(\p{L}\p{M}*)+/u', $query) );
+    }
+
+    /**
+     * Check that tokenized output has a CHAPTER_NUMBER after the book indicator.
+     *
+     * @param \BibleGet\Api\Pipeline\Tokenizer\Token[] $tokens
+     */
+    private function hasChapterAfterBook(array $tokens): bool
+    {
+        $foundBook = false;
+        foreach ($tokens as $token) {
+            if ($token->type === TokenType::BOOK_NAME) {
+                $foundBook = true;
+                continue;
+            }
+            if ($foundBook && $token->type === TokenType::CHAPTER_NUMBER) {
+                return true;
+            }
+            // If no book was found, the first CHAPTER_NUMBER is the "chapter" (book inherited)
+            if (!$foundBook && $token->type === TokenType::CHAPTER_NUMBER) {
+                return true;
+            }
+            if ($token->type === TokenType::EOF) {
+                break;
+            }
+        }
+        // If there's a book name but no chapter, check if the query is book-only
+        // (the old validator considered this invalid — rule 1)
+        return !$foundBook;
+    }
+
+    /**
+     * Extract the full book name (with numeric prefix) from tokens.
+     *
+     * @param \BibleGet\Api\Pipeline\Tokenizer\Token[] $tokens
+     */
+    private function extractBookName(array $tokens): ?string
+    {
+        $prefix = '';
+        $name   = '';
+        foreach ($tokens as $token) {
+            if ($token->type === TokenType::BOOK_NUMERIC_PREFIX) {
+                $prefix = $token->value;
+            } elseif ($token->type === TokenType::BOOK_NAME) {
+                $name = $token->value;
+                break;
+            }
+        }
+        return $name !== '' ? $prefix . $name : null;
     }
 }

--- a/src/Pipeline/QueryValidator.php
+++ b/src/Pipeline/QueryValidator.php
@@ -42,6 +42,10 @@ class QueryValidator
             return false;
         }
 
+        // Reset inherited-book state so repeated calls don't leak stale state
+        $this->previousBook     = 0;
+        $this->previousBookName = '';
+
         // First query must start with a valid book indicator
         if (!$this->startsWithBookIndicator($this->ctx->queries[0])) {
             $this->ctx->addErrorMessage(0);

--- a/src/Pipeline/QuoteContext.php
+++ b/src/Pipeline/QuoteContext.php
@@ -284,7 +284,7 @@ class QuoteContext
 
     private static function convertAllDashesToHyphens(string $querystr): string
     {
-        return preg_replace('/[\x{2011}-\x{2015}|\x{2212}|\x{23AF}]/u', '-', $querystr) ?? $querystr;
+        return preg_replace('/[\x{2010}-\x{2015}\x{2212}\x{23AF}\x{FE58}\x{FE63}\x{FF0D}]/u', '-', $querystr) ?? $querystr;
     }
 
     /**

--- a/src/Pipeline/QuoteContext.php
+++ b/src/Pipeline/QuoteContext.php
@@ -93,6 +93,9 @@ class QuoteContext
     /** @var array<string, string> */
     public array $DATA = [];
 
+    /** @var array<int, \BibleGet\Api\Pipeline\Ast\BibleQuery> */
+    public array $parsedQueries = [];
+
     /** @var array<array{errNum: int, errMessage: string}> */
     public array $errors = [];
     /** @var array<int, array<string, mixed>> */

--- a/src/Pipeline/QuoteContext.php
+++ b/src/Pipeline/QuoteContext.php
@@ -190,6 +190,7 @@ class QuoteContext
     {
         $querystr               = self::removeWhitespace($this->DATA['query']);
         $querystr               = trim($querystr);
+        $querystr               = self::stripReferencePrefix($querystr);
         $querystr               = self::convertAllDashesToHyphens($querystr);
         $this->detectedNotation = self::detectAndNormalizeNotation($querystr);
 
@@ -255,6 +256,24 @@ class QuoteContext
         }
 
         return $detectedNotation;
+    }
+
+    /**
+     * Strip "Cf.", "Cfr.", "Confer" and similar Latin reference prefixes
+     * from each semicolon-delimited query. Whitespace has already been
+     * removed, so the prefix is glued to the book name (e.g. "Cf.John3,16").
+     */
+    private static function stripReferencePrefix(string $querystr): string
+    {
+        // Process each semicolon-delimited query independently so that a
+        // prefix on one query does not affect the others.
+        $queries = explode(';', $querystr);
+        foreach ($queries as &$q) {
+            // Match (case-insensitive): Cfr. / Cf. / Cfr / Cf / Confer
+            // The dot is optional; "Confer" has no dot variant.
+            $q = preg_replace('/^(?:cfr\.?|cf\.?|confer)/i', '', $q) ?? $q;
+        }
+        return implode(';', $queries);
     }
 
     private static function removeWhitespace(string $querystr): string

--- a/src/Pipeline/Tokenizer/ReferenceTokenizer.php
+++ b/src/Pipeline/Tokenizer/ReferenceTokenizer.php
@@ -1,0 +1,306 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BibleGet\Api\Pipeline\Tokenizer;
+
+use BibleGet\Api\Util\StringUtils;
+
+/**
+ * Converts a normalized Bible reference string into a stream of typed tokens.
+ *
+ * Operates on a single query (already split by ";") after notation normalization
+ * (English→European), so ":" has already been replaced by ",".
+ *
+ * The tokenizer resolves CHAPTER_NUMBER vs VERSE_NUMBER based on a minimal
+ * context flag (chapter_level vs verse_level) — see the plan document for
+ * the full classification table.
+ */
+final class ReferenceTokenizer
+{
+    private string $input;
+    private int $length;
+    private int $pos = 0;
+
+    /** @var Token[] */
+    private array $tokens = [];
+
+    private bool $atVerseLevel = false;
+
+    /**
+     * @return Token[]
+     */
+    public function tokenize(string $input): array
+    {
+        $this->input        = $input;
+        $this->length       = strlen($input);
+        $this->pos          = 0;
+        $this->tokens       = [];
+        $this->atVerseLevel = false;
+
+        while ($this->pos < $this->length) {
+            $this->readNextToken();
+        }
+
+        $this->tokens[] = new Token(TokenType::EOF, '', $this->pos);
+
+        return $this->tokens;
+    }
+
+    private function readNextToken(): void
+    {
+        $ch = $this->input[$this->pos];
+
+        if ($ch === ',') {
+            $this->tokens[] = new Token(TokenType::CHAPTER_VERSE_SEPARATOR, ',', $this->pos);
+            $this->pos++;
+            $this->atVerseLevel = true;
+            return;
+        }
+
+        if ($ch === '.') {
+            $this->tokens[] = new Token(TokenType::EXPLICIT_VERSE_SEPARATOR, '.', $this->pos);
+            $this->pos++;
+            $this->atVerseLevel = true;
+            return;
+        }
+
+        if ($ch === '-') {
+            $this->tokens[] = new Token(TokenType::RANGE_SEPARATOR, '-', $this->pos);
+            $this->pos++;
+            // atVerseLevel is inherited — don't change it
+            return;
+        }
+
+        if ($ch === ';') {
+            $this->tokens[] = new Token(TokenType::QUERY_SEPARATOR, ';', $this->pos);
+            $this->pos++;
+            $this->atVerseLevel = false;
+            return;
+        }
+
+        if ($ch === '(') {
+            $this->tokens[] = new Token(TokenType::OPEN_PARENTHESIS, '(', $this->pos);
+            $this->pos++;
+            $this->readAlternateChapter();
+            return;
+        }
+
+        if ($this->isDigit($ch)) {
+            $this->readNumber();
+            return;
+        }
+
+        // Must be a book name (possibly preceded by a numeric prefix already consumed,
+        // or starting fresh). Try to read a book indicator.
+        $this->readBookIndicator();
+    }
+
+    private function readBookIndicator(): void
+    {
+        $startPos = $this->pos;
+
+        // Check for numeric prefix (1-4 before a book name)
+        if (
+            $this->pos < $this->length
+            && $this->input[$this->pos] >= '1'
+            && $this->input[$this->pos] <= '4'
+            && $this->pos + 1 < $this->length
+            && $this->isLetterStart($this->pos + 1)
+        ) {
+            $this->tokens[] = new Token(TokenType::BOOK_NUMERIC_PREFIX, $this->input[$this->pos], $this->pos);
+            $this->pos++;
+        }
+
+        // Read the book name: Unicode letters (possibly with combining marks)
+        $bookStart = $this->pos;
+        $bookName  = $this->readUnicodeWord();
+
+        if ($bookName === '') {
+            // Unexpected character — skip it to avoid infinite loop
+            $this->pos++;
+            return;
+        }
+
+        $this->tokens[]     = new Token(TokenType::BOOK_NAME, $bookName, $bookStart);
+        $this->atVerseLevel = false;
+    }
+
+    private function readUnicodeWord(): string
+    {
+        $start = $this->pos;
+        // Match Unicode letters and combining marks: (\p{L}\p{M}*)+
+        if (preg_match('/\G(\p{L}\p{M}*)+/u', $this->input, $matches, 0, $this->pos)) {
+            $this->pos += strlen($matches[0]);
+            return $matches[0];
+        }
+        return '';
+    }
+
+    private function readNumber(): void
+    {
+        $startPos = $this->pos;
+        $numStr   = '';
+
+        while ($this->pos < $this->length && $this->isDigit($this->input[$this->pos])) {
+            $numStr .= $this->input[$this->pos];
+            $this->pos++;
+        }
+
+        // Determine if this is a book numeric prefix: digit 1-4 followed by letter, no tokens yet or last was QUERY_SEPARATOR
+        if ($this->isBookNumericPrefix($numStr)) {
+            $this->tokens[] = new Token(TokenType::BOOK_NUMERIC_PREFIX, $numStr, $startPos);
+            // Now read the book name
+            $bookStart = $this->pos;
+            $bookName  = $this->readUnicodeWord();
+            if ($bookName !== '') {
+                $this->tokens[]     = new Token(TokenType::BOOK_NAME, $bookName, $bookStart);
+                $this->atVerseLevel = false;
+            }
+            return;
+        }
+
+        // Classify as CHAPTER_NUMBER or VERSE_NUMBER based on context
+        $type           = $this->classifyNumber();
+        $this->tokens[] = new Token($type, $numStr, $startPos);
+
+        // After emitting a number, check for partial verse suffix (lowercase letter immediately after)
+        if ($type === TokenType::VERSE_NUMBER) {
+            $this->readPartialVerseSuffix();
+        }
+    }
+
+    private function isBookNumericPrefix(string $numStr): bool
+    {
+        // Must be a single digit 1-4
+        if (strlen($numStr) !== 1 || $numStr < '1' || $numStr > '4') {
+            return false;
+        }
+
+        // Must be followed by a letter (start of book name)
+        if ($this->pos >= $this->length || !$this->isLetterStart($this->pos)) {
+            return false;
+        }
+
+        // Must be at the start of a query: either no tokens yet, or last token is QUERY_SEPARATOR or BOOK_NAME-adjacent
+        if (empty($this->tokens)) {
+            return true;
+        }
+
+        $lastToken = $this->tokens[count($this->tokens) - 1];
+        return $lastToken->type === TokenType::QUERY_SEPARATOR;
+    }
+
+    private function classifyNumber(): TokenType
+    {
+        // Look at the preceding token
+        $lastToken = $this->lastMeaningfulToken();
+
+        // After a book name → always CHAPTER_NUMBER
+        if ($lastToken !== null && $lastToken->type === TokenType::BOOK_NAME) {
+            return TokenType::CHAPTER_NUMBER;
+        }
+
+        // After CHAPTER_VERSE_SEPARATOR → always VERSE_NUMBER
+        if ($lastToken !== null && $lastToken->type === TokenType::CHAPTER_VERSE_SEPARATOR) {
+            return TokenType::VERSE_NUMBER;
+        }
+
+        // After EXPLICIT_VERSE_SEPARATOR → always VERSE_NUMBER
+        if ($lastToken !== null && $lastToken->type === TokenType::EXPLICIT_VERSE_SEPARATOR) {
+            return TokenType::VERSE_NUMBER;
+        }
+
+        // After CLOSE_PARENTHESIS (dual Psalm numbering) — treat like after CHAPTER_NUMBER
+        // Lookahead determines: if followed by CHAPTER_VERSE_SEPARATOR → CHAPTER_NUMBER (already is)
+        // This case shouldn't produce a number directly, but handle defensively
+        if ($lastToken !== null && $lastToken->type === TokenType::CLOSE_PARENTHESIS) {
+            return $this->classifyByLookahead();
+        }
+
+        // After RANGE_SEPARATOR — lookahead determines classification
+        if ($lastToken !== null && $lastToken->type === TokenType::RANGE_SEPARATOR) {
+            return $this->classifyByLookahead();
+        }
+
+        // Default: use lookahead
+        return $this->classifyByLookahead();
+    }
+
+    private function classifyByLookahead(): TokenType
+    {
+        // If the next character is ',' → this number is a CHAPTER_NUMBER
+        if ($this->pos < $this->length && $this->input[$this->pos] === ',') {
+            return TokenType::CHAPTER_NUMBER;
+        }
+
+        // If the next character is '(' → this number is a CHAPTER_NUMBER (Psalm dual numbering)
+        if ($this->pos < $this->length && $this->input[$this->pos] === '(') {
+            return TokenType::CHAPTER_NUMBER;
+        }
+
+        // Otherwise, inherit from context
+        return $this->atVerseLevel ? TokenType::VERSE_NUMBER : TokenType::CHAPTER_NUMBER;
+    }
+
+    private function readPartialVerseSuffix(): void
+    {
+        if ($this->pos >= $this->length) {
+            return;
+        }
+
+        // A partial verse suffix is a single lowercase ASCII letter immediately after a verse number,
+        // but NOT if it starts a book name (i.e., not if followed by more letters)
+        $ch = $this->input[$this->pos];
+        if ($ch >= 'a' && $ch <= 'z') {
+            // Check the character after this one — if it's also a letter, this is likely
+            // a book name, not a partial verse suffix
+            $nextPos = $this->pos + 1;
+            if ($nextPos < $this->length && $this->isLetterStart($nextPos)) {
+                return;
+            }
+            $this->tokens[] = new Token(TokenType::PARTIAL_VERSE_SUFFIX, $ch, $this->pos);
+            $this->pos++;
+        }
+    }
+
+    private function readAlternateChapter(): void
+    {
+        // We already consumed '(' — now read the number inside
+        $startPos = $this->pos;
+        $numStr   = '';
+
+        while ($this->pos < $this->length && $this->isDigit($this->input[$this->pos])) {
+            $numStr .= $this->input[$this->pos];
+            $this->pos++;
+        }
+
+        if ($numStr !== '') {
+            $this->tokens[] = new Token(TokenType::ALTERNATE_CHAPTER, $numStr, $startPos);
+        }
+
+        // Consume closing parenthesis
+        if ($this->pos < $this->length && $this->input[$this->pos] === ')') {
+            $this->tokens[] = new Token(TokenType::CLOSE_PARENTHESIS, ')', $this->pos);
+            $this->pos++;
+        }
+    }
+
+    private function lastMeaningfulToken(): ?Token
+    {
+        for ($i = count($this->tokens) - 1; $i >= 0; $i--) {
+            return $this->tokens[$i];
+        }
+        return null;
+    }
+
+    private function isDigit(string $ch): bool
+    {
+        return $ch >= '0' && $ch <= '9';
+    }
+
+    private function isLetterStart(int $pos): bool
+    {
+        return (bool) preg_match('/\p{L}/u', $this->input[$pos]);
+    }
+}

--- a/src/Pipeline/Tokenizer/ReferenceTokenizer.php
+++ b/src/Pipeline/Tokenizer/ReferenceTokenizer.php
@@ -301,6 +301,8 @@ final class ReferenceTokenizer
 
     private function isLetterStart(int $pos): bool
     {
-        return (bool) preg_match('/\p{L}/u', $this->input[$pos]);
+        // Use \G anchor at byte offset to match a single Unicode letter,
+        // which correctly handles multibyte UTF-8 characters.
+        return (bool) preg_match('/\G\p{L}/u', $this->input, matches: $m, offset: $pos);
     }
 }

--- a/src/Pipeline/Tokenizer/Token.php
+++ b/src/Pipeline/Tokenizer/Token.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BibleGet\Api\Pipeline\Tokenizer;
+
+final class Token
+{
+    public function __construct(
+        public readonly TokenType $type,
+        public readonly string $value,
+        public readonly int $position,
+    ) {
+    }
+
+    public function is(TokenType $type): bool
+    {
+        return $this->type === $type;
+    }
+}

--- a/src/Pipeline/Tokenizer/TokenType.php
+++ b/src/Pipeline/Tokenizer/TokenType.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BibleGet\Api\Pipeline\Tokenizer;
+
+enum TokenType: string
+{
+    // ── Identifiers ──────────────────────────────────────────────
+    case BOOK_NUMERIC_PREFIX = 'BOOK_NUMERIC_PREFIX';
+    case BOOK_NAME           = 'BOOK_NAME';
+
+    // ── Numeric tokens (resolved by context during tokenization) ─
+    case CHAPTER_NUMBER       = 'CHAPTER_NUMBER';
+    case VERSE_NUMBER         = 'VERSE_NUMBER';
+    case PARTIAL_VERSE_SUFFIX = 'PARTIAL_VERSE_SUFFIX';
+
+    // ── Psalm dual numbering ────────────────────────────────────
+    case OPEN_PARENTHESIS  = 'OPEN_PARENTHESIS';
+    case ALTERNATE_CHAPTER = 'ALTERNATE_CHAPTER';
+    case CLOSE_PARENTHESIS = 'CLOSE_PARENTHESIS';
+
+    // ── Structural separators (semantic, post-normalization) ────
+    case CHAPTER_VERSE_SEPARATOR  = 'CHAPTER_VERSE_SEPARATOR';
+    case EXPLICIT_VERSE_SEPARATOR = 'EXPLICIT_VERSE_SEPARATOR';
+    case RANGE_SEPARATOR          = 'RANGE_SEPARATOR';
+    case QUERY_SEPARATOR          = 'QUERY_SEPARATOR';
+
+    // ── Control ──────────────────────────────────────────────────
+    case EOF = 'EOF';
+}

--- a/src/Pipeline/Transform/EstherRemapper.php
+++ b/src/Pipeline/Transform/EstherRemapper.php
@@ -9,18 +9,20 @@ use BibleGet\Api\Pipeline\Ast\VerseRange;
 use BibleGet\Api\Pipeline\Ast\VerseRef;
 
 /**
- * AST→AST transformation that remaps Psalm chapter/verse numbers for
- * VGCL and DRB Catholic versions (Greek/Vulgate numbering).
+ * AST→AST transformation that remaps Esther chapter/verse numbers for
+ * VGCL and DRB Catholic versions (Greek additions to Esther).
+ *
+ * Book 19 = Esther in the Catholic canon. Chapters 10–16 contain the Greek
+ * additions which require verseorigin filtering.
  *
  * This is a pure function of the AST — no database access, no SQL.
- * The mapping table is extracted from the legacy QueryFormulator::PSALM_VGCL_DRB_MAPPINGS.
  */
-final class PsalmRemapper
+final class EstherRemapper
 {
-    private const PSALMS_BOOK_NUM = 19;
+    private const ESTHER_BOOK_NUM = 19;
 
     /**
-     * Psalm verse-mapping rules for VGCL/DRB versions.
+     * Esther verse-mapping rules for VGCL/DRB versions (Greek additions).
      * Each entry: [ranges => [[chapter, verseMin, verseMax], ...], map => [mappedChapter, mappedVerse]]
      * A null verseMin/verseMax means the rule matches when verse is null too.
      *
@@ -49,7 +51,7 @@ final class PsalmRemapper
     }
 
     /**
-     * Remap a BibleQuery AST if it targets Psalms in a VGCL/DRB version.
+     * Remap a BibleQuery AST if it targets Esther in a VGCL/DRB version.
      *
      * Returns a new BibleQuery with remapped segments, plus the preferorigin
      * annotation to use. If no remapping applies, returns the query unchanged.
@@ -87,7 +89,7 @@ final class PsalmRemapper
 
     private function shouldRemap(int $book, string $version): bool
     {
-        return $book === self::PSALMS_BOOK_NUM
+        return $book === self::ESTHER_BOOK_NUM
             && in_array($version, $this->catholicVersions)
             && ( $version === 'VGCL' || $version === 'DRB' );
     }

--- a/src/Pipeline/Transform/PsalmChapterSwapper.php
+++ b/src/Pipeline/Transform/PsalmChapterSwapper.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BibleGet\Api\Pipeline\Transform;
+
+use BibleGet\Api\Pipeline\Ast\BibleQuery;
+use BibleGet\Api\Pipeline\Ast\VerseRange;
+use BibleGet\Api\Pipeline\Ast\VerseRef;
+
+/**
+ * AST→AST transformation that swaps the primary chapter with the alternate
+ * chapter for Psalm references in Vulgate-numbered versions (VGCL, DRB).
+ *
+ * When a user queries "Psalm51(50),1":
+ *  - For VGCL/DRB (Vulgate numbering): SQL should use chapter 50
+ *  - For other versions (Hebrew numbering): SQL should use chapter 51
+ *
+ * This is a pure function of the AST — no database access, no SQL.
+ */
+final class PsalmChapterSwapper
+{
+    private const PSALMS_BOOK_NUM = 23;
+
+    /** Versions that use Vulgate/LXX psalm numbering */
+    private const VULGATE_VERSIONS = ['VGCL', 'DRB'];
+
+    /**
+     * Swap chapter ↔ alternateChapter for Psalm queries targeting VGCL/DRB.
+     *
+     * Only swaps segments where alternateChapter is set; segments without
+     * an alternate are left unchanged.
+     */
+    public function swap(BibleQuery $query, string $version): BibleQuery
+    {
+        if ($query->book !== self::PSALMS_BOOK_NUM) {
+            return $query;
+        }
+        if (!in_array($version, self::VULGATE_VERSIONS, true)) {
+            return $query;
+        }
+
+        $hasAlternate = false;
+        foreach ($query->segments as $segment) {
+            if ($segment instanceof VerseRef && $segment->alternateChapter !== null) {
+                $hasAlternate = true;
+                break;
+            }
+            if ($segment instanceof VerseRange && ( $segment->from->alternateChapter !== null || $segment->to->alternateChapter !== null )) {
+                $hasAlternate = true;
+                break;
+            }
+        }
+        if (!$hasAlternate) {
+            return $query;
+        }
+
+        $newSegments = [];
+        foreach ($query->segments as $segment) {
+            if ($segment instanceof VerseRef) {
+                $newSegments[] = $this->swapVerseRef($segment);
+            } elseif ($segment instanceof VerseRange) {
+                $newSegments[] = new VerseRange(
+                    $this->swapVerseRef($segment->from),
+                    $this->swapVerseRef($segment->to),
+                );
+            }
+        }
+
+        return new BibleQuery($query->book, $newSegments);
+    }
+
+    private function swapVerseRef(VerseRef $ref): VerseRef
+    {
+        if ($ref->alternateChapter === null) {
+            return $ref;
+        }
+
+        return new VerseRef(
+            $ref->book,
+            $ref->alternateChapter,
+            $ref->chapter,
+            $ref->verse,
+            $ref->partialSuffix,
+            $ref->position,
+        );
+    }
+}

--- a/src/Pipeline/Transform/PsalmRemapper.php
+++ b/src/Pipeline/Transform/PsalmRemapper.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BibleGet\Api\Pipeline\Transform;
+
+use BibleGet\Api\Pipeline\Ast\BibleQuery;
+use BibleGet\Api\Pipeline\Ast\VerseRange;
+use BibleGet\Api\Pipeline\Ast\VerseRef;
+
+/**
+ * AST→AST transformation that remaps Psalm chapter/verse numbers for
+ * VGCL and DRB Catholic versions (Greek/Vulgate numbering).
+ *
+ * This is a pure function of the AST — no database access, no SQL.
+ * The mapping table is extracted from the legacy QueryFormulator::PSALM_VGCL_DRB_MAPPINGS.
+ */
+final class PsalmRemapper
+{
+    private const PSALMS_BOOK_NUM = 19;
+
+    /**
+     * Psalm verse-mapping rules for VGCL/DRB versions.
+     * Each entry: [ranges => [[chapter, verseMin, verseMax], ...], map => [mappedChapter, mappedVerse]]
+     * A null verseMin/verseMax means the rule matches when verse is null too.
+     *
+     * @var array<int, array{ranges: array<int, array{int, int|null, int|null}>, map: array{int, int}}>
+     */
+    private const MAPPINGS = [
+        ['ranges' => [[10, 4, 13], [11, 1, 1]],  'map' => [10, 3]],
+        ['ranges' => [[11, 2, 12], [12, 1, 6]],   'map' => [1, 1]],
+        ['ranges' => [[13, 1, 7]],                 'map' => [3, 13]],
+        ['ranges' => [[13, 8, 18], [14, 1, 19]],   'map' => [4, 17]],
+        ['ranges' => [[15, 1, 3]],                 'map' => [4, 8]],
+        ['ranges' => [[15, 4, 14]],                'map' => [5, 1]],
+        ['ranges' => [[15, 15, 19]],               'map' => [5, 2]],
+        ['ranges' => [[16, null, null]],           'map' => [8, 12]],
+    ];
+
+    /** @var array<int, string> */
+    private array $catholicVersions;
+
+    /**
+     * @param array<int, string> $catholicVersions
+     */
+    public function __construct(array $catholicVersions)
+    {
+        $this->catholicVersions = $catholicVersions;
+    }
+
+    /**
+     * Remap a BibleQuery AST if it targets Psalms in a VGCL/DRB version.
+     *
+     * Returns a new BibleQuery with remapped segments, plus the preferorigin
+     * annotation to use. If no remapping applies, returns the query unchanged.
+     *
+     * @return array{BibleQuery, string} [remappedQuery, preferOriginSuffix]
+     */
+    public function remap(BibleQuery $query, string $version, string $defaultPreferOrigin): array
+    {
+        if (!$this->shouldRemap($query->book, $version)) {
+            return [$query, $defaultPreferOrigin];
+        }
+
+        $segments     = [];
+        $preferOrigin = $defaultPreferOrigin;
+
+        foreach ($query->segments as $segment) {
+            if ($segment instanceof VerseRef) {
+                [$mapped, $po] = $this->remapVerseRef($segment, $defaultPreferOrigin);
+                $segments[]    = $mapped;
+                $preferOrigin  = $po;
+            } elseif ($segment instanceof VerseRange) {
+                [$from, $poFrom] = $this->remapVerseRef($segment->from, $defaultPreferOrigin);
+                [$to, $poTo]     = $this->remapVerseRef($segment->to, $defaultPreferOrigin);
+                $segments[]      = new VerseRange($from, $to);
+                $preferOrigin    = $poFrom;
+            }
+        }
+
+        return [new BibleQuery($query->book, $segments), $preferOrigin];
+    }
+
+    private function shouldRemap(int $book, string $version): bool
+    {
+        return $book === self::PSALMS_BOOK_NUM
+            && in_array($version, $this->catholicVersions)
+            && ( $version === 'VGCL' || $version === 'DRB' );
+    }
+
+    /**
+     * @return array{VerseRef, string}
+     */
+    private function remapVerseRef(VerseRef $ref, string $defaultPreferOrigin): array
+    {
+        $mapped = $this->matchMapping($ref->chapter, $ref->verse);
+        if ($mapped !== null) {
+            [$chapter, $verse, $preferOrigin] = $mapped;
+            return [
+                new VerseRef($ref->book, $chapter, $ref->alternateChapter, $verse, $ref->partialSuffix),
+                $preferOrigin,
+            ];
+        }
+        return [$ref, $defaultPreferOrigin];
+    }
+
+    /**
+     * @return array{int, int|null, string}|null [chapter, verse, preferorigin] or null
+     */
+    private function matchMapping(int $chapter, ?int $verse): ?array
+    {
+        foreach (self::MAPPINGS as $mapping) {
+            foreach ($mapping['ranges'] as [$rngChapter, $rngMin, $rngMax]) {
+                if ($chapter !== $rngChapter) {
+                    continue;
+                }
+                $verseInRange = $rngMin === null
+                    ? $verse === null
+                    : $verse !== null && $verse >= $rngMin && $verse <= ( $rngMax ?? $rngMin );
+                if ($verseInRange) {
+                    return [$mapping['map'][0], $mapping['map'][1], " AND verseorigin = 'GREEK'"];
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/Pipeline/Transform/PsalmRemapper.php
+++ b/src/Pipeline/Transform/PsalmRemapper.php
@@ -54,31 +54,35 @@ final class PsalmRemapper
      * Returns a new BibleQuery with remapped segments, plus the preferorigin
      * annotation to use. If no remapping applies, returns the query unchanged.
      *
-     * @return array{BibleQuery, string} [remappedQuery, preferOriginSuffix]
+     * Returns per-segment preferOrigin strings so each non-consecutive chunk
+     * gets the correct verseorigin filter (matching legacy per-chunk behavior).
+     *
+     * @return array{BibleQuery, array<int, string>} [remappedQuery, perSegmentPreferOrigins]
      */
     public function remap(BibleQuery $query, string $version, string $defaultPreferOrigin): array
     {
         if (!$this->shouldRemap($query->book, $version)) {
-            return [$query, $defaultPreferOrigin];
+            $origins = array_fill(0, count($query->segments), $defaultPreferOrigin);
+            return [$query, $origins];
         }
 
-        $segments     = [];
-        $preferOrigin = $defaultPreferOrigin;
+        $segments = [];
+        $origins  = [];
 
         foreach ($query->segments as $segment) {
             if ($segment instanceof VerseRef) {
                 [$mapped, $po] = $this->remapVerseRef($segment, $defaultPreferOrigin);
                 $segments[]    = $mapped;
-                $preferOrigin  = $po;
+                $origins[]     = $po;
             } elseif ($segment instanceof VerseRange) {
                 [$from, $poFrom] = $this->remapVerseRef($segment->from, $defaultPreferOrigin);
                 [$to, $poTo]     = $this->remapVerseRef($segment->to, $defaultPreferOrigin);
                 $segments[]      = new VerseRange($from, $to);
-                $preferOrigin    = $poFrom;
+                $origins[]       = $poFrom;
             }
         }
 
-        return [new BibleQuery($query->book, $segments), $preferOrigin];
+        return [new BibleQuery($query->book, $segments), $origins];
     }
 
     private function shouldRemap(int $book, string $version): bool

--- a/src/Pipeline/Validator/AstValidator.php
+++ b/src/Pipeline/Validator/AstValidator.php
@@ -186,10 +186,10 @@ final class AstValidator
 
     private function validateVerseRef(VerseRef $ref, int $nonZeroBookIdx): void
     {
-        $this->validateChapter($ref->chapter, $nonZeroBookIdx);
+        $this->validateChapter($ref->chapter, $nonZeroBookIdx, $ref->position);
 
         if ($ref->verse !== null) {
-            $this->validateVerse($ref->verse, $ref->chapter, $nonZeroBookIdx);
+            $this->validateVerse($ref->verse, $ref->chapter, $nonZeroBookIdx, $ref->position);
         }
     }
 
@@ -205,7 +205,8 @@ final class AstValidator
                     'Invalid range: start chapter %d is greater than end chapter %d',
                     $range->from->chapter,
                     $range->to->chapter
-                )
+                ),
+                $range->to->position
             );
         } elseif (
             $range->from->chapter === $range->to->chapter
@@ -219,16 +220,18 @@ final class AstValidator
                     $range->from->verse,
                     $range->to->verse,
                     $range->from->chapter
-                )
+                ),
+                $range->to->position
             );
         }
     }
 
-    private function validateChapter(int $chapter, int $nonZeroBookIdx): void
+    private function validateChapter(int $chapter, int $nonZeroBookIdx, int $position = -1): void
     {
         if ($chapter < 1) {
             $this->errors[] = new ValidationError(
-                sprintf('Invalid chapter number: %d. Chapters must be 1 or greater.', $chapter)
+                sprintf('Invalid chapter number: %d. Chapters must be 1 or greater.', $chapter),
+                $position
             );
             return;
         }
@@ -250,17 +253,19 @@ final class AstValidator
                         $chapter,
                         $variant,
                         $chapterLimit
-                    )
+                    ),
+                    $position
                 );
             }
         }
     }
 
-    private function validateVerse(int $verse, int $chapter, int $nonZeroBookIdx): void
+    private function validateVerse(int $verse, int $chapter, int $nonZeroBookIdx, int $position = -1): void
     {
         if ($verse < 1) {
             $this->errors[] = new ValidationError(
-                sprintf('Invalid verse number: %d. Verses must be 1 or greater.', $verse)
+                sprintf('Invalid verse number: %d. Verses must be 1 or greater.', $verse),
+                $position
             );
             return;
         }
@@ -289,7 +294,8 @@ final class AstValidator
                         $chapter,
                         $variant,
                         $verseLimit
-                    )
+                    ),
+                    $position
                 );
             }
         }

--- a/src/Pipeline/Validator/AstValidator.php
+++ b/src/Pipeline/Validator/AstValidator.php
@@ -254,7 +254,7 @@ final class AstValidator
                 continue;
             }
             $index   = $this->indexes[$variant];
-            $bookidx = array_search($nonZeroBookIdx, $index['book_num']);
+            $bookidx = array_search($nonZeroBookIdx, $index['book_num'], true);
             if ($bookidx === false) {
                 continue;
             }
@@ -288,7 +288,7 @@ final class AstValidator
                 continue;
             }
             $index   = $this->indexes[$variant];
-            $bookidx = array_search($nonZeroBookIdx, $index['book_num']);
+            $bookidx = array_search($nonZeroBookIdx, $index['book_num'], true);
             if ($bookidx === false) {
                 continue;
             }

--- a/src/Pipeline/Validator/AstValidator.php
+++ b/src/Pipeline/Validator/AstValidator.php
@@ -88,6 +88,19 @@ final class AstValidator
             }
         }
 
+        if (empty($this->validatedVariants)) {
+            $position       = $this->extractBookPosition($tokens);
+            $this->errors[] = new ValidationError(
+                sprintf(
+                    'The book (index %d) is not available in any of the requested versions: %s',
+                    $nonZeroBookIdx,
+                    implode(', ', $this->requestedVersions)
+                ),
+                $position
+            );
+            return null;
+        }
+
         // Validate each segment
         foreach ($query->segments as $segment) {
             if ($segment instanceof VerseRef) {

--- a/src/Pipeline/Validator/AstValidator.php
+++ b/src/Pipeline/Validator/AstValidator.php
@@ -83,7 +83,7 @@ final class AstValidator
 
         // Determine which requested versions have this book
         foreach ($this->requestedVersions as $variant) {
-            if (isset($this->indexes[$variant]) && in_array($nonZeroBookIdx, $this->indexes[$variant]['book_num'])) {
+            if (isset($this->indexes[$variant]) && in_array($nonZeroBookIdx, $this->indexes[$variant]['book_num'], true)) {
                 $this->validatedVariants[] = $variant;
             }
         }
@@ -188,7 +188,7 @@ final class AstValidator
         foreach ($this->bibleBooks as $index => $value) {
             if (is_array($value)) {
                 foreach ($value as $subValue) {
-                    if (is_array($subValue) && in_array($needle, $subValue)) {
+                    if (is_array($subValue) && in_array($needle, $subValue, true)) {
                         return $index;
                     }
                 }

--- a/src/Pipeline/Validator/AstValidator.php
+++ b/src/Pipeline/Validator/AstValidator.php
@@ -226,6 +226,13 @@ final class AstValidator
 
     private function validateChapter(int $chapter, int $nonZeroBookIdx): void
     {
+        if ($chapter < 1) {
+            $this->errors[] = new ValidationError(
+                sprintf('Invalid chapter number: %d. Chapters must be 1 or greater.', $chapter)
+            );
+            return;
+        }
+
         foreach ($this->validatedVariants as $variant) {
             if (!isset($this->indexes[$variant])) {
                 continue;
@@ -251,6 +258,13 @@ final class AstValidator
 
     private function validateVerse(int $verse, int $chapter, int $nonZeroBookIdx): void
     {
+        if ($verse < 1) {
+            $this->errors[] = new ValidationError(
+                sprintf('Invalid verse number: %d. Verses must be 1 or greater.', $verse)
+            );
+            return;
+        }
+
         foreach ($this->validatedVariants as $variant) {
             if (!isset($this->indexes[$variant])) {
                 continue;

--- a/src/Pipeline/Validator/AstValidator.php
+++ b/src/Pipeline/Validator/AstValidator.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BibleGet\Api\Pipeline\Validator;
+
+use BibleGet\Api\Pipeline\Ast\BibleQuery;
+use BibleGet\Api\Pipeline\Ast\VerseRange;
+use BibleGet\Api\Pipeline\Ast\VerseRef;
+use BibleGet\Api\Pipeline\Tokenizer\Token;
+use BibleGet\Api\Pipeline\Tokenizer\TokenType;
+
+/**
+ * Validates a parsed BibleQuery AST against database metadata.
+ *
+ * Checks:
+ * - Book name exists and is valid for the requested versions
+ * - Chapter numbers are within bounds for the book
+ * - Verse numbers are within bounds for the chapter (per version)
+ * - Range start <= range end
+ * - Cross-chapter range chapters are in order
+ */
+final class AstValidator
+{
+    /** @var array<int, array<int, array<int, string>>> */
+    private array $bibleBooks;
+
+    /** @var array<string, array{abbreviations: array<int, string>, biblebooks: array<int, string>, chapter_limit: array<int, int>, verse_limit: array<int, array<int, int>>, book_num: array<int, int>}> */
+    private array $indexes;
+
+    /** @var array<int, string> */
+    private array $requestedVersions;
+
+    /** @var ValidationError[] */
+    private array $errors = [];
+
+    /** @var array<int, string> */
+    private array $validatedVariants = [];
+
+    /**
+     * @param array<int, array<int, array<int, string>>> $bibleBooks
+     * @param array<string, array{abbreviations: array<int, string>, biblebooks: array<int, string>, chapter_limit: array<int, int>, verse_limit: array<int, array<int, int>>, book_num: array<int, int>}> $indexes
+     * @param array<int, string> $requestedVersions
+     */
+    public function __construct(array $bibleBooks, array $indexes, array $requestedVersions)
+    {
+        $this->bibleBooks        = $bibleBooks;
+        $this->indexes           = $indexes;
+        $this->requestedVersions = $requestedVersions;
+    }
+
+    /**
+     * Validate a BibleQuery AST and resolve the book index.
+     *
+     * @param Token[] $tokens  The original token stream (for book name + position lookup)
+     * @return BibleQuery|null The query with resolved book index, or null if invalid
+     */
+    public function validate(BibleQuery $query, array $tokens): ?BibleQuery
+    {
+        $this->errors            = [];
+        $this->validatedVariants = [];
+
+        $bookName = $this->extractBookName($tokens);
+        if ($bookName === null) {
+            $this->errors[] = new ValidationError('No book name found in query');
+            return null;
+        }
+
+        $bookIdx = $this->resolveBookIndex($bookName);
+        if ($bookIdx === null) {
+            $position       = $this->extractBookPosition($tokens);
+            $this->errors[] = new ValidationError(
+                sprintf(
+                    'The book %s is not a valid Bible book. Please check the documentation for a list of correct Bible book names, whether full or abbreviated.',
+                    $bookName
+                ),
+                $position
+            );
+            return null;
+        }
+
+        $nonZeroBookIdx = $bookIdx + 1;
+
+        // Determine which requested versions have this book
+        foreach ($this->requestedVersions as $variant) {
+            if (isset($this->indexes[$variant]) && in_array($nonZeroBookIdx, $this->indexes[$variant]['book_num'])) {
+                $this->validatedVariants[] = $variant;
+            }
+        }
+
+        // Validate each segment
+        foreach ($query->segments as $segment) {
+            if ($segment instanceof VerseRef) {
+                $this->validateVerseRef($segment, $nonZeroBookIdx);
+            } elseif ($segment instanceof VerseRange) {
+                $this->validateVerseRange($segment, $nonZeroBookIdx);
+            }
+        }
+
+        if (!empty($this->errors)) {
+            return null;
+        }
+
+        // Return a new BibleQuery with the resolved book index
+        return new BibleQuery($nonZeroBookIdx, $query->segments);
+    }
+
+    /**
+     * @return ValidationError[]
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getValidatedVariants(): array
+    {
+        return $this->validatedVariants;
+    }
+
+    /**
+     * @param Token[] $tokens
+     */
+    private function extractBookName(array $tokens): ?string
+    {
+        $prefix = '';
+        $name   = '';
+        foreach ($tokens as $token) {
+            if ($token->type === TokenType::BOOK_NUMERIC_PREFIX) {
+                $prefix = $token->value;
+            } elseif ($token->type === TokenType::BOOK_NAME) {
+                $name = $token->value;
+                break;
+            }
+        }
+        if ($name === '') {
+            return null;
+        }
+        return $prefix . $name;
+    }
+
+    /**
+     * @param Token[] $tokens
+     */
+    private function extractBookPosition(array $tokens): int
+    {
+        foreach ($tokens as $token) {
+            if ($token->type === TokenType::BOOK_NUMERIC_PREFIX || $token->type === TokenType::BOOK_NAME) {
+                return $token->position;
+            }
+        }
+        return 0;
+    }
+
+    /**
+     * Resolve a book name to its zero-based index in the BIBLEBOOKS array.
+     */
+    private function resolveBookIndex(string $bookName): ?int
+    {
+        $idx = $this->idxOf($bookName);
+        if ($idx !== false) {
+            return $idx;
+        }
+        return null;
+    }
+
+    /**
+     * @return int|false
+     */
+    private function idxOf(string $needle): int|false
+    {
+        foreach ($this->bibleBooks as $index => $value) {
+            if (is_array($value)) {
+                foreach ($value as $subValue) {
+                    if (is_array($subValue) && in_array($needle, $subValue)) {
+                        return $index;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private function validateVerseRef(VerseRef $ref, int $nonZeroBookIdx): void
+    {
+        $this->validateChapter($ref->chapter, $nonZeroBookIdx);
+
+        if ($ref->verse !== null) {
+            $this->validateVerse($ref->verse, $ref->chapter, $nonZeroBookIdx);
+        }
+    }
+
+    private function validateVerseRange(VerseRange $range, int $nonZeroBookIdx): void
+    {
+        $this->validateVerseRef($range->from, $nonZeroBookIdx);
+        $this->validateVerseRef($range->to, $nonZeroBookIdx);
+
+        // Check range ordering
+        if ($range->from->chapter > $range->to->chapter) {
+            $this->errors[] = new ValidationError(
+                sprintf(
+                    'Invalid range: start chapter %d is greater than end chapter %d',
+                    $range->from->chapter,
+                    $range->to->chapter
+                )
+            );
+        } elseif (
+            $range->from->chapter === $range->to->chapter
+            && $range->from->verse !== null
+            && $range->to->verse !== null
+            && $range->from->verse > $range->to->verse
+        ) {
+            $this->errors[] = new ValidationError(
+                sprintf(
+                    'Invalid range: start verse %d is greater than end verse %d in chapter %d',
+                    $range->from->verse,
+                    $range->to->verse,
+                    $range->from->chapter
+                )
+            );
+        }
+    }
+
+    private function validateChapter(int $chapter, int $nonZeroBookIdx): void
+    {
+        foreach ($this->indexes as $variant => $index) {
+            $bookidx = array_search($nonZeroBookIdx, $index['book_num']);
+            if ($bookidx === false) {
+                continue;
+            }
+            $chapterLimit = $index['chapter_limit'][$bookidx];
+            if ($chapter > $chapterLimit) {
+                $this->errors[] = new ValidationError(
+                    sprintf(
+                        'A chapter in the query is out of bounds: there is no chapter <%d> in the book in the requested version %s, the last possible chapter is <%d>',
+                        $chapter,
+                        $variant,
+                        $chapterLimit
+                    )
+                );
+            }
+        }
+    }
+
+    private function validateVerse(int $verse, int $chapter, int $nonZeroBookIdx): void
+    {
+        foreach ($this->indexes as $variant => $index) {
+            $bookidx = array_search($nonZeroBookIdx, $index['book_num']);
+            if ($bookidx === false) {
+                continue;
+            }
+            $chapterLimit = $index['chapter_limit'][$bookidx];
+            if ($chapter > $chapterLimit) {
+                // Already reported by validateChapter
+                continue;
+            }
+            $verseLimits = $index['verse_limit'][$bookidx];
+            $verseLimit  = $verseLimits[$chapter - 1] ?? 0;
+            if ($verse > $verseLimit) {
+                $this->errors[] = new ValidationError(
+                    sprintf(
+                        'A verse in the query is out of bounds: there is no verse <%d> at chapter <%d> in the requested version %s, the last possible verse is <%d>',
+                        $verse,
+                        $chapter,
+                        $variant,
+                        $verseLimit
+                    )
+                );
+            }
+        }
+    }
+}

--- a/src/Pipeline/Validator/AstValidator.php
+++ b/src/Pipeline/Validator/AstValidator.php
@@ -226,7 +226,11 @@ final class AstValidator
 
     private function validateChapter(int $chapter, int $nonZeroBookIdx): void
     {
-        foreach ($this->indexes as $variant => $index) {
+        foreach ($this->validatedVariants as $variant) {
+            if (!isset($this->indexes[$variant])) {
+                continue;
+            }
+            $index   = $this->indexes[$variant];
             $bookidx = array_search($nonZeroBookIdx, $index['book_num']);
             if ($bookidx === false) {
                 continue;
@@ -247,7 +251,11 @@ final class AstValidator
 
     private function validateVerse(int $verse, int $chapter, int $nonZeroBookIdx): void
     {
-        foreach ($this->indexes as $variant => $index) {
+        foreach ($this->validatedVariants as $variant) {
+            if (!isset($this->indexes[$variant])) {
+                continue;
+            }
+            $index   = $this->indexes[$variant];
             $bookidx = array_search($nonZeroBookIdx, $index['book_num']);
             if ($bookidx === false) {
                 continue;

--- a/src/Pipeline/Validator/ValidationError.php
+++ b/src/Pipeline/Validator/ValidationError.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BibleGet\Api\Pipeline\Validator;
+
+final class ValidationError
+{
+    public function __construct(
+        public readonly string $message,
+        public readonly int $position = -1,
+    ) {
+    }
+}

--- a/tests/Integration/Pipeline/IssueRegressionPipelineTest.php
+++ b/tests/Integration/Pipeline/IssueRegressionPipelineTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BibleGet\Tests\Integration\Pipeline;
+
+use BibleGet\Api\Pipeline\QuoteContext;
+use BibleGet\Api\Pipeline\QueryValidator;
+use BibleGet\Api\Pipeline\QueryFormulator;
+use BibleGet\Api\Pipeline\QueryExecutor;
+use BibleGet\Tests\Integration\DatabaseTestCase;
+
+/**
+ * End-to-end regression tests proving that reported issues are resolved.
+ *
+ * Each test exercises the full pipeline (normalize → validate → formulate → execute)
+ * to confirm the fix works from raw input to final results.
+ */
+class IssueRegressionPipelineTest extends DatabaseTestCase
+{
+    private function executePipeline(string $query, string $version = 'TEST1'): QuoteContext
+    {
+        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+
+        $ctx = new QuoteContext(['query' => $query, 'version' => $version]);
+        $ctx->initialize();
+        $ctx->queryStrClean();
+
+        $validator = new QueryValidator($ctx);
+        $validator->validateQueries();
+
+        if (!empty($ctx->validatedQueries)) {
+            $formulator = new QueryFormulator($ctx);
+            $formulator->formulateSQLQueries();
+
+            $executor = new QueryExecutor($ctx);
+            $executor->executeSQLQueries();
+        }
+
+        return $ctx;
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['REMOTE_ADDR']);
+        parent::tearDown();
+    }
+
+    /**
+     * Issue #41: cross-chapter range with discontinuous verses.
+     *
+     * Original report: "Matthew 9:35–10:1, 5, 6-8" (English notation)
+     * Adapted to test data (European notation): Genesis1,5-2,1.5.6-8
+     *   → cross-chapter range 1:5–2:1, then 2:5, then 2:6–2:8
+     * Expected: ch1 v5–10 (6) + ch2 v1 (1) + ch2 v5 (1) + ch2 v6–8 (3) = 11 verses
+     */
+    public function testIssue41CrossChapterRangeWithDiscontinuousVerses(): void
+    {
+        $ctx = $this->executePipeline('Genesis1,5-2,1.5.6-8');
+
+        self::assertEmpty($ctx->errors, 'Expected no errors');
+        self::assertCount(11, $ctx->results);
+
+        // First result is chapter 1 verse 5
+        self::assertEquals(1, $ctx->results[0]['chapter']);
+        self::assertEquals(5, $ctx->results[0]['verse']);
+
+        // Last result is chapter 2 verse 8
+        $last = $ctx->results[count($ctx->results) - 1];
+        self::assertEquals(2, $last['chapter']);
+        self::assertEquals(8, $last['verse']);
+    }
+
+    /**
+     * Issue #42: verse "letters" (partial verse suffixes) should be stripped.
+     *
+     * "Genesis 2,4a" should return verse 4.
+     */
+    public function testIssue42PartialVerseSuffixReturnsVerse(): void
+    {
+        $ctx = $this->executePipeline('Genesis2,4a');
+
+        self::assertEmpty($ctx->errors, 'Expected no errors');
+        self::assertCount(1, $ctx->results);
+        self::assertEquals(4, $ctx->results[0]['verse']);
+    }
+
+    /**
+     * Issue #42: verse letter range "Genesis 2,4a-7b" should return verses 4–7.
+     */
+    public function testIssue42PartialVerseSuffixRange(): void
+    {
+        $ctx = $this->executePipeline('Genesis2,4a-7b');
+
+        self::assertEmpty($ctx->errors, 'Expected no errors');
+        self::assertCount(4, $ctx->results);
+        self::assertEquals(4, $ctx->results[0]['verse']);
+        self::assertEquals(7, $ctx->results[3]['verse']);
+    }
+
+    /**
+     * Issue #43: "Cf." prefix should be stripped so the query succeeds.
+     */
+    public function testIssue43CfPrefixStripped(): void
+    {
+        $ctx = $this->executePipeline('Cf. Genesis 1:1');
+
+        self::assertEmpty($ctx->errors, 'Expected no errors');
+        self::assertCount(1, $ctx->results);
+        self::assertEquals(1, $ctx->results[0]['chapter']);
+        self::assertEquals(1, $ctx->results[0]['verse']);
+    }
+
+    /**
+     * Issue #43: "Cfr." prefix variant.
+     */
+    public function testIssue43CfrPrefixStripped(): void
+    {
+        $ctx = $this->executePipeline('Cfr. Genesis 2:1');
+
+        self::assertEmpty($ctx->errors, 'Expected no errors');
+        self::assertCount(1, $ctx->results);
+        self::assertEquals(2, $ctx->results[0]['chapter']);
+        self::assertEquals(1, $ctx->results[0]['verse']);
+    }
+
+    /**
+     * Issue #43: prefix on one query in a multi-query string.
+     */
+    public function testIssue43PrefixOnSecondQuery(): void
+    {
+        $ctx = $this->executePipeline('Genesis1:1; Cf. Exodus1:1');
+
+        self::assertEmpty($ctx->errors, 'Expected no errors');
+        self::assertCount(2, $ctx->results);
+        self::assertSame('Genesis', $ctx->results[0]['book']);
+        self::assertSame('Exodus', $ctx->results[1]['book']);
+    }
+
+    /**
+     * Issue #47: out-of-bounds verse in first query must not cause a fatal SQL
+     * error in the second query.
+     *
+     * Original report: "Isaiah8:23;9:1-3" produced a fatal SQL syntax error.
+     * Adapted to test data: Genesis1:99 is out of bounds (ch1 has 10 verses),
+     * and the second query "2:1" would inherit Genesis.
+     *
+     * Expected: clean validation error(s), no fatal SQL exception.
+     */
+    public function testIssue47OutOfBoundsDoesNotCauseFatalSqlError(): void
+    {
+        $ctx = $this->executePipeline('Genesis1:99;2:1');
+
+        // The key assertion: we get here without a fatal error / exception.
+        // First query should produce a validation error.
+        self::assertNotEmpty($ctx->errors, 'Expected validation error for out-of-bounds verse');
+        self::assertStringContainsString('out of bounds', $ctx->errors[0]['errMessage']);
+    }
+
+    /**
+     * Issue #47: the second query after an out-of-bounds first query should
+     * not produce malformed SQL. If the book is explicitly stated, the second
+     * query should succeed independently.
+     */
+    public function testIssue47ValidSecondQueryAfterInvalidFirst(): void
+    {
+        // "Genesis1:99" fails validation; "Genesis2:1" is explicit and valid
+        $ctx = $this->executePipeline('Genesis1:99;Genesis2:1');
+
+        // First query produces an error
+        self::assertNotEmpty($ctx->errors);
+
+        // Second query should still produce a result
+        self::assertNotEmpty($ctx->results, 'Valid second query should return results');
+        self::assertEquals(2, $ctx->results[0]['chapter']);
+        self::assertEquals(1, $ctx->results[0]['verse']);
+    }
+}

--- a/tests/Integration/Pipeline/PsalmChapterSwapIntegrationTest.php
+++ b/tests/Integration/Pipeline/PsalmChapterSwapIntegrationTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BibleGet\Tests\Integration\Pipeline;
+
+use BibleGet\Api\Pipeline\QuoteContext;
+use BibleGet\Api\Pipeline\QueryValidator;
+use BibleGet\Api\Pipeline\QueryFormulator;
+use BibleGet\Api\Pipeline\QueryExecutor;
+use BibleGet\Tests\Integration\DatabaseTestCase;
+
+/**
+ * Integration tests for issue #46: Psalm references with dual Hebrew/Vulgate numbering.
+ *
+ * Verifies that "Psalm51(50),1" queries chapter 50 in VGCL/DRB (Vulgate)
+ * and chapter 51 in TEST1 (Hebrew).
+ */
+class PsalmChapterSwapIntegrationTest extends DatabaseTestCase
+{
+    private function executePipeline(string $query, string $version): QuoteContext
+    {
+        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+
+        $ctx = new QuoteContext(['query' => $query, 'version' => $version]);
+        $ctx->initialize();
+        $ctx->queryStrClean();
+
+        $validator = new QueryValidator($ctx);
+        $validator->validateQueries();
+
+        if (!empty($ctx->validatedQueries)) {
+            $formulator = new QueryFormulator($ctx);
+            $formulator->formulateSQLQueries();
+
+            $executor = new QueryExecutor($ctx);
+            $executor->executeSQLQueries();
+        }
+
+        return $ctx;
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['REMOTE_ADDR']);
+        parent::tearDown();
+    }
+
+    /**
+     * Psalm51(50),3 with VGCL → should query chapter 50, return Latin "Miserere mei".
+     */
+    public function testPsalmDualNumberingVgclUsesAlternateChapter(): void
+    {
+        $ctx = $this->executePipeline('Psalm51(50),3', 'VGCL');
+
+        self::assertEmpty($ctx->errors, 'Expected no errors: ' . print_r($ctx->errors, true));
+        self::assertCount(1, $ctx->results);
+        self::assertEquals(50, $ctx->results[0]['chapter']);
+        self::assertEquals(3, $ctx->results[0]['verse']);
+        self::assertStringContainsString('Miserere', $ctx->results[0]['text']);
+    }
+
+    /**
+     * Psalm51(50),3 with DRB → should query chapter 50, return English "Have mercy".
+     */
+    public function testPsalmDualNumberingDrbUsesAlternateChapter(): void
+    {
+        $ctx = $this->executePipeline('Psalm51(50),3', 'DRB');
+
+        self::assertEmpty($ctx->errors, 'Expected no errors: ' . print_r($ctx->errors, true));
+        self::assertCount(1, $ctx->results);
+        self::assertEquals(50, $ctx->results[0]['chapter']);
+        self::assertStringContainsString('mercy', $ctx->results[0]['text']);
+    }
+
+    /**
+     * Psalm51(50),1 with TEST1 → should query chapter 51 (Hebrew numbering, no swap).
+     */
+    public function testPsalmDualNumberingTest1UsesPrimaryChapter(): void
+    {
+        $ctx = $this->executePipeline('Psalm51(50),1', 'TEST1');
+
+        self::assertEmpty($ctx->errors, 'Expected no errors: ' . print_r($ctx->errors, true));
+        self::assertCount(1, $ctx->results);
+        self::assertEquals(51, $ctx->results[0]['chapter']);
+        self::assertEquals(1, $ctx->results[0]['verse']);
+    }
+
+    /**
+     * Psalm51,1 (no alternate) with VGCL → no swap, queries chapter 51 as-is.
+     * VGCL chapter 51 is actually Hebrew Psalm 52 ("Quid gloriaris").
+     */
+    public function testPsalmWithoutAlternateNoSwap(): void
+    {
+        $ctx = $this->executePipeline('Psalm51,1', 'VGCL');
+
+        self::assertEmpty($ctx->errors, 'Expected no errors: ' . print_r($ctx->errors, true));
+        self::assertCount(1, $ctx->results);
+        self::assertEquals(51, $ctx->results[0]['chapter']);
+        self::assertStringContainsString('Intellectus', $ctx->results[0]['text']);
+    }
+
+    /**
+     * Psalm51(50),3-5 range with VGCL → should return VGCL chapter 50 verses 3-5.
+     */
+    public function testPsalmDualNumberingRangeWithVgcl(): void
+    {
+        $ctx = $this->executePipeline('Psalm51(50),3-5', 'VGCL');
+
+        self::assertEmpty($ctx->errors, 'Expected no errors: ' . print_r($ctx->errors, true));
+        self::assertCount(3, $ctx->results);
+        self::assertEquals(50, $ctx->results[0]['chapter']);
+        self::assertEquals(3, $ctx->results[0]['verse']);
+        self::assertEquals(5, $ctx->results[2]['verse']);
+    }
+
+    /**
+     * Multi-version: Psalm51(50),3 with VGCL,TEST1 → VGCL returns ch50 v3,
+     * TEST1 returns ch51 v3.
+     */
+    public function testPsalmDualNumberingMultiVersion(): void
+    {
+        $ctx = $this->executePipeline('Psalm51(50),3', 'VGCL,TEST1');
+
+        self::assertEmpty($ctx->errors, 'Expected no errors: ' . print_r($ctx->errors, true));
+        self::assertCount(2, $ctx->results);
+
+        // Results are ordered by version iteration: VGCL first, then TEST1
+        $vgclResult  = null;
+        $test1Result = null;
+        foreach ($ctx->results as $r) {
+            if ($r['version'] === 'VGCL') {
+                $vgclResult = $r;
+            } elseif ($r['version'] === 'TEST1') {
+                $test1Result = $r;
+            }
+        }
+
+        self::assertNotNull($vgclResult, 'VGCL result expected');
+        self::assertNotNull($test1Result, 'TEST1 result expected');
+        self::assertEquals(50, $vgclResult['chapter']);
+        self::assertEquals(51, $test1Result['chapter']);
+    }
+}

--- a/tests/Unit/Pipeline/Compiler/SqlCompilerTest.php
+++ b/tests/Unit/Pipeline/Compiler/SqlCompilerTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BibleGet\Tests\Unit\Pipeline\Compiler;
+
+use BibleGet\Api\Pipeline\Ast\BibleQuery;
+use BibleGet\Api\Pipeline\Ast\VerseRange;
+use BibleGet\Api\Pipeline\Ast\VerseRef;
+use BibleGet\Api\Pipeline\Compiler\SqlCompiler;
+use PHPUnit\Framework\TestCase;
+
+final class SqlCompilerTest extends TestCase
+{
+    private SqlCompiler $compiler;
+
+    protected function setUp(): void
+    {
+        $this->compiler = new SqlCompiler();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function compile(BibleQuery $query, string $version = 'CEI2008', string $preferOrigin = ''): array
+    {
+        return $this->compiler->compile($query, $version, $preferOrigin, [], []);
+    }
+
+    // ── Single verse ──────────────────────────────────────────────
+
+    public function testSingleVerse(): void
+    {
+        $query  = new BibleQuery(1, [new VerseRef(1, 3, null, 16)]);
+        $result = $this->compile($query);
+
+        $this->assertCount(1, $result);
+        $this->assertSame(
+            'SELECT * FROM CEI2008 WHERE book = 1 AND chapter = 3 AND verse = 16 ORDER BY verseID',
+            $result[0]
+        );
+    }
+
+    // ── Whole chapter ─────────────────────────────────────────────
+
+    public function testWholeChapter(): void
+    {
+        $query  = new BibleQuery(1, [new VerseRef(1, 5)]);
+        $result = $this->compile($query);
+
+        $this->assertSame(
+            'SELECT * FROM CEI2008 WHERE book = 1 AND chapter = 5 ORDER BY verseID',
+            $result[0]
+        );
+    }
+
+    // ── Verse range (same chapter) ────────────────────────────────
+
+    public function testSameChapterVerseRange(): void
+    {
+        $from   = new VerseRef(1, 3, null, 1);
+        $to     = new VerseRef(1, 3, null, 10);
+        $query  = new BibleQuery(1, [new VerseRange($from, $to)]);
+        $result = $this->compile($query);
+
+        $this->assertSame(
+            'SELECT * FROM CEI2008 WHERE book = 1 AND chapter = 3 AND verse >= 1 AND verse <= 10 ORDER BY verseID',
+            $result[0]
+        );
+    }
+
+    // ── Chapter range ─────────────────────────────────────────────
+
+    public function testChapterRange(): void
+    {
+        $from   = new VerseRef(1, 1);
+        $to     = new VerseRef(1, 3);
+        $query  = new BibleQuery(1, [new VerseRange($from, $to)]);
+        $result = $this->compile($query);
+
+        $this->assertSame(
+            'SELECT * FROM CEI2008 WHERE book = 1 AND chapter >= 1 AND chapter <= 3 ORDER BY verseID',
+            $result[0]
+        );
+    }
+
+    // ── Cross-chapter range ───────────────────────────────────────
+
+    public function testCrossChapterRange(): void
+    {
+        $from   = new VerseRef(1, 1, null, 5);
+        $to     = new VerseRef(1, 2, null, 3);
+        $query  = new BibleQuery(1, [new VerseRange($from, $to)]);
+        $result = $this->compile($query);
+
+        $this->assertSame(
+            'SELECT * FROM CEI2008 WHERE book = 1 AND ( ( chapter = 1 AND verse >= 5 ) OR ( chapter = 2 AND verse <= 3 ) ) ORDER BY verseID',
+            $result[0]
+        );
+    }
+
+    // ── Cross-chapter range with intermediate chapters ────────────
+
+    public function testCrossChapterRangeWithIntermediateChapters(): void
+    {
+        $from   = new VerseRef(1, 1, null, 5);
+        $to     = new VerseRef(1, 4, null, 3);
+        $query  = new BibleQuery(1, [new VerseRange($from, $to)]);
+        $result = $this->compile($query);
+
+        $this->assertSame(
+            'SELECT * FROM CEI2008 WHERE book = 1 AND ( ( chapter = 1 AND verse >= 5 ) OR ( chapter = 2 ) OR ( chapter = 3 ) OR ( chapter = 4 AND verse <= 3 ) ) ORDER BY verseID',
+            $result[0]
+        );
+    }
+
+    // ── Non-consecutive verses → multiple queries ─────────────────
+
+    public function testNonConsecutiveVerses(): void
+    {
+        // Genesis1,1-3.5.10 → 3 segments → 3 SQL queries
+        $query  = new BibleQuery(1, [
+            new VerseRange(new VerseRef(1, 1, null, 1), new VerseRef(1, 1, null, 3)),
+            new VerseRef(1, 1, null, 5),
+            new VerseRef(1, 1, null, 10),
+        ]);
+        $result = $this->compile($query);
+
+        $this->assertCount(3, $result);
+        $this->assertStringContainsString('verse >= 1 AND verse <= 3', $result[0]);
+        $this->assertStringContainsString('verse = 5', $result[1]);
+        $this->assertStringContainsString('verse = 10', $result[2]);
+    }
+
+    // ── preferOrigin annotation ───────────────────────────────────
+
+    public function testPreferOrigin(): void
+    {
+        $query  = new BibleQuery(19, [new VerseRef(19, 51, null, 1)]);
+        $result = $this->compiler->compile($query, 'CEI2008', " AND verseorigin = 'GREEK'", [], []);
+
+        $this->assertStringContainsString("AND verseorigin = 'GREEK'", $result[0]);
+    }
+
+    // ── Copyright LIMIT 30 ────────────────────────────────────────
+
+    public function testCopyrightLimit(): void
+    {
+        $query  = new BibleQuery(1, [new VerseRef(1, 1)]);
+        $result = $this->compiler->compile($query, 'NABRE', '', ['NABRE'], []);
+
+        $this->assertStringEndsWith('LIMIT 30', $result[0]);
+    }
+
+    public function testNoCopyrightLimitForNonCopyrighted(): void
+    {
+        $query  = new BibleQuery(1, [new VerseRef(1, 1)]);
+        $result = $this->compiler->compile($query, 'CEI2008', '', ['NABRE'], []);
+
+        $this->assertStringEndsWith('ORDER BY verseID', $result[0]);
+    }
+
+    public function testForcedCopyrightLimit(): void
+    {
+        $query  = new BibleQuery(1, [new VerseRef(1, 1)]);
+        $result = $this->compiler->compile($query, 'CUSTOM', '', [], ['CUSTOM']);
+
+        $this->assertStringEndsWith('LIMIT 30', $result[0]);
+    }
+}

--- a/tests/Unit/Pipeline/Parser/ReferenceParserTest.php
+++ b/tests/Unit/Pipeline/Parser/ReferenceParserTest.php
@@ -7,7 +7,6 @@ namespace BibleGet\Tests\Unit\Pipeline\Parser;
 use BibleGet\Api\Pipeline\Ast\BibleQuery;
 use BibleGet\Api\Pipeline\Ast\VerseRange;
 use BibleGet\Api\Pipeline\Ast\VerseRef;
-use BibleGet\Api\Pipeline\Parser\ParseException;
 use BibleGet\Api\Pipeline\Parser\ReferenceParser;
 use BibleGet\Api\Pipeline\Tokenizer\ReferenceTokenizer;
 use PHPUnit\Framework\TestCase;
@@ -152,11 +151,11 @@ final class ReferenceParserTest extends TestCase
 
     // ── Parse exception on invalid input ──────────────────────────
 
-    public function testThrowsOnMissingBookName(): void
+    public function testNoBookProducesZeroBookIndex(): void
     {
-        $this->expectException(ParseException::class);
-        // Tokenize "123" — will produce CHAPTER_NUMBER, not BOOK_NAME
-        $this->parse('123');
+        // "123" has no book name — parser produces book=0 for caller to handle
+        $q = $this->parse('123');
+        $this->assertSame(0, $q->book);
     }
 
     // ── Numbered book ─────────────────────────────────────────────

--- a/tests/Unit/Pipeline/Parser/ReferenceParserTest.php
+++ b/tests/Unit/Pipeline/Parser/ReferenceParserTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BibleGet\Tests\Unit\Pipeline\Parser;
+
+use BibleGet\Api\Pipeline\Ast\BibleQuery;
+use BibleGet\Api\Pipeline\Ast\VerseRange;
+use BibleGet\Api\Pipeline\Ast\VerseRef;
+use BibleGet\Api\Pipeline\Parser\ParseException;
+use BibleGet\Api\Pipeline\Parser\ReferenceParser;
+use BibleGet\Api\Pipeline\Tokenizer\ReferenceTokenizer;
+use PHPUnit\Framework\TestCase;
+
+final class ReferenceParserTest extends TestCase
+{
+    private ReferenceTokenizer $tokenizer;
+    private ReferenceParser $parser;
+
+    protected function setUp(): void
+    {
+        $this->tokenizer = new ReferenceTokenizer();
+        $this->parser    = new ReferenceParser();
+    }
+
+    private function parse(string $input): BibleQuery
+    {
+        return $this->parser->parse($this->tokenizer->tokenize($input));
+    }
+
+    // ── Whole chapter ─────────────────────────────────────────────
+
+    public function testWholeChapter(): void
+    {
+        $q = $this->parse('Genesis1');
+        $this->assertCount(1, $q->segments);
+        $this->assertInstanceOf(VerseRef::class, $q->segments[0]);
+        $this->assertSame(1, $q->segments[0]->chapter);
+        $this->assertNull($q->segments[0]->verse);
+    }
+
+    // ── Single verse ──────────────────────────────────────────────
+
+    public function testSingleVerse(): void
+    {
+        $q = $this->parse('Genesis1,5');
+        $this->assertCount(1, $q->segments);
+        $seg = $q->segments[0];
+        $this->assertInstanceOf(VerseRef::class, $seg);
+        $this->assertSame(1, $seg->chapter);
+        $this->assertSame(5, $seg->verse);
+    }
+
+    // ── Verse range (same chapter) ────────────────────────────────
+
+    public function testVerseRangeSameChapter(): void
+    {
+        $q = $this->parse('Genesis1,5-10');
+        $this->assertCount(1, $q->segments);
+        $seg = $q->segments[0];
+        $this->assertInstanceOf(VerseRange::class, $seg);
+        $this->assertSame(1, $seg->from->chapter);
+        $this->assertSame(5, $seg->from->verse);
+        $this->assertSame(1, $seg->to->chapter);
+        $this->assertSame(10, $seg->to->verse);
+    }
+
+    // ── Chapter range ─────────────────────────────────────────────
+
+    public function testChapterRange(): void
+    {
+        $q = $this->parse('Genesis1-3');
+        $this->assertCount(1, $q->segments);
+        $seg = $q->segments[0];
+        $this->assertInstanceOf(VerseRange::class, $seg);
+        $this->assertSame(1, $seg->from->chapter);
+        $this->assertNull($seg->from->verse);
+        $this->assertSame(3, $seg->to->chapter);
+        $this->assertNull($seg->to->verse);
+    }
+
+    // ── Cross-chapter range ───────────────────────────────────────
+
+    public function testCrossChapterRange(): void
+    {
+        $q = $this->parse('Genesis1,5-2,3');
+        $this->assertCount(1, $q->segments);
+        $seg = $q->segments[0];
+        $this->assertInstanceOf(VerseRange::class, $seg);
+        $this->assertSame(1, $seg->from->chapter);
+        $this->assertSame(5, $seg->from->verse);
+        $this->assertSame(2, $seg->to->chapter);
+        $this->assertSame(3, $seg->to->verse);
+    }
+
+    // ── Non-consecutive verses ────────────────────────────────────
+
+    public function testNonConsecutiveVerses(): void
+    {
+        $q = $this->parse('Genesis1,1-3.5.10');
+        $this->assertCount(3, $q->segments);
+
+        // First: range 1:1-3
+        $this->assertInstanceOf(VerseRange::class, $q->segments[0]);
+        $this->assertSame(1, $q->segments[0]->from->verse);
+        $this->assertSame(3, $q->segments[0]->to->verse);
+
+        // Second: verse 1:5
+        $this->assertInstanceOf(VerseRef::class, $q->segments[1]);
+        $this->assertSame(1, $q->segments[1]->chapter);
+        $this->assertSame(5, $q->segments[1]->verse);
+
+        // Third: verse 1:10
+        $this->assertInstanceOf(VerseRef::class, $q->segments[2]);
+        $this->assertSame(1, $q->segments[2]->chapter);
+        $this->assertSame(10, $q->segments[2]->verse);
+    }
+
+    // ── Partial verse suffix ──────────────────────────────────────
+
+    public function testPartialVerseSuffix(): void
+    {
+        $q   = $this->parse('Genesis2,4a');
+        $seg = $q->segments[0];
+        $this->assertInstanceOf(VerseRef::class, $seg);
+        $this->assertSame(4, $seg->verse);
+        $this->assertSame('a', $seg->partialSuffix);
+    }
+
+    public function testPartialVerseSuffixInRange(): void
+    {
+        $q   = $this->parse('Genesis2,4a-7b');
+        $seg = $q->segments[0];
+        $this->assertInstanceOf(VerseRange::class, $seg);
+        $this->assertSame(4, $seg->from->verse);
+        $this->assertSame('a', $seg->from->partialSuffix);
+        $this->assertSame(7, $seg->to->verse);
+        $this->assertSame('b', $seg->to->partialSuffix);
+    }
+
+    // ── Dual Psalm numbering ──────────────────────────────────────
+
+    public function testDualPsalmNumbering(): void
+    {
+        $q   = $this->parse('Psalm51(50),1');
+        $seg = $q->segments[0];
+        $this->assertInstanceOf(VerseRef::class, $seg);
+        $this->assertSame(51, $seg->chapter);
+        $this->assertSame(50, $seg->alternateChapter);
+        $this->assertSame(1, $seg->verse);
+    }
+
+    // ── Parse exception on invalid input ──────────────────────────
+
+    public function testThrowsOnMissingBookName(): void
+    {
+        $this->expectException(ParseException::class);
+        // Tokenize "123" — will produce CHAPTER_NUMBER, not BOOK_NAME
+        $this->parse('123');
+    }
+
+    // ── Numbered book ─────────────────────────────────────────────
+
+    public function testNumberedBook(): void
+    {
+        $q = $this->parse('1John3,16');
+        $this->assertSame(0, $q->book); // book=0 placeholder until validator resolves it
+        $seg = $q->segments[0];
+        $this->assertInstanceOf(VerseRef::class, $seg);
+        $this->assertSame(3, $seg->chapter);
+        $this->assertSame(16, $seg->verse);
+    }
+
+    // ── Non-consecutive verse ranges ──────────────────────────────
+
+    public function testNonConsecutiveVerseRanges(): void
+    {
+        // Genesis1,1-3.5-8 → range 1:1-3, then range 1:5-8
+        $q = $this->parse('Genesis1,1-3.5-8');
+        $this->assertCount(2, $q->segments);
+
+        $this->assertInstanceOf(VerseRange::class, $q->segments[0]);
+        $this->assertSame(1, $q->segments[0]->from->verse);
+        $this->assertSame(3, $q->segments[0]->to->verse);
+
+        $this->assertInstanceOf(VerseRange::class, $q->segments[1]);
+        $this->assertSame(5, $q->segments[1]->from->verse);
+        $this->assertSame(8, $q->segments[1]->to->verse);
+    }
+}

--- a/tests/Unit/Pipeline/Parser/ReferenceParserTest.php
+++ b/tests/Unit/Pipeline/Parser/ReferenceParserTest.php
@@ -170,6 +170,105 @@ final class ReferenceParserTest extends TestCase
         $this->assertSame(16, $seg->verse);
     }
 
+    // ── Non-Latin script book names ────────────────────────────────
+
+    public function testChineseBookNameParsesToAst(): void
+    {
+        // 創世記 = Genesis in Chinese
+        $q = $this->parse('創世記1,5');
+        $this->assertSame(0, $q->book); // placeholder until validator resolves
+        $seg = $q->segments[0];
+        $this->assertInstanceOf(VerseRef::class, $seg);
+        $this->assertSame(1, $seg->chapter);
+        $this->assertSame(5, $seg->verse);
+    }
+
+    public function testArabicBookNameParsesRange(): void
+    {
+        // يوحنا = John in Arabic (RTL)
+        $q = $this->parse('يوحنا3,16-18');
+        $this->assertCount(1, $q->segments);
+        $seg = $q->segments[0];
+        $this->assertInstanceOf(VerseRange::class, $seg);
+        $this->assertSame(3, $seg->from->chapter);
+        $this->assertSame(16, $seg->from->verse);
+        $this->assertSame(3, $seg->to->chapter);
+        $this->assertSame(18, $seg->to->verse);
+    }
+
+    public function testKoreanBookNameWholeChapter(): void
+    {
+        // 창세기 = Genesis in Korean
+        $q = $this->parse('창세기1');
+        $this->assertCount(1, $q->segments);
+        $seg = $q->segments[0];
+        $this->assertInstanceOf(VerseRef::class, $seg);
+        $this->assertSame(1, $seg->chapter);
+        $this->assertNull($seg->verse);
+    }
+
+    public function testJapaneseBookNameCrossChapterRange(): void
+    {
+        // ヨハネ = John in Japanese (Katakana)
+        $q = $this->parse('ヨハネ1,5-2,3');
+        $this->assertCount(1, $q->segments);
+        $seg = $q->segments[0];
+        $this->assertInstanceOf(VerseRange::class, $seg);
+        $this->assertSame(1, $seg->from->chapter);
+        $this->assertSame(5, $seg->from->verse);
+        $this->assertSame(2, $seg->to->chapter);
+        $this->assertSame(3, $seg->to->verse);
+    }
+
+    public function testArabicBookNameNonConsecutiveVerses(): void
+    {
+        // يوحنا3,16.18.20 → three individual verse refs
+        $q = $this->parse('يوحنا3,16.18.20');
+        $this->assertCount(3, $q->segments);
+
+        $this->assertInstanceOf(VerseRef::class, $q->segments[0]);
+        $this->assertSame(16, $q->segments[0]->verse);
+
+        $this->assertInstanceOf(VerseRef::class, $q->segments[1]);
+        $this->assertSame(18, $q->segments[1]->verse);
+
+        $this->assertInstanceOf(VerseRef::class, $q->segments[2]);
+        $this->assertSame(20, $q->segments[2]->verse);
+    }
+
+    public function testUrduBookNameParsesToAst(): void
+    {
+        // پیدائش = Genesis in Urdu (RTL Nastaliq)
+        $q   = $this->parse('پیدائش1,1');
+        $seg = $q->segments[0];
+        $this->assertInstanceOf(VerseRef::class, $seg);
+        $this->assertSame(1, $seg->chapter);
+        $this->assertSame(1, $seg->verse);
+    }
+
+    public function testTamilBookNameParsesToAst(): void
+    {
+        // ஆதியாகமம் = Genesis in Tamil (combining marks)
+        $q   = $this->parse('ஆதியாகமம்1,1');
+        $seg = $q->segments[0];
+        $this->assertInstanceOf(VerseRef::class, $seg);
+        $this->assertSame(1, $seg->chapter);
+        $this->assertSame(1, $seg->verse);
+    }
+
+    public function testAmharicBookNameChapterRange(): void
+    {
+        // ዘፍጥረት = Genesis in Amharic (Ge'ez script)
+        $q = $this->parse('ዘፍጥረት1-3');
+        $this->assertCount(1, $q->segments);
+        $seg = $q->segments[0];
+        $this->assertInstanceOf(VerseRange::class, $seg);
+        $this->assertSame(1, $seg->from->chapter);
+        $this->assertNull($seg->from->verse);
+        $this->assertSame(3, $seg->to->chapter);
+        $this->assertNull($seg->to->verse);
+    }
+
     // ── Non-consecutive verse ranges ──────────────────────────────
 
     public function testNonConsecutiveVerseRanges(): void

--- a/tests/Unit/Pipeline/QuoteContextTest.php
+++ b/tests/Unit/Pipeline/QuoteContextTest.php
@@ -159,6 +159,36 @@ class QuoteContextTest extends TestCase
         self::assertStringContainsString('-', $ctx->queries[0]);
     }
 
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function referencePrefixProvider(): array
+    {
+        return [
+            'Cf. with dot'     => ['Cf.John3,16', 'John3,16'],
+            'cf. lowercase'    => ['cf.John3,16', 'John3,16'],
+            'CF. uppercase'    => ['CF.John3,16', 'John3,16'],
+            'Cfr. with dot'    => ['Cfr.John3,16', 'John3,16'],
+            'cfr. lowercase'   => ['cfr.John3,16', 'John3,16'],
+            'Cf without dot'   => ['CfJohn3,16', 'John3,16'],
+            'Cfr without dot'  => ['CfrJohn3,16', 'John3,16'],
+            'Confer'           => ['ConferJohn3,16', 'John3,16'],
+            'confer lowercase' => ['conferJohn3,16', 'John3,16'],
+            'no prefix'        => ['John3,16', 'John3,16'],
+            'prefix on second' => ['Gen1,1;Cf.Ex2,3', 'Ex2,3'],
+        ];
+    }
+
+    #[DataProvider('referencePrefixProvider')]
+    public function testQueryStrCleanStripsReferencePrefix(string $input, string $expectedLastQuery): void
+    {
+        $ctx = new QuoteContext(['query' => $input]);
+        $ctx->queryStrClean();
+        $last = $ctx->queries[array_key_last($ctx->queries)];
+        // Compare only the book+chapter+verse portion (notation may differ)
+        self::assertStringStartsWith($expectedLastQuery, $last);
+    }
+
     public function testErrorMessagesAreComplete(): void
     {
         for ($i = 0; $i <= 12; $i++) {

--- a/tests/Unit/Pipeline/QuoteContextTest.php
+++ b/tests/Unit/Pipeline/QuoteContextTest.php
@@ -151,12 +151,58 @@ class QuoteContextTest extends TestCase
         self::assertSame('John3,16', $ctx->queries[0]);
     }
 
-    public function testQueryStrCleanNormalizesUnicodeDashes(): void
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function unicodeDashProvider(): array
     {
-        // EN DASH (U+2013)
-        $ctx = new QuoteContext(['query' => "John3,16\u{2013}18"]);
+        return [
+            'U+2010 HYPHEN'                 => ["John3,16\u{2010}18", 'John3,16-18'],
+            'U+2011 NON-BREAKING HYPHEN'    => ["John3,16\u{2011}18", 'John3,16-18'],
+            'U+2012 FIGURE DASH'            => ["John3,16\u{2012}18", 'John3,16-18'],
+            'U+2013 EN DASH'                => ["John3,16\u{2013}18", 'John3,16-18'],
+            'U+2014 EM DASH'                => ["John3,16\u{2014}18", 'John3,16-18'],
+            'U+2015 HORIZONTAL BAR'         => ["John3,16\u{2015}18", 'John3,16-18'],
+            'U+2212 MINUS SIGN'             => ["John3,16\u{2212}18", 'John3,16-18'],
+            'U+23AF HORIZONTAL LINE EXT'    => ["John3,16\u{23AF}18", 'John3,16-18'],
+            'U+FE58 SMALL EM DASH'          => ["John3,16\u{FE58}18", 'John3,16-18'],
+            'U+FE63 SMALL HYPHEN-MINUS'     => ["John3,16\u{FE63}18", 'John3,16-18'],
+            'U+FF0D FULLWIDTH HYPHEN-MINUS' => ["John3,16\u{FF0D}18", 'John3,16-18'],
+            'ASCII hyphen unchanged'        => ['John3,16-18', 'John3,16-18'],
+        ];
+    }
+
+    #[DataProvider('unicodeDashProvider')]
+    public function testQueryStrCleanNormalizesUnicodeDashes(string $input, string $expected): void
+    {
+        $ctx = new QuoteContext(['query' => $input]);
         $ctx->queryStrClean();
-        self::assertStringContainsString('-', $ctx->queries[0]);
+        self::assertSame($expected, $ctx->queries[0]);
+    }
+
+    /**
+     * Verify Unicode dashes work with non-Latin book names.
+     *
+     * @return array<string, array{string, string}>
+     */
+    public static function unicodeDashWithNonLatinProvider(): array
+    {
+        return [
+            'Chinese with en dash'             => ["創世記1,1\u{2013}3", '創世記1,1-3'],
+            'Arabic with em dash'              => ["يوحنا3,16\u{2014}18", 'يوحنا3,16-18'],
+            'Korean with fullwidth hyphen'     => ["창세기1,1\u{FF0D}3", '창세기1,1-3'],
+            'Thai with figure dash'            => ["ปฐมกาล1,1\u{2012}3", 'ปฐมกาล1,1-3'],
+            'Amharic with non-breaking hyphen' => ["ዘፍጥረት1,1\u{2011}3", 'ዘፍጥረት1,1-3'],
+            'Japanese with minus sign'         => ["創世記1,1\u{2212}3", '創世記1,1-3'],
+        ];
+    }
+
+    #[DataProvider('unicodeDashWithNonLatinProvider')]
+    public function testUnicodeDashesWithNonLatinBookNames(string $input, string $expected): void
+    {
+        $ctx = new QuoteContext(['query' => $input]);
+        $ctx->queryStrClean();
+        self::assertSame($expected, $ctx->queries[0]);
     }
 
     /**

--- a/tests/Unit/Pipeline/Tokenizer/IssueRegressionTokenizerTest.php
+++ b/tests/Unit/Pipeline/Tokenizer/IssueRegressionTokenizerTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BibleGet\Tests\Unit\Pipeline\Tokenizer;
+
+use BibleGet\Api\Pipeline\Tokenizer\ReferenceTokenizer;
+use BibleGet\Api\Pipeline\Tokenizer\Token;
+use BibleGet\Api\Pipeline\Tokenizer\TokenType;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression tests for tokenizer covering reported issues.
+ */
+final class IssueRegressionTokenizerTest extends TestCase
+{
+    private ReferenceTokenizer $tokenizer;
+
+    protected function setUp(): void
+    {
+        $this->tokenizer = new ReferenceTokenizer();
+    }
+
+    /**
+     * @return array<int, array{TokenType, string}>
+     */
+    private function typeValues(string $input): array
+    {
+        $tokens = $this->tokenizer->tokenize($input);
+        return array_values(array_map(
+            fn(Token $t) => [$t->type, $t->value],
+            array_filter($tokens, fn(Token $t) => $t->type !== TokenType::EOF)
+        ));
+    }
+
+    /**
+     * Issue #41: cross-chapter range + discontinuous verses.
+     * Input after English→European normalization: Matthew9,35-10,1.5.6-8
+     */
+    public function testIssue41CrossChapterRangeWithDiscontinuousVerses(): void
+    {
+        $result = $this->typeValues('Matthew9,35-10,1.5.6-8');
+        $this->assertSame([
+            [TokenType::BOOK_NAME, 'Matthew'],
+            [TokenType::CHAPTER_NUMBER, '9'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '35'],
+            [TokenType::RANGE_SEPARATOR, '-'],
+            [TokenType::CHAPTER_NUMBER, '10'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '1'],
+            [TokenType::EXPLICIT_VERSE_SEPARATOR, '.'],
+            [TokenType::VERSE_NUMBER, '5'],
+            [TokenType::EXPLICIT_VERSE_SEPARATOR, '.'],
+            [TokenType::VERSE_NUMBER, '6'],
+            [TokenType::RANGE_SEPARATOR, '-'],
+            [TokenType::VERSE_NUMBER, '8'],
+        ], $result);
+    }
+
+    /**
+     * Issue #42: verse letters (partial verse suffixes).
+     */
+    public function testIssue42PartialVerseSuffixes(): void
+    {
+        $result = $this->typeValues('Genesis2,4a');
+        $this->assertSame([
+            [TokenType::BOOK_NAME, 'Genesis'],
+            [TokenType::CHAPTER_NUMBER, '2'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '4'],
+            [TokenType::PARTIAL_VERSE_SUFFIX, 'a'],
+        ], $result);
+    }
+
+    public function testIssue42PartialVerseSuffixRange(): void
+    {
+        $result = $this->typeValues('Mark16,9b-20');
+        $this->assertSame([
+            [TokenType::BOOK_NAME, 'Mark'],
+            [TokenType::CHAPTER_NUMBER, '16'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '9'],
+            [TokenType::PARTIAL_VERSE_SUFFIX, 'b'],
+            [TokenType::RANGE_SEPARATOR, '-'],
+            [TokenType::VERSE_NUMBER, '20'],
+        ], $result);
+    }
+
+    /**
+     * Issue #46: dual Psalm numbering with parenthesized alternate chapter.
+     */
+    public function testIssue46DualPsalmNumbering(): void
+    {
+        $result = $this->typeValues('Psalm51(50),1-6');
+        $this->assertSame([
+            [TokenType::BOOK_NAME, 'Psalm'],
+            [TokenType::CHAPTER_NUMBER, '51'],
+            [TokenType::OPEN_PARENTHESIS, '('],
+            [TokenType::ALTERNATE_CHAPTER, '50'],
+            [TokenType::CLOSE_PARENTHESIS, ')'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '1'],
+            [TokenType::RANGE_SEPARATOR, '-'],
+            [TokenType::VERSE_NUMBER, '6'],
+        ], $result);
+    }
+
+    /**
+     * Issue #47: second query inherits book, after normalization becomes "9,1-3".
+     */
+    public function testIssue47BooklessQueryTokenizes(): void
+    {
+        $result = $this->typeValues('9,1-3');
+        $this->assertSame([
+            [TokenType::CHAPTER_NUMBER, '9'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '1'],
+            [TokenType::RANGE_SEPARATOR, '-'],
+            [TokenType::VERSE_NUMBER, '3'],
+        ], $result);
+    }
+}

--- a/tests/Unit/Pipeline/Tokenizer/ReferenceTokenizerTest.php
+++ b/tests/Unit/Pipeline/Tokenizer/ReferenceTokenizerTest.php
@@ -1,0 +1,277 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BibleGet\Tests\Unit\Pipeline\Tokenizer;
+
+use BibleGet\Api\Pipeline\Tokenizer\ReferenceTokenizer;
+use BibleGet\Api\Pipeline\Tokenizer\Token;
+use BibleGet\Api\Pipeline\Tokenizer\TokenType;
+use PHPUnit\Framework\TestCase;
+
+final class ReferenceTokenizerTest extends TestCase
+{
+    private ReferenceTokenizer $tokenizer;
+
+    protected function setUp(): void
+    {
+        $this->tokenizer = new ReferenceTokenizer();
+    }
+
+    /**
+     * Helper: extract [type, value] pairs (excluding EOF).
+     *
+     * @return array<int, array{TokenType, string}>
+     */
+    private function typeValues(string $input): array
+    {
+        $tokens = $this->tokenizer->tokenize($input);
+        return array_values(array_map(
+            fn(Token $t) => [$t->type, $t->value],
+            array_filter($tokens, fn(Token $t) => $t->type !== TokenType::EOF)
+        ));
+    }
+
+    // ── Basic book + chapter ──────────────────────────────────────
+
+    public function testBookAndChapter(): void
+    {
+        $result = $this->typeValues('Genesis1');
+        $this->assertSame([
+            [TokenType::BOOK_NAME, 'Genesis'],
+            [TokenType::CHAPTER_NUMBER, '1'],
+        ], $result);
+    }
+
+    public function testBookChapterVerse(): void
+    {
+        $result = $this->typeValues('Genesis1,5');
+        $this->assertSame([
+            [TokenType::BOOK_NAME, 'Genesis'],
+            [TokenType::CHAPTER_NUMBER, '1'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '5'],
+        ], $result);
+    }
+
+    // ── Verse range (same chapter) ────────────────────────────────
+
+    public function testVerseRange(): void
+    {
+        $result = $this->typeValues('Genesis1,5-10');
+        $this->assertSame([
+            [TokenType::BOOK_NAME, 'Genesis'],
+            [TokenType::CHAPTER_NUMBER, '1'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '5'],
+            [TokenType::RANGE_SEPARATOR, '-'],
+            [TokenType::VERSE_NUMBER, '10'],
+        ], $result);
+    }
+
+    // ── Chapter range ─────────────────────────────────────────────
+
+    public function testChapterRange(): void
+    {
+        $result = $this->typeValues('Genesis1-3');
+        $this->assertSame([
+            [TokenType::BOOK_NAME, 'Genesis'],
+            [TokenType::CHAPTER_NUMBER, '1'],
+            [TokenType::RANGE_SEPARATOR, '-'],
+            [TokenType::CHAPTER_NUMBER, '3'],
+        ], $result);
+    }
+
+    // ── Cross-chapter verse range ─────────────────────────────────
+
+    public function testCrossChapterRange(): void
+    {
+        $result = $this->typeValues('Genesis1,5-2,3');
+        $this->assertSame([
+            [TokenType::BOOK_NAME, 'Genesis'],
+            [TokenType::CHAPTER_NUMBER, '1'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '5'],
+            [TokenType::RANGE_SEPARATOR, '-'],
+            [TokenType::CHAPTER_NUMBER, '2'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '3'],
+        ], $result);
+    }
+
+    // ── Non-consecutive verses ────────────────────────────────────
+
+    public function testNonConsecutiveVerses(): void
+    {
+        $result = $this->typeValues('Genesis1,1-3.5.10');
+        $this->assertSame([
+            [TokenType::BOOK_NAME, 'Genesis'],
+            [TokenType::CHAPTER_NUMBER, '1'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '1'],
+            [TokenType::RANGE_SEPARATOR, '-'],
+            [TokenType::VERSE_NUMBER, '3'],
+            [TokenType::EXPLICIT_VERSE_SEPARATOR, '.'],
+            [TokenType::VERSE_NUMBER, '5'],
+            [TokenType::EXPLICIT_VERSE_SEPARATOR, '.'],
+            [TokenType::VERSE_NUMBER, '10'],
+        ], $result);
+    }
+
+    // ── Numbered book ─────────────────────────────────────────────
+
+    public function testNumberedBook(): void
+    {
+        $result = $this->typeValues('1John3,16');
+        $this->assertSame([
+            [TokenType::BOOK_NUMERIC_PREFIX, '1'],
+            [TokenType::BOOK_NAME, 'John'],
+            [TokenType::CHAPTER_NUMBER, '3'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '16'],
+        ], $result);
+    }
+
+    // ── Partial verse suffix ──────────────────────────────────────
+
+    public function testPartialVerseSuffix(): void
+    {
+        $result = $this->typeValues('Genesis2,4a');
+        $this->assertSame([
+            [TokenType::BOOK_NAME, 'Genesis'],
+            [TokenType::CHAPTER_NUMBER, '2'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '4'],
+            [TokenType::PARTIAL_VERSE_SUFFIX, 'a'],
+        ], $result);
+    }
+
+    public function testPartialVerseSuffixInRange(): void
+    {
+        $result = $this->typeValues('Genesis2,4a-7b');
+        $this->assertSame([
+            [TokenType::BOOK_NAME, 'Genesis'],
+            [TokenType::CHAPTER_NUMBER, '2'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '4'],
+            [TokenType::PARTIAL_VERSE_SUFFIX, 'a'],
+            [TokenType::RANGE_SEPARATOR, '-'],
+            [TokenType::VERSE_NUMBER, '7'],
+            [TokenType::PARTIAL_VERSE_SUFFIX, 'b'],
+        ], $result);
+    }
+
+    // ── Dual Psalm numbering ──────────────────────────────────────
+
+    public function testDualPsalmNumbering(): void
+    {
+        $result = $this->typeValues('Psalm51(50),1');
+        $this->assertSame([
+            [TokenType::BOOK_NAME, 'Psalm'],
+            [TokenType::CHAPTER_NUMBER, '51'],
+            [TokenType::OPEN_PARENTHESIS, '('],
+            [TokenType::ALTERNATE_CHAPTER, '50'],
+            [TokenType::CLOSE_PARENTHESIS, ')'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '1'],
+        ], $result);
+    }
+
+    // ── EOF is always present ─────────────────────────────────────
+
+    public function testEofAlwaysPresent(): void
+    {
+        $tokens = $this->tokenizer->tokenize('Genesis1');
+        $last   = $tokens[count($tokens) - 1];
+        $this->assertSame(TokenType::EOF, $last->type);
+    }
+
+    public function testEmptyInputProducesOnlyEof(): void
+    {
+        $tokens = $this->tokenizer->tokenize('');
+        $this->assertCount(1, $tokens);
+        $this->assertSame(TokenType::EOF, $tokens[0]->type);
+    }
+
+    // ── Position tracking ─────────────────────────────────────────
+
+    public function testPositionsAreCorrect(): void
+    {
+        $tokens = $this->tokenizer->tokenize('Genesis1,5');
+        // "Genesis" starts at 0, "1" at 7, "," at 8, "5" at 9
+        $this->assertSame(0, $tokens[0]->position); // BOOK_NAME
+        $this->assertSame(7, $tokens[1]->position); // CHAPTER_NUMBER
+        $this->assertSame(8, $tokens[2]->position); // CHAPTER_VERSE_SEPARATOR
+        $this->assertSame(9, $tokens[3]->position); // VERSE_NUMBER
+    }
+
+    // ── Unicode book names ────────────────────────────────────────
+
+    public function testUnicodeBookName(): void
+    {
+        // Italian: "Gv" for Giovanni (John)
+        $result = $this->typeValues('Gv3,16');
+        $this->assertSame([
+            [TokenType::BOOK_NAME, 'Gv'],
+            [TokenType::CHAPTER_NUMBER, '3'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '16'],
+        ], $result);
+    }
+
+    // ── Multi-digit chapters and verses ───────────────────────────
+
+    public function testMultiDigitChapterAndVerse(): void
+    {
+        $result = $this->typeValues('Psalms119,176');
+        $this->assertSame([
+            [TokenType::BOOK_NAME, 'Psalms'],
+            [TokenType::CHAPTER_NUMBER, '119'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '176'],
+        ], $result);
+    }
+
+    // ── Whole chapter (no verse) ──────────────────────────────────
+
+    public function testWholeChapter(): void
+    {
+        $result = $this->typeValues('Genesis1');
+        $this->assertSame([
+            [TokenType::BOOK_NAME, 'Genesis'],
+            [TokenType::CHAPTER_NUMBER, '1'],
+        ], $result);
+    }
+
+    // ── Numbered book prefix 2, 3, 4 ─────────────────────────────
+
+    public function testSecondBook(): void
+    {
+        $result = $this->typeValues('2Kings5,14');
+        $this->assertSame([
+            [TokenType::BOOK_NUMERIC_PREFIX, '2'],
+            [TokenType::BOOK_NAME, 'Kings'],
+            [TokenType::CHAPTER_NUMBER, '5'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '14'],
+        ], $result);
+    }
+
+    // ── Reusability: tokenizer can be called multiple times ──────
+
+    public function testTokenizerIsReusable(): void
+    {
+        $t1 = $this->typeValues('Genesis1');
+        $t2 = $this->typeValues('John3,16');
+        $this->assertSame([
+            [TokenType::BOOK_NAME, 'Genesis'],
+            [TokenType::CHAPTER_NUMBER, '1'],
+        ], $t1);
+        $this->assertSame([
+            [TokenType::BOOK_NAME, 'John'],
+            [TokenType::CHAPTER_NUMBER, '3'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '16'],
+        ], $t2);
+    }
+}

--- a/tests/Unit/Pipeline/Tokenizer/ReferenceTokenizerTest.php
+++ b/tests/Unit/Pipeline/Tokenizer/ReferenceTokenizerTest.php
@@ -257,6 +257,196 @@ final class ReferenceTokenizerTest extends TestCase
         ], $result);
     }
 
+    // ── Non-Latin script book names ─────────────────────────────
+
+    public function testChineseBookName(): void
+    {
+        // 創世記 = Genesis in Chinese
+        $result = $this->typeValues('創世記1,5');
+        $this->assertSame([
+            [TokenType::BOOK_NAME, '創世記'],
+            [TokenType::CHAPTER_NUMBER, '1'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '5'],
+        ], $result);
+    }
+
+    public function testChineseBookNameWithRange(): void
+    {
+        $result = $this->typeValues('創世記1,5-10');
+        $this->assertSame([
+            [TokenType::BOOK_NAME, '創世記'],
+            [TokenType::CHAPTER_NUMBER, '1'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '5'],
+            [TokenType::RANGE_SEPARATOR, '-'],
+            [TokenType::VERSE_NUMBER, '10'],
+        ], $result);
+    }
+
+    public function testArabicBookName(): void
+    {
+        // يوحنا = John in Arabic (RTL script)
+        $result = $this->typeValues('يوحنا3,16');
+        $this->assertSame([
+            [TokenType::BOOK_NAME, 'يوحنا'],
+            [TokenType::CHAPTER_NUMBER, '3'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '16'],
+        ], $result);
+    }
+
+    public function testArabicBookNameWithRange(): void
+    {
+        $result = $this->typeValues('يوحنا3,16-18');
+        $this->assertSame([
+            [TokenType::BOOK_NAME, 'يوحنا'],
+            [TokenType::CHAPTER_NUMBER, '3'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '16'],
+            [TokenType::RANGE_SEPARATOR, '-'],
+            [TokenType::VERSE_NUMBER, '18'],
+        ], $result);
+    }
+
+    public function testKoreanBookName(): void
+    {
+        // 창세기 = Genesis in Korean
+        $result = $this->typeValues('창세기1,1');
+        $this->assertSame([
+            [TokenType::BOOK_NAME, '창세기'],
+            [TokenType::CHAPTER_NUMBER, '1'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '1'],
+        ], $result);
+    }
+
+    public function testJapaneseBookName(): void
+    {
+        // ヨハネ = John in Japanese (Katakana)
+        $result = $this->typeValues('ヨハネ3,16');
+        $this->assertSame([
+            [TokenType::BOOK_NAME, 'ヨハネ'],
+            [TokenType::CHAPTER_NUMBER, '3'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '16'],
+        ], $result);
+    }
+
+    public function testThaiBookName(): void
+    {
+        // ปฐมกาล = Genesis in Thai
+        $result = $this->typeValues('ปฐมกาล1,1');
+        $this->assertSame([
+            [TokenType::BOOK_NAME, 'ปฐมกาล'],
+            [TokenType::CHAPTER_NUMBER, '1'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '1'],
+        ], $result);
+    }
+
+    public function testAmharicBookName(): void
+    {
+        // ዘፍጥረት = Genesis in Amharic (Ge'ez script)
+        $result = $this->typeValues('ዘፍጥረት1,1');
+        $this->assertSame([
+            [TokenType::BOOK_NAME, 'ዘፍጥረት'],
+            [TokenType::CHAPTER_NUMBER, '1'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '1'],
+        ], $result);
+    }
+
+    public function testRussianBookName(): void
+    {
+        // Бытие = Genesis in Russian (Cyrillic)
+        $result = $this->typeValues('Бытие1,1');
+        $this->assertSame([
+            [TokenType::BOOK_NAME, 'Бытие'],
+            [TokenType::CHAPTER_NUMBER, '1'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '1'],
+        ], $result);
+    }
+
+    public function testGreekBookName(): void
+    {
+        // Γένεσις = Genesis in Greek
+        $result = $this->typeValues('Γένεσις1,1');
+        $this->assertSame([
+            [TokenType::BOOK_NAME, 'Γένεσις'],
+            [TokenType::CHAPTER_NUMBER, '1'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '1'],
+        ], $result);
+    }
+
+    public function testTamilBookName(): void
+    {
+        // ஆதியாகமம் = Genesis in Tamil
+        $result = $this->typeValues('ஆதியாகமம்1,1');
+        $this->assertSame([
+            [TokenType::BOOK_NAME, 'ஆதியாகமம்'],
+            [TokenType::CHAPTER_NUMBER, '1'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '1'],
+        ], $result);
+    }
+
+    public function testUrduBookName(): void
+    {
+        // پیدائش = Genesis in Urdu (RTL, Nastaliq script)
+        $result = $this->typeValues('پیدائش1,1');
+        $this->assertSame([
+            [TokenType::BOOK_NAME, 'پیدائش'],
+            [TokenType::CHAPTER_NUMBER, '1'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '1'],
+        ], $result);
+    }
+
+    public function testNonLatinBookNameWithCrossChapterRange(): void
+    {
+        // Complex reference with CJK book name
+        $result = $this->typeValues('創世記1,5-2,3');
+        $this->assertSame([
+            [TokenType::BOOK_NAME, '創世記'],
+            [TokenType::CHAPTER_NUMBER, '1'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '5'],
+            [TokenType::RANGE_SEPARATOR, '-'],
+            [TokenType::CHAPTER_NUMBER, '2'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '3'],
+        ], $result);
+    }
+
+    public function testNonLatinBookNameWithNonConsecutiveVerses(): void
+    {
+        // Arabic book name with non-consecutive verses
+        $result = $this->typeValues('يوحنا3,16.18.20');
+        $this->assertSame([
+            [TokenType::BOOK_NAME, 'يوحنا'],
+            [TokenType::CHAPTER_NUMBER, '3'],
+            [TokenType::CHAPTER_VERSE_SEPARATOR, ','],
+            [TokenType::VERSE_NUMBER, '16'],
+            [TokenType::EXPLICIT_VERSE_SEPARATOR, '.'],
+            [TokenType::VERSE_NUMBER, '18'],
+            [TokenType::EXPLICIT_VERSE_SEPARATOR, '.'],
+            [TokenType::VERSE_NUMBER, '20'],
+        ], $result);
+    }
+
+    public function testNonLatinPositionsAreCorrectMultibyte(): void
+    {
+        // 創世記 is 9 bytes in UTF-8 (3 chars × 3 bytes each)
+        $tokens = $this->tokenizer->tokenize('創世記1,5');
+        $this->assertSame(0, $tokens[0]->position);  // BOOK_NAME at byte 0
+        $this->assertSame(9, $tokens[1]->position);  // CHAPTER_NUMBER at byte 9
+        $this->assertSame(10, $tokens[2]->position); // CHAPTER_VERSE_SEPARATOR at byte 10
+        $this->assertSame(11, $tokens[3]->position); // VERSE_NUMBER at byte 11
+    }
+
     // ── Reusability: tokenizer can be called multiple times ──────
 
     public function testTokenizerIsReusable(): void

--- a/tests/Unit/Pipeline/Transform/EstherRemapperTest.php
+++ b/tests/Unit/Pipeline/Transform/EstherRemapperTest.php
@@ -7,16 +7,16 @@ namespace BibleGet\Tests\Unit\Pipeline\Transform;
 use BibleGet\Api\Pipeline\Ast\BibleQuery;
 use BibleGet\Api\Pipeline\Ast\VerseRange;
 use BibleGet\Api\Pipeline\Ast\VerseRef;
-use BibleGet\Api\Pipeline\Transform\PsalmRemapper;
+use BibleGet\Api\Pipeline\Transform\EstherRemapper;
 use PHPUnit\Framework\TestCase;
 
-final class PsalmRemapperTest extends TestCase
+final class EstherRemapperTest extends TestCase
 {
-    private PsalmRemapper $remapper;
+    private EstherRemapper $remapper;
 
     protected function setUp(): void
     {
-        $this->remapper = new PsalmRemapper(['VGCL', 'DRB', 'CEI2008']);
+        $this->remapper = new EstherRemapper(['VGCL', 'DRB', 'CEI2008']);
     }
 
     private function assertVerseRef(BibleQuery $result, int $index, int $chapter, ?int $verse): void
@@ -38,9 +38,9 @@ final class PsalmRemapperTest extends TestCase
         $this->assertSame([''], $pos);
     }
 
-    // ── No remapping for non-Psalms ──────────────────────────────
+    // ── No remapping for non-Esther books ──────────────────────
 
-    public function testNoRemapForNonPsalms(): void
+    public function testNoRemapForNonEsther(): void
     {
         $query          = new BibleQuery(1, [new VerseRef(1, 10, null, 5)]);
         [$result, $pos] = $this->remapper->remap($query, 'VGCL', '');
@@ -48,9 +48,9 @@ final class PsalmRemapperTest extends TestCase
         $this->assertVerseRef($result, 0, 10, 5);
     }
 
-    // ── Mapping: Psalm 10:4-13 → chapter 10, verse 3 ────────────
+    // ── Mapping: Esther 10:4-13 → chapter 10, verse 3 ─────────
 
-    public function testRemapPsalm10Verse5InVgcl(): void
+    public function testRemapEsther10Verse5InVgcl(): void
     {
         $query          = new BibleQuery(19, [new VerseRef(19, 10, null, 5)]);
         [$result, $pos] = $this->remapper->remap($query, 'VGCL', '');
@@ -59,9 +59,9 @@ final class PsalmRemapperTest extends TestCase
         $this->assertStringContainsString('GREEK', $pos[0]);
     }
 
-    // ── Mapping: Psalm 13:1-7 → chapter 3, verse 13 ─────────────
+    // ── Mapping: Esther 13:1-7 → chapter 3, verse 13 ──────────
 
-    public function testRemapPsalm13Verse3InDrb(): void
+    public function testRemapEsther13Verse3InDrb(): void
     {
         $query          = new BibleQuery(19, [new VerseRef(19, 13, null, 3)]);
         [$result, $pos] = $this->remapper->remap($query, 'DRB', '');
@@ -69,9 +69,9 @@ final class PsalmRemapperTest extends TestCase
         $this->assertVerseRef($result, 0, 3, 13);
     }
 
-    // ── Mapping: Psalm 16 (whole chapter, null verse) → 8, 12 ───
+    // ── Mapping: Esther 16 (whole chapter, null verse) → 8, 12 ─
 
-    public function testRemapPsalm16WholeChapter(): void
+    public function testRemapEsther16WholeChapter(): void
     {
         $query          = new BibleQuery(19, [new VerseRef(19, 16)]);
         [$result, $pos] = $this->remapper->remap($query, 'VGCL', '');
@@ -79,17 +79,17 @@ final class PsalmRemapperTest extends TestCase
         $this->assertVerseRef($result, 0, 8, 12);
     }
 
-    // ── No mapping for unmapped Psalm ────────────────────────────
+    // ── No mapping for unmapped Esther chapter ─────────────────
 
-    public function testNoRemapForUnmappedPsalm(): void
+    public function testNoRemapForUnmappedEsther(): void
     {
-        $query          = new BibleQuery(19, [new VerseRef(19, 50, null, 1)]);
+        $query          = new BibleQuery(19, [new VerseRef(19, 5, null, 1)]);
         [$result, $pos] = $this->remapper->remap($query, 'VGCL', '');
 
-        $this->assertVerseRef($result, 0, 50, 1);
+        $this->assertVerseRef($result, 0, 5, 1);
     }
 
-    // ── Range remapping ──────────────────────────────────────────
+    // ── Range remapping ────────────────────────────────────────
 
     public function testRemapRange(): void
     {
@@ -106,24 +106,24 @@ final class PsalmRemapperTest extends TestCase
         $this->assertSame(3, $seg->to->verse);
     }
 
-    // ── Default prefer origin passed through when no remapping ───
+    // ── Default prefer origin passed through when no remapping ──
 
     public function testDefaultPreferOriginPassedThrough(): void
     {
-        $query          = new BibleQuery(19, [new VerseRef(19, 50, null, 1)]);
+        $query          = new BibleQuery(19, [new VerseRef(19, 5, null, 1)]);
         [$result, $pos] = $this->remapper->remap($query, 'VGCL', " AND verseorigin = 'HEBREW'");
 
         $this->assertSame([" AND verseorigin = 'HEBREW'"], $pos);
     }
 
-    // ── Per-segment origins ──────────────────────────────────────
+    // ── Per-segment origins ────────────────────────────────────
 
     public function testPerSegmentOrigins(): void
     {
-        // Two segments: one mapped (Psalm 10:5), one unmapped (Psalm 50:1)
+        // Two segments: one mapped (Esther 10:5), one unmapped (Esther 5:1)
         $query          = new BibleQuery(19, [
             new VerseRef(19, 10, null, 5),
-            new VerseRef(19, 50, null, 1),
+            new VerseRef(19, 5, null, 1),
         ]);
         [$result, $pos] = $this->remapper->remap($query, 'VGCL', '');
 

--- a/tests/Unit/Pipeline/Transform/PsalmChapterSwapperTest.php
+++ b/tests/Unit/Pipeline/Transform/PsalmChapterSwapperTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BibleGet\Tests\Unit\Pipeline\Transform;
+
+use BibleGet\Api\Pipeline\Ast\BibleQuery;
+use BibleGet\Api\Pipeline\Ast\VerseRange;
+use BibleGet\Api\Pipeline\Ast\VerseRef;
+use BibleGet\Api\Pipeline\Transform\PsalmChapterSwapper;
+use PHPUnit\Framework\TestCase;
+
+final class PsalmChapterSwapperTest extends TestCase
+{
+    private PsalmChapterSwapper $swapper;
+
+    protected function setUp(): void
+    {
+        $this->swapper = new PsalmChapterSwapper();
+    }
+
+    // ── No swap for non-Psalm book ─────────────────────────────
+
+    public function testNoSwapForNonPsalm(): void
+    {
+        $query  = new BibleQuery(1, [new VerseRef(1, 51, 50, 1)]);
+        $result = $this->swapper->swap($query, 'VGCL');
+
+        self::assertSame(51, $result->segments[0]->chapter);
+        self::assertSame(50, $result->segments[0]->alternateChapter);
+    }
+
+    // ── No swap for non-Vulgate version ────────────────────────
+
+    public function testNoSwapForNonVulgateVersion(): void
+    {
+        $query  = new BibleQuery(23, [new VerseRef(23, 51, 50, 1)]);
+        $result = $this->swapper->swap($query, 'TEST1');
+
+        self::assertSame(51, $result->segments[0]->chapter);
+        self::assertSame(50, $result->segments[0]->alternateChapter);
+    }
+
+    // ── Swap for VGCL ──────────────────────────────────────────
+
+    public function testSwapForVgcl(): void
+    {
+        $query  = new BibleQuery(23, [new VerseRef(23, 51, 50, 1)]);
+        $result = $this->swapper->swap($query, 'VGCL');
+
+        self::assertSame(50, $result->segments[0]->chapter);
+        self::assertSame(51, $result->segments[0]->alternateChapter);
+        self::assertSame(1, $result->segments[0]->verse);
+    }
+
+    // ── Swap for DRB ───────────────────────────────────────────
+
+    public function testSwapForDrb(): void
+    {
+        $query  = new BibleQuery(23, [new VerseRef(23, 51, 50, 1)]);
+        $result = $this->swapper->swap($query, 'DRB');
+
+        self::assertSame(50, $result->segments[0]->chapter);
+        self::assertSame(51, $result->segments[0]->alternateChapter);
+    }
+
+    // ── No swap when alternateChapter is null ───────────────────
+
+    public function testNoSwapWithoutAlternate(): void
+    {
+        $query  = new BibleQuery(23, [new VerseRef(23, 51, null, 1)]);
+        $result = $this->swapper->swap($query, 'VGCL');
+
+        self::assertSame(51, $result->segments[0]->chapter);
+        self::assertNull($result->segments[0]->alternateChapter);
+    }
+
+    // ── Swap in VerseRange ─────────────────────────────────────
+
+    public function testSwapRange(): void
+    {
+        $from   = new VerseRef(23, 51, 50, 1);
+        $to     = new VerseRef(23, 51, 50, 5);
+        $query  = new BibleQuery(23, [new VerseRange($from, $to)]);
+        $result = $this->swapper->swap($query, 'VGCL');
+
+        $seg = $result->segments[0];
+        self::assertInstanceOf(VerseRange::class, $seg);
+        self::assertSame(50, $seg->from->chapter);
+        self::assertSame(51, $seg->from->alternateChapter);
+        self::assertSame(50, $seg->to->chapter);
+        self::assertSame(51, $seg->to->alternateChapter);
+    }
+
+    // ── Mixed segments: only swap those with alternateChapter ──
+
+    public function testMixedSegments(): void
+    {
+        $query  = new BibleQuery(23, [
+            new VerseRef(23, 51, 50, 1),
+            new VerseRef(23, 100, null, 1),
+        ]);
+        $result = $this->swapper->swap($query, 'VGCL');
+
+        // First segment swapped
+        self::assertSame(50, $result->segments[0]->chapter);
+        // Second segment unchanged
+        self::assertSame(100, $result->segments[1]->chapter);
+        self::assertNull($result->segments[1]->alternateChapter);
+    }
+
+    // ── Preserves partial verse suffix ─────────────────────────
+
+    public function testPreservesPartialSuffix(): void
+    {
+        $query  = new BibleQuery(23, [new VerseRef(23, 51, 50, 3, 'a')]);
+        $result = $this->swapper->swap($query, 'VGCL');
+
+        self::assertSame(50, $result->segments[0]->chapter);
+        self::assertSame(3, $result->segments[0]->verse);
+        self::assertSame('a', $result->segments[0]->partialSuffix);
+    }
+}

--- a/tests/Unit/Pipeline/Transform/PsalmRemapperTest.php
+++ b/tests/Unit/Pipeline/Transform/PsalmRemapperTest.php
@@ -31,19 +31,19 @@ final class PsalmRemapperTest extends TestCase
 
     public function testNoRemapForNonVgclDrb(): void
     {
-        $query         = new BibleQuery(19, [new VerseRef(19, 10, null, 5)]);
-        [$result, $po] = $this->remapper->remap($query, 'CEI2008', '');
+        $query          = new BibleQuery(19, [new VerseRef(19, 10, null, 5)]);
+        [$result, $pos] = $this->remapper->remap($query, 'CEI2008', '');
 
         $this->assertVerseRef($result, 0, 10, 5);
-        $this->assertSame('', $po);
+        $this->assertSame([''], $pos);
     }
 
     // ── No remapping for non-Psalms ──────────────────────────────
 
     public function testNoRemapForNonPsalms(): void
     {
-        $query         = new BibleQuery(1, [new VerseRef(1, 10, null, 5)]);
-        [$result, $po] = $this->remapper->remap($query, 'VGCL', '');
+        $query          = new BibleQuery(1, [new VerseRef(1, 10, null, 5)]);
+        [$result, $pos] = $this->remapper->remap($query, 'VGCL', '');
 
         $this->assertVerseRef($result, 0, 10, 5);
     }
@@ -52,19 +52,19 @@ final class PsalmRemapperTest extends TestCase
 
     public function testRemapPsalm10Verse5InVgcl(): void
     {
-        $query         = new BibleQuery(19, [new VerseRef(19, 10, null, 5)]);
-        [$result, $po] = $this->remapper->remap($query, 'VGCL', '');
+        $query          = new BibleQuery(19, [new VerseRef(19, 10, null, 5)]);
+        [$result, $pos] = $this->remapper->remap($query, 'VGCL', '');
 
         $this->assertVerseRef($result, 0, 10, 3);
-        $this->assertStringContainsString('GREEK', $po);
+        $this->assertStringContainsString('GREEK', $pos[0]);
     }
 
     // ── Mapping: Psalm 13:1-7 → chapter 3, verse 13 ─────────────
 
     public function testRemapPsalm13Verse3InDrb(): void
     {
-        $query         = new BibleQuery(19, [new VerseRef(19, 13, null, 3)]);
-        [$result, $po] = $this->remapper->remap($query, 'DRB', '');
+        $query          = new BibleQuery(19, [new VerseRef(19, 13, null, 3)]);
+        [$result, $pos] = $this->remapper->remap($query, 'DRB', '');
 
         $this->assertVerseRef($result, 0, 3, 13);
     }
@@ -73,8 +73,8 @@ final class PsalmRemapperTest extends TestCase
 
     public function testRemapPsalm16WholeChapter(): void
     {
-        $query         = new BibleQuery(19, [new VerseRef(19, 16)]);
-        [$result, $po] = $this->remapper->remap($query, 'VGCL', '');
+        $query          = new BibleQuery(19, [new VerseRef(19, 16)]);
+        [$result, $pos] = $this->remapper->remap($query, 'VGCL', '');
 
         $this->assertVerseRef($result, 0, 8, 12);
     }
@@ -83,8 +83,8 @@ final class PsalmRemapperTest extends TestCase
 
     public function testNoRemapForUnmappedPsalm(): void
     {
-        $query         = new BibleQuery(19, [new VerseRef(19, 50, null, 1)]);
-        [$result, $po] = $this->remapper->remap($query, 'VGCL', '');
+        $query          = new BibleQuery(19, [new VerseRef(19, 50, null, 1)]);
+        [$result, $pos] = $this->remapper->remap($query, 'VGCL', '');
 
         $this->assertVerseRef($result, 0, 50, 1);
     }
@@ -93,10 +93,10 @@ final class PsalmRemapperTest extends TestCase
 
     public function testRemapRange(): void
     {
-        $from          = new VerseRef(19, 10, null, 4);
-        $to            = new VerseRef(19, 10, null, 10);
-        $query         = new BibleQuery(19, [new VerseRange($from, $to)]);
-        [$result, $po] = $this->remapper->remap($query, 'VGCL', '');
+        $from           = new VerseRef(19, 10, null, 4);
+        $to             = new VerseRef(19, 10, null, 10);
+        $query          = new BibleQuery(19, [new VerseRange($from, $to)]);
+        [$result, $pos] = $this->remapper->remap($query, 'VGCL', '');
 
         $seg = $result->segments[0];
         $this->assertInstanceOf(VerseRange::class, $seg);
@@ -110,9 +110,25 @@ final class PsalmRemapperTest extends TestCase
 
     public function testDefaultPreferOriginPassedThrough(): void
     {
-        $query         = new BibleQuery(19, [new VerseRef(19, 50, null, 1)]);
-        [$result, $po] = $this->remapper->remap($query, 'VGCL', " AND verseorigin = 'HEBREW'");
+        $query          = new BibleQuery(19, [new VerseRef(19, 50, null, 1)]);
+        [$result, $pos] = $this->remapper->remap($query, 'VGCL', " AND verseorigin = 'HEBREW'");
 
-        $this->assertSame(" AND verseorigin = 'HEBREW'", $po);
+        $this->assertSame([" AND verseorigin = 'HEBREW'"], $pos);
+    }
+
+    // ── Per-segment origins ──────────────────────────────────────
+
+    public function testPerSegmentOrigins(): void
+    {
+        // Two segments: one mapped (Psalm 10:5), one unmapped (Psalm 50:1)
+        $query          = new BibleQuery(19, [
+            new VerseRef(19, 10, null, 5),
+            new VerseRef(19, 50, null, 1),
+        ]);
+        [$result, $pos] = $this->remapper->remap($query, 'VGCL', '');
+
+        $this->assertCount(2, $pos);
+        $this->assertStringContainsString('GREEK', $pos[0]);
+        $this->assertSame('', $pos[1]);
     }
 }

--- a/tests/Unit/Pipeline/Transform/PsalmRemapperTest.php
+++ b/tests/Unit/Pipeline/Transform/PsalmRemapperTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BibleGet\Tests\Unit\Pipeline\Transform;
+
+use BibleGet\Api\Pipeline\Ast\BibleQuery;
+use BibleGet\Api\Pipeline\Ast\VerseRange;
+use BibleGet\Api\Pipeline\Ast\VerseRef;
+use BibleGet\Api\Pipeline\Transform\PsalmRemapper;
+use PHPUnit\Framework\TestCase;
+
+final class PsalmRemapperTest extends TestCase
+{
+    private PsalmRemapper $remapper;
+
+    protected function setUp(): void
+    {
+        $this->remapper = new PsalmRemapper(['VGCL', 'DRB', 'CEI2008']);
+    }
+
+    private function assertVerseRef(BibleQuery $result, int $index, int $chapter, ?int $verse): void
+    {
+        $seg = $result->segments[$index];
+        $this->assertInstanceOf(VerseRef::class, $seg);
+        $this->assertSame($chapter, $seg->chapter);
+        $this->assertSame($verse, $seg->verse);
+    }
+
+    // ── No remapping for non-VGCL/DRB versions ──────────────────
+
+    public function testNoRemapForNonVgclDrb(): void
+    {
+        $query         = new BibleQuery(19, [new VerseRef(19, 10, null, 5)]);
+        [$result, $po] = $this->remapper->remap($query, 'CEI2008', '');
+
+        $this->assertVerseRef($result, 0, 10, 5);
+        $this->assertSame('', $po);
+    }
+
+    // ── No remapping for non-Psalms ──────────────────────────────
+
+    public function testNoRemapForNonPsalms(): void
+    {
+        $query         = new BibleQuery(1, [new VerseRef(1, 10, null, 5)]);
+        [$result, $po] = $this->remapper->remap($query, 'VGCL', '');
+
+        $this->assertVerseRef($result, 0, 10, 5);
+    }
+
+    // ── Mapping: Psalm 10:4-13 → chapter 10, verse 3 ────────────
+
+    public function testRemapPsalm10Verse5InVgcl(): void
+    {
+        $query         = new BibleQuery(19, [new VerseRef(19, 10, null, 5)]);
+        [$result, $po] = $this->remapper->remap($query, 'VGCL', '');
+
+        $this->assertVerseRef($result, 0, 10, 3);
+        $this->assertStringContainsString('GREEK', $po);
+    }
+
+    // ── Mapping: Psalm 13:1-7 → chapter 3, verse 13 ─────────────
+
+    public function testRemapPsalm13Verse3InDrb(): void
+    {
+        $query         = new BibleQuery(19, [new VerseRef(19, 13, null, 3)]);
+        [$result, $po] = $this->remapper->remap($query, 'DRB', '');
+
+        $this->assertVerseRef($result, 0, 3, 13);
+    }
+
+    // ── Mapping: Psalm 16 (whole chapter, null verse) → 8, 12 ───
+
+    public function testRemapPsalm16WholeChapter(): void
+    {
+        $query         = new BibleQuery(19, [new VerseRef(19, 16)]);
+        [$result, $po] = $this->remapper->remap($query, 'VGCL', '');
+
+        $this->assertVerseRef($result, 0, 8, 12);
+    }
+
+    // ── No mapping for unmapped Psalm ────────────────────────────
+
+    public function testNoRemapForUnmappedPsalm(): void
+    {
+        $query         = new BibleQuery(19, [new VerseRef(19, 50, null, 1)]);
+        [$result, $po] = $this->remapper->remap($query, 'VGCL', '');
+
+        $this->assertVerseRef($result, 0, 50, 1);
+    }
+
+    // ── Range remapping ──────────────────────────────────────────
+
+    public function testRemapRange(): void
+    {
+        $from          = new VerseRef(19, 10, null, 4);
+        $to            = new VerseRef(19, 10, null, 10);
+        $query         = new BibleQuery(19, [new VerseRange($from, $to)]);
+        [$result, $po] = $this->remapper->remap($query, 'VGCL', '');
+
+        $seg = $result->segments[0];
+        $this->assertInstanceOf(VerseRange::class, $seg);
+        $this->assertSame(10, $seg->from->chapter);
+        $this->assertSame(3, $seg->from->verse);
+        $this->assertSame(10, $seg->to->chapter);
+        $this->assertSame(3, $seg->to->verse);
+    }
+
+    // ── Default prefer origin passed through when no remapping ───
+
+    public function testDefaultPreferOriginPassedThrough(): void
+    {
+        $query         = new BibleQuery(19, [new VerseRef(19, 50, null, 1)]);
+        [$result, $po] = $this->remapper->remap($query, 'VGCL', " AND verseorigin = 'HEBREW'");
+
+        $this->assertSame(" AND verseorigin = 'HEBREW'", $po);
+    }
+}

--- a/tests/Unit/Pipeline/Validator/AstValidatorTest.php
+++ b/tests/Unit/Pipeline/Validator/AstValidatorTest.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BibleGet\Tests\Unit\Pipeline\Validator;
+
+use BibleGet\Api\Pipeline\Ast\BibleQuery;
+use BibleGet\Api\Pipeline\Ast\VerseRange;
+use BibleGet\Api\Pipeline\Ast\VerseRef;
+use BibleGet\Api\Pipeline\Parser\ReferenceParser;
+use BibleGet\Api\Pipeline\Tokenizer\ReferenceTokenizer;
+use BibleGet\Api\Pipeline\Tokenizer\Token;
+use BibleGet\Api\Pipeline\Validator\AstValidator;
+use PHPUnit\Framework\TestCase;
+
+final class AstValidatorTest extends TestCase
+{
+    private ReferenceTokenizer $tokenizer;
+    private ReferenceParser $parser;
+
+    /**
+     * Minimal BIBLEBOOKS array: index 0 = Genesis (book_num 1), index 18 = Psalms (book_num 19).
+     * Each entry: [language_idx => [fullname, abbreviation, ...normalized forms]]
+     *
+     * @var array<int, array<int, array<int, string>>>
+     */
+    private array $bibleBooks;
+
+    /**
+     * Minimal index for a single version "TST" (test).
+     *
+     * @var array<string, array{abbreviations: array<int, string>, biblebooks: array<int, string>, chapter_limit: array<int, int>, verse_limit: array<int, array<int, int>>, book_num: array<int, int>}>
+     */
+    private array $indexes;
+
+    protected function setUp(): void
+    {
+        $this->tokenizer = new ReferenceTokenizer();
+        $this->parser    = new ReferenceParser();
+
+        // Genesis at index 0 (book_num = 1): 50 chapters, chapter 1 has 31 verses, chapter 2 has 25 verses
+        // Psalms at index 18 (book_num = 19): 150 chapters
+        $this->bibleBooks = [];
+        for ($i = 0; $i < 73; $i++) {
+            $this->bibleBooks[$i] = [];
+        }
+        $this->bibleBooks[0]  = [1 => ['Genesis', 'Gen', 'Genesis', 'Gen']];
+        $this->bibleBooks[18] = [1 => ['Psalms', 'Ps', 'Psalms', 'Ps']];
+        $this->bibleBooks[42] = [1 => ['John', 'Jn', 'John', 'Jn']];
+        $this->bibleBooks[61] = [1 => ['1John', '1Jn', '1John', '1Jn']];
+
+        $this->indexes = [
+            'TST' => [
+                'abbreviations' => ['Gen', 'Ps', 'Jn', '1Jn'],
+                'biblebooks'    => ['Genesis', 'Psalms', 'John', '1John'],
+                'chapter_limit' => [50, 150, 21, 5],
+                'verse_limit'   => [
+                    // Genesis: chapters 1-50, but we only fill first few for testing
+                    array_merge([31, 25, 24], array_fill(0, 47, 30)),
+                    // Psalms: 150 chapters
+                    array_fill(0, 150, 20),
+                    // John: 21 chapters
+                    array_merge([51, 25, 36], array_fill(0, 18, 25)),
+                    // 1John: 5 chapters
+                    array_fill(0, 5, 21),
+                ],
+                'book_num'      => [1, 19, 43, 62],
+            ],
+        ];
+    }
+
+    private function createValidator(): AstValidator
+    {
+        return new AstValidator($this->bibleBooks, $this->indexes, ['TST']);
+    }
+
+    /**
+     * @return array{BibleQuery, Token[]}
+     */
+    private function tokenizeAndParse(string $input): array
+    {
+        $tokens = $this->tokenizer->tokenize($input);
+        $query  = $this->parser->parse($tokens);
+        return [$query, $tokens];
+    }
+
+    // ── Valid references ──────────────────────────────────────────
+
+    public function testValidWholeChapter(): void
+    {
+        $validator        = $this->createValidator();
+        [$query, $tokens] = $this->tokenizeAndParse('Genesis1');
+        $result           = $validator->validate($query, $tokens);
+
+        $this->assertNotNull($result);
+        $this->assertSame(1, $result->book);
+        $this->assertCount(1, $result->segments);
+        $this->assertEmpty($validator->getErrors());
+    }
+
+    public function testValidSingleVerse(): void
+    {
+        $validator        = $this->createValidator();
+        [$query, $tokens] = $this->tokenizeAndParse('Genesis1,5');
+        $result           = $validator->validate($query, $tokens);
+
+        $this->assertNotNull($result);
+        $this->assertSame(1, $result->book);
+        $this->assertEmpty($validator->getErrors());
+    }
+
+    public function testValidVerseRange(): void
+    {
+        $validator        = $this->createValidator();
+        [$query, $tokens] = $this->tokenizeAndParse('Genesis1,5-10');
+        $result           = $validator->validate($query, $tokens);
+
+        $this->assertNotNull($result);
+        $this->assertEmpty($validator->getErrors());
+    }
+
+    public function testValidCrossChapterRange(): void
+    {
+        $validator        = $this->createValidator();
+        [$query, $tokens] = $this->tokenizeAndParse('Genesis1,5-2,3');
+        $result           = $validator->validate($query, $tokens);
+
+        $this->assertNotNull($result);
+        $this->assertEmpty($validator->getErrors());
+    }
+
+    public function testValidNumberedBook(): void
+    {
+        $validator        = $this->createValidator();
+        [$query, $tokens] = $this->tokenizeAndParse('1John3,16');
+        $result           = $validator->validate($query, $tokens);
+
+        $this->assertNotNull($result);
+        $this->assertSame(62, $result->book);
+        $this->assertEmpty($validator->getErrors());
+    }
+
+    // ── Invalid book ──────────────────────────────────────────────
+
+    public function testInvalidBookName(): void
+    {
+        $validator        = $this->createValidator();
+        [$query, $tokens] = $this->tokenizeAndParse('Foobar1,1');
+        $result           = $validator->validate($query, $tokens);
+
+        $this->assertNull($result);
+        $this->assertNotEmpty($validator->getErrors());
+        $this->assertStringContainsString('not a valid Bible book', $validator->getErrors()[0]->message);
+    }
+
+    // ── Chapter out of bounds ─────────────────────────────────────
+
+    public function testChapterOutOfBounds(): void
+    {
+        $validator        = $this->createValidator();
+        [$query, $tokens] = $this->tokenizeAndParse('Genesis99');
+        $result           = $validator->validate($query, $tokens);
+
+        $this->assertNull($result);
+        $this->assertNotEmpty($validator->getErrors());
+        $this->assertStringContainsString('chapter', $validator->getErrors()[0]->message);
+        $this->assertStringContainsString('out of bounds', $validator->getErrors()[0]->message);
+    }
+
+    // ── Verse out of bounds ───────────────────────────────────────
+
+    public function testVerseOutOfBounds(): void
+    {
+        $validator        = $this->createValidator();
+        [$query, $tokens] = $this->tokenizeAndParse('Genesis1,99');
+        $result           = $validator->validate($query, $tokens);
+
+        $this->assertNull($result);
+        $this->assertNotEmpty($validator->getErrors());
+        $this->assertStringContainsString('verse', $validator->getErrors()[0]->message);
+        $this->assertStringContainsString('out of bounds', $validator->getErrors()[0]->message);
+    }
+
+    // ── Range ordering ────────────────────────────────────────────
+
+    public function testInvalidRangeVerseOrder(): void
+    {
+        $validator        = $this->createValidator();
+        [$query, $tokens] = $this->tokenizeAndParse('Genesis1,10-5');
+        $result           = $validator->validate($query, $tokens);
+
+        $this->assertNull($result);
+        $this->assertNotEmpty($validator->getErrors());
+        $this->assertStringContainsString('start verse', $validator->getErrors()[0]->message);
+    }
+
+    public function testInvalidRangeChapterOrder(): void
+    {
+        $validator        = $this->createValidator();
+        [$query, $tokens] = $this->tokenizeAndParse('Genesis3,1-1,5');
+        $result           = $validator->validate($query, $tokens);
+
+        $this->assertNull($result);
+        $this->assertNotEmpty($validator->getErrors());
+        $this->assertStringContainsString('start chapter', $validator->getErrors()[0]->message);
+    }
+
+    // ── Validated variants ────────────────────────────────────────
+
+    public function testValidatedVariantsPopulated(): void
+    {
+        $validator        = $this->createValidator();
+        [$query, $tokens] = $this->tokenizeAndParse('Genesis1');
+        $validator->validate($query, $tokens);
+
+        $this->assertSame(['TST'], $validator->getValidatedVariants());
+    }
+
+    public function testValidatedVariantsEmptyForMissingBook(): void
+    {
+        $validator        = $this->createValidator();
+        [$query, $tokens] = $this->tokenizeAndParse('Foobar1');
+        $validator->validate($query, $tokens);
+
+        $this->assertEmpty($validator->getValidatedVariants());
+    }
+}

--- a/tests/fixtures/seed.sql
+++ b/tests/fixtures/seed.sql
@@ -1,20 +1,62 @@
 -- Seed data for integration tests
 
--- Two test Bible versions: TEST1 (Catholic, not copyrighted), TEST2 (Protestant, copyrighted)
+-- Test Bible versions
 INSERT IGNORE INTO versions_available (sigla, fullname, year, language, imprimatur, canon, copyright_holder, notes, copyright, type) VALUES
 ('TEST1', 'Test Bible Version 1', '2020', 'English', 'Yes', 'CATHOLIC', 'Test Publisher', 'Test notes', 0, 'BIBLE'),
-('TEST2', 'Test Bible Version 2', '2021', 'English', 'No', 'PROTESTANT', 'Other Publisher', '', 1, 'BIBLE');
+('TEST2', 'Test Bible Version 2', '2021', 'English', 'No', 'PROTESTANT', 'Other Publisher', '', 1, 'BIBLE'),
+('VGCL', 'Vulgata Clementina', '1592', 'Latin', 'Yes', 'CATHOLIC', '', 'Test subset', 0, 'BIBLE'),
+('DRB', 'Douay-Rheims Bible', '1752', 'English', 'Yes', 'CATHOLIC', '', 'Test subset', 0, 'BIBLE');
 
--- Bible book names: just populate first 3 books (Genesis, Exodus, Leviticus) for testing
+-- Bible book names: books 1-3 (Genesis, Exodus, Leviticus) + 4-22 (fillers) + 23 (Psalms)
 INSERT IGNORE INTO biblebooks_fullname (BOOK, ENGLISH, ITALIAN) VALUES
 (1, 'Genesis', 'Genesi'),
 (2, 'Exodus', 'Esodo'),
-(3, 'Leviticus', 'Levitico');
+(3, 'Leviticus', 'Levitico'),
+(4, 'Numbers', 'Numeri'),
+(5, 'Deuteronomy', 'Deuteronomio'),
+(6, 'Joshua', 'Giosue'),
+(7, 'Judges', 'Giudici'),
+(8, 'Ruth', 'Rut'),
+(9, '1 Samuel', '1Samuele'),
+(10, '2 Samuel', '2Samuele'),
+(11, '1 Kings', '1Re'),
+(12, '2 Kings', '2Re'),
+(13, '1 Chronicles', '1Cronache'),
+(14, '2 Chronicles', '2Cronache'),
+(15, 'Ezra', 'Esdra'),
+(16, 'Nehemiah', 'Neemia'),
+(17, 'Tobit | Tobias', 'Tobia'),
+(18, 'Judith', 'Giuditta'),
+(19, 'Esther', 'Ester'),
+(20, '1 Maccabees', '1Maccabei'),
+(21, '2 Maccabees', '2Maccabei'),
+(22, 'Job', 'Giobbe'),
+(23, 'Psalms | Psalm', 'Salmi | Salmo');
 
 INSERT IGNORE INTO biblebooks_abbr (BOOK, ENGLISH, ITALIAN) VALUES
 (1, 'Gen | Gn', 'Gen | Gn'),
 (2, 'Exod | Ex', 'Es | Esod'),
-(3, 'Lev | Lv', 'Lv | Lev');
+(3, 'Lev | Lv', 'Lv | Lev'),
+(4, 'Num | Nm', 'Nm'),
+(5, 'Deut | Dt', 'Dt'),
+(6, 'Josh', 'Gs'),
+(7, 'Jdg | Jgs', 'Gdc'),
+(8, 'Ru', 'Rt'),
+(9, '1Sam', '1Sam'),
+(10, '2Sam', '2Sam'),
+(11, '1Kgs', '1Re'),
+(12, '2Kgs', '2Re'),
+(13, '1Chron | 1Chr', '1Cr'),
+(14, '2Chron | 2Chr', '2Cr'),
+(15, 'Ezr', 'Esd'),
+(16, 'Neh', 'Ne'),
+(17, 'Tob', 'Tb'),
+(18, 'Jdt', 'Gdt'),
+(19, 'Est', 'Est'),
+(20, '1Macc | 1Mc', '1Mac'),
+(21, '2Macc | 2Mc', '2Mac'),
+(22, 'Jb', 'Gb'),
+(23, 'Ps | Pss', 'Sal | Salm');
 
 -- Index tables for TEST1 (3 books)
 CREATE TABLE IF NOT EXISTS TEST1_idx (
@@ -29,7 +71,8 @@ CREATE TABLE IF NOT EXISTS TEST1_idx (
 INSERT IGNORE INTO TEST1_idx (abbrev, fullname, chapters, verses_last, book) VALUES
 ('Gen', 'Genesis', 3, '10,8,5', 1),
 ('Exod', 'Exodus', 2, '7,5', 2),
-('Lev', 'Leviticus', 2, '6,4', 3);
+('Lev', 'Leviticus', 2, '6,4', 3),
+('Ps', 'Psalms', 55, '6,12,8,8,12,10,17,9,21,18,7,8,6,7,5,11,15,10,21,18,7,8,6,10,12,12,10,17,9,3,5,16,8,8,10,13,18,7,14,11,19,17,8,4,3,13,14,7,13,12,19,6,12,8,6,12,5,4,8,3,11,11,8,10,13,6,5,17,9,14,10,17,7,13,20,6,10,7,13,7,18,6', 23);
 
 -- Index tables for TEST2 (3 books)
 CREATE TABLE IF NOT EXISTS TEST2_idx (
@@ -44,7 +87,8 @@ CREATE TABLE IF NOT EXISTS TEST2_idx (
 INSERT IGNORE INTO TEST2_idx (abbrev, fullname, chapters, verses_last, book) VALUES
 ('Gen', 'Genesis', 3, '10,8,5', 1),
 ('Exod', 'Exodus', 2, '7,5', 2),
-('Lev', 'Leviticus', 2, '6,4', 3);
+('Lev', 'Leviticus', 2, '6,4', 3),
+('Ps', 'Psalms', 55, '6,12,8,8,12,10,17,9,21,18,7,8,6,7,5,11,15,10,21,18,7,8,6,10,12,12,10,17,9,3,5,16,8,8,10,13,18,7,14,11,19,17,8,4,3,13,14,7,13,12,19,6,12,8,6,12,5,4,8,3,11,11,8,10,13,6,5,17,9,14,10,17,7,13,20,6,10,7,13,7,18,6', 23);
 
 -- Bible text tables for TEST1 (sample verses)
 CREATE TABLE IF NOT EXISTS TEST1 (
@@ -80,7 +124,14 @@ INSERT IGNORE INTO TEST1 (book, chapter, verse, text, testament, section) VALUES
 (1, 2, 8, 'The Lord God planted a garden toward the east, in Eden.', 1, 1),
 (2, 1, 1, 'Now these are the names of the sons of Israel who came to Egypt.', 1, 2),
 (2, 1, 2, 'Reuben, Simeon, Levi and Judah.', 1, 2),
-(2, 1, 3, 'Issachar, Zebulun and Benjamin.', 1, 2);
+(2, 1, 3, 'Issachar, Zebulun and Benjamin.', 1, 2),
+-- Psalms (book 23) — Hebrew numbering: chapter 51 = "Miserere"
+(23, 51, 1, 'Have mercy on me, O God, according to your unfailing love.', 1, 7),
+(23, 51, 2, 'Wash away all my iniquity and cleanse me from my sin.', 1, 7),
+(23, 51, 3, 'For I know my transgressions, and my sin is always before me.', 1, 7),
+(23, 51, 4, 'Against you, you only, have I sinned and done what is evil in your sight.', 1, 7),
+(23, 51, 5, 'Surely I was sinful at birth, sinful from the time my mother conceived me.', 1, 7),
+(23, 51, 6, 'Yet you desired faithfulness even in the womb; you taught me wisdom in that secret place.', 1, 7);
 
 -- Bible text tables for TEST2 (same sample verses)
 CREATE TABLE IF NOT EXISTS TEST2 (
@@ -103,3 +154,81 @@ INSERT IGNORE INTO TEST2 (book, chapter, verse, text, testament, section) VALUES
 (1, 1, 5, 'And God called the light Day, and the darkness he called Night.', 1, 1),
 (1, 2, 1, 'Thus the heavens and the earth were finished, and all the host of them.', 1, 1),
 (2, 1, 1, 'Now these are the names of the children of Israel.', 1, 2);
+
+-- ── VGCL (Vulgata Clementina) ──────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS VGCL_idx (
+    abbrev     VARCHAR(20) NOT NULL DEFAULT '',
+    fullname   VARCHAR(100) NOT NULL DEFAULT '',
+    chapters   INT NOT NULL DEFAULT 0,
+    verses_last VARCHAR(500) NOT NULL DEFAULT '',
+    book       INT NOT NULL DEFAULT 0,
+    PRIMARY KEY (book)
+) DEFAULT CHARSET=utf8mb4;
+
+-- Vulgate numbering: 150 Psalms. Hebrew Psalm 51 = VGCL chapter 50.
+INSERT IGNORE INTO VGCL_idx (abbrev, fullname, chapters, verses_last, book) VALUES
+('Gen', 'Genesis', 3, '10,8,5', 1),
+('Psal', 'Psalmorum', 55, '6,13,9,10,13,11,18,10,39,8,9,6,7,5,10,15,51,15,10,14,32,6,10,22,12,14,9,11,13,25,11,22,23,28,13,40,23,14,18,14,12,5,26,18,12,10,15,21,23,21,11,7,9,24,13', 23);
+
+CREATE TABLE IF NOT EXISTS VGCL (
+    verseID     INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    book        INT NOT NULL,
+    chapter     INT NOT NULL,
+    verse       INT NOT NULL,
+    text        TEXT NOT NULL,
+    testament   TINYINT NOT NULL DEFAULT 1,
+    section     INT NOT NULL DEFAULT 0,
+    verseorigin VARCHAR(10) NOT NULL DEFAULT '',
+    FULLTEXT(text)
+) DEFAULT CHARSET=utf8mb4;
+
+-- VGCL Psalm 50 (= Hebrew Psalm 51, "Miserere mei")
+INSERT IGNORE INTO VGCL (book, chapter, verse, text, testament, section) VALUES
+(23, 50, 1, 'In finem. Psalmus David,', 1, 7),
+(23, 50, 2, 'cum venit ad eum Nathan propheta, quando intravit ad Bethsabee.', 1, 7),
+(23, 50, 3, 'Miserere mei, Deus, secundum magnam misericordiam tuam.', 1, 7),
+(23, 50, 4, 'Amplius lava me ab iniquitate mea, et a peccato meo munda me.', 1, 7),
+(23, 50, 5, 'Quoniam iniquitatem meam ego cognosco, et peccatum meum contra me est semper.', 1, 7),
+(23, 50, 6, 'Tibi soli peccavi, et malum coram te feci.', 1, 7),
+-- VGCL Psalm 51 (= Hebrew Psalm 52, a different Psalm)
+(23, 51, 1, 'In finem. Intellectus David,', 1, 7),
+(23, 51, 2, 'cum venit Doeg Idumaeus, et nuntiavit Sauli.', 1, 7),
+(23, 51, 3, 'Quid gloriaris in malitia, qui potens es in iniquitate?', 1, 7);
+
+-- ── DRB (Douay-Rheims Bible) ───────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS DRB_idx (
+    abbrev     VARCHAR(20) NOT NULL DEFAULT '',
+    fullname   VARCHAR(100) NOT NULL DEFAULT '',
+    chapters   INT NOT NULL DEFAULT 0,
+    verses_last VARCHAR(500) NOT NULL DEFAULT '',
+    book       INT NOT NULL DEFAULT 0,
+    PRIMARY KEY (book)
+) DEFAULT CHARSET=utf8mb4;
+
+-- DRB uses same Vulgate numbering as VGCL.
+INSERT IGNORE INTO DRB_idx (abbrev, fullname, chapters, verses_last, book) VALUES
+('Gen', 'Genesis', 3, '10,8,5', 1),
+('Ps', 'Psalms', 55, '6,13,9,10,13,11,18,10,39,8,9,6,7,5,11,15,51,15,9,14,32,6,10,22,12,14,9,10,13,25,11,22,23,28,13,40,23,14,18,14,12,6,26,18,12,10,15,21,23,21,11,7,9,24,13', 23);
+
+CREATE TABLE IF NOT EXISTS DRB (
+    verseID     INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    book        INT NOT NULL,
+    chapter     INT NOT NULL,
+    verse       INT NOT NULL,
+    text        TEXT NOT NULL,
+    testament   TINYINT NOT NULL DEFAULT 1,
+    section     INT NOT NULL DEFAULT 0,
+    verseorigin VARCHAR(10) NOT NULL DEFAULT '',
+    FULLTEXT(text)
+) DEFAULT CHARSET=utf8mb4;
+
+-- DRB Psalm 50 (= Hebrew Psalm 51, "Have mercy")
+INSERT IGNORE INTO DRB (book, chapter, verse, text, testament, section) VALUES
+(23, 50, 1, 'Unto the end, a psalm of David,', 1, 7),
+(23, 50, 2, 'When Nathan the prophet came to him, after he had sinned with Bethsabee.', 1, 7),
+(23, 50, 3, 'Have mercy on me, O God, according to thy great mercy.', 1, 7),
+(23, 50, 4, 'Wash me yet more from my iniquity, and cleanse me from my sin.', 1, 7),
+(23, 50, 5, 'For I know my iniquity, and my sin is always before me.', 1, 7),
+(23, 50, 6, 'To thee only have I sinned, and have done evil before thee.', 1, 7);


### PR DESCRIPTION
## Summary

- Implements issue #57: replaces the regex-based `QueryValidator`/`QueryFormulator` internals with a structured tokenizer → parser → AST pipeline
- Adds new classes: `TokenType`, `Token`, `ReferenceTokenizer`, `ReferenceParser`, `ParseException`, `VerseRef`, `VerseRange`, `BibleQuery`, `AstValidator`, `ValidationError`, `EstherRemapper`, `PsalmChapterSwapper`, `SqlCompiler`
- Refactors `QueryValidator` and `QueryFormulator` to delegate to the new pipeline while keeping the public API unchanged
- Strips `Cf.`/`Cfr.`/`Confer` reference prefixes during query normalization
- Renames the misnamed `PsalmRemapper` to `EstherRemapper` (it handles Esther Greek additions, book 19, not Psalms)
- Implements `PsalmChapterSwapper`: swaps to Vulgate chapter numbering for VGCL/DRB when alternate chapter is provided (e.g., `Psalm51(50),1` → uses chapter 50 for VGCL)
- Extended test seed data with books 4–23, VGCL/DRB versions, and Psalm verse data

## Architecture

```
Raw input string
  → Normalizer (QuoteContext::queryStrClean — strips Cf. prefixes, normalizes dashes/notation)
  → ReferenceTokenizer (string → Token[])
  → ReferenceParser (Token[] → BibleQuery AST)
  → AstValidator (walk AST, check against DB metadata)
  → EstherRemapper (AST → AST rewrite for Esther Greek additions in VGCL/DRB)
  → PsalmChapterSwapper (AST → AST swap for Vulgate Psalm numbering)
  → SqlCompiler (walk AST → SQL WHERE clauses)
  → QueryExecutor (unchanged — runs SQL)
```

## Issues resolved

- **#41** — Cross-chapter ranges with dashes (`Matthew 9:35–10:1, 5, 6-8`)
- **#42** — Verse "letters" (`3a`, `5b`) normalized via `PARTIAL_VERSE_SUFFIX` tokens
- **#43** — `Cf.`/`Cfr.`/`Confer` prefixes stripped during query normalization
- **#46** — Psalm dual numbering in parentheses (`Psalm 51(50):1`) with Vulgate chapter swap for VGCL/DRB
- **#47** — Fatal SQL error with `Isaiah8:23;9:1-3` prevented by fail-fast validation

Closes #41
Closes #42
Closes #43
Closes #46
Closes #47
Closes #57

## Test plan

- [x] 329 tests pass (unit + integration), PHPStan level 10 clean, PHPCS clean
- [x] Issue regression tests at tokenizer level for #41, #42, #46, #47
- [x] Full-pipeline integration regression tests for #41, #42, #43, #47
- [x] Psalm chapter swap integration tests for #46 (VGCL, DRB, TEST1, ranges, multi-version)
- [x] PsalmChapterSwapper unit tests (8 cases)
- [x] EstherRemapper unit tests (9 cases, renamed from PsalmRemapper)
- [ ] Manual testing against production DB with sample queries from each issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)