### PR TITLE
Add Cache-Control and ETag headers to API responses

### DIFF
--- a/src/Handlers/AbstractHandler.php
+++ b/src/Handlers/AbstractHandler.php
@@ -345,6 +345,36 @@ abstract class AbstractHandler implements RequestHandlerInterface
     }
 
     /**
+     * Add Cache-Control and ETag headers to the response.
+     *
+     * If the client sent an If-None-Match header that matches the ETag,
+     * a 304 Not Modified response is returned instead.
+     *
+     * @param int $maxAge Cache max-age in seconds (default: 259200 = 3 days)
+     */
+    protected function withCacheHeaders(
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        int $maxAge = 259200
+    ): ResponseInterface {
+        $body = (string) $response->getBody();
+        $etag = '"' . md5($body) . '"';
+
+        $response = $response
+            ->withHeader('Cache-Control', 'must-revalidate, max-age=' . $maxAge)
+            ->withHeader('ETag', $etag);
+
+        $ifNoneMatch = $request->getHeaderLine('If-None-Match');
+        if ($ifNoneMatch !== '' && $ifNoneMatch === $etag) {
+            return $response
+                ->withStatus(StatusCode::NOT_MODIFIED->value, StatusCode::NOT_MODIFIED->reason())
+                ->withBody(Stream::create(''));
+        }
+
+        return $response;
+    }
+
+    /**
      * Write a JSON-encoded body to the response.
      *
      * @param mixed $data

--- a/src/Handlers/AbstractHandler.php
+++ b/src/Handlers/AbstractHandler.php
@@ -365,13 +365,33 @@ abstract class AbstractHandler implements RequestHandlerInterface
             ->withHeader('ETag', $etag);
 
         $ifNoneMatch = $request->getHeaderLine('If-None-Match');
-        if ($ifNoneMatch !== '' && $ifNoneMatch === $etag) {
+        if ($ifNoneMatch !== '' && self::etagMatches($ifNoneMatch, $etag)) {
             return $response
                 ->withStatus(StatusCode::NOT_MODIFIED->value, StatusCode::NOT_MODIFIED->reason())
                 ->withBody(Stream::create(''));
         }
 
         return $response;
+    }
+
+    /**
+     * Check whether an ETag is present in an If-None-Match header value.
+     *
+     * Handles the wildcard "*" and comma-separated lists per RFC 9110 §13.1.2.
+     */
+    private static function etagMatches(string $ifNoneMatch, string $etag): bool
+    {
+        if ($ifNoneMatch === '*') {
+            return true;
+        }
+
+        foreach (explode(',', $ifNoneMatch) as $candidate) {
+            if (trim($candidate) === $etag) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Handlers/MetadataHandler.php
+++ b/src/Handlers/MetadataHandler.php
@@ -58,16 +58,16 @@ class MetadataHandler extends AbstractHandler
         $data['info'] = ['ENDPOINT_VERSION' => self::ENDPOINT_VERSION];
 
         if ($contentType === 'application/json') {
-            return $this->jsonResponse($response, $data);
+            $response = $this->jsonResponse($response, $data);
+        } elseif ($contentType === 'application/xml') {
+            $response = $this->xmlResponse($response, $this->toXml($data, $subResource));
+        } else {
+            // HTML fallback
+            $json     = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+            $response = $this->htmlResponse($response, '<pre>' . htmlspecialchars($json !== false ? $json : '{}') . '</pre>');
         }
 
-        if ($contentType === 'application/xml') {
-            return $this->xmlResponse($response, $this->toXml($data, $subResource));
-        }
-
-        // HTML fallback
-        $json = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
-        return $this->htmlResponse($response, '<pre>' . htmlspecialchars($json !== false ? $json : '{}') . '</pre>');
+        return $this->withCacheHeaders($request, $response);
     }
 
     /**

--- a/src/Handlers/QuoteHandler.php
+++ b/src/Handlers/QuoteHandler.php
@@ -74,7 +74,8 @@ class QuoteHandler extends AbstractHandler
         }
 
         // Build response body
-        return $this->buildResponse($response, $contentType, $ctx);
+        $response = $this->buildResponse($response, $contentType, $ctx);
+        return $this->withCacheHeaders($request, $response);
     }
 
     private function buildResponse(ResponseInterface $response, string $contentType, QuoteContext $ctx): ResponseInterface

--- a/src/Handlers/SearchHandler.php
+++ b/src/Handlers/SearchHandler.php
@@ -59,7 +59,8 @@ class SearchHandler extends AbstractHandler
         $body->errors  = [];
         $body->info    = ['ENDPOINT_VERSION' => self::ENDPOINT_VERSION];
 
-        return $this->buildSearchResponse($response, $contentType, $body, $results);
+        $response = $this->buildSearchResponse($response, $contentType, $body, $results);
+        return $this->withCacheHeaders($request, $response);
     }
 
     /**

--- a/src/Http/Enum/StatusCode.php
+++ b/src/Http/Enum/StatusCode.php
@@ -8,6 +8,7 @@ enum StatusCode: int
 {
     case OK                     = 200;
     case NO_CONTENT             = 204;
+    case NOT_MODIFIED           = 304;
     case BAD_REQUEST            = 400;
     case FORBIDDEN              = 403;
     case NOT_FOUND              = 404;
@@ -24,6 +25,7 @@ enum StatusCode: int
         return match ($this) {
             self::OK                     => 'OK',
             self::NO_CONTENT             => 'No Content',
+            self::NOT_MODIFIED           => 'Not Modified',
             self::BAD_REQUEST            => 'Bad Request',
             self::FORBIDDEN              => 'Forbidden',
             self::NOT_FOUND              => 'Not Found',

--- a/tests/Unit/Handlers/AbstractHandlerTest.php
+++ b/tests/Unit/Handlers/AbstractHandlerTest.php
@@ -335,6 +335,30 @@ class AbstractHandlerTest extends TestCase
         self::assertSame($body, (string) $response->getBody());
     }
 
+    public function testCacheHeaders304WhenWildcardIfNoneMatch(): void
+    {
+        $handler  = $this->createHandler();
+        $request  = new ServerRequest('GET', '/', ['If-None-Match' => '*']);
+        $response = new \Nyholm\Psr7\Response(200, [], '{"hello":"world"}');
+
+        $response = $handler->testWithCacheHeaders($request, $response);
+
+        self::assertSame(304, $response->getStatusCode());
+    }
+
+    public function testCacheHeaders304WhenEtagInMultiValueHeader(): void
+    {
+        $handler = $this->createHandler();
+        $body    = '{"hello":"world"}';
+        $etag    = '"' . md5($body) . '"';
+        $request = new ServerRequest('GET', '/', ['If-None-Match' => '"old-etag", ' . $etag . ', "other"']);
+
+        $response = new \Nyholm\Psr7\Response(200, [], $body);
+        $response = $handler->testWithCacheHeaders($request, $response);
+
+        self::assertSame(304, $response->getStatusCode());
+    }
+
     // -- Fluent setters --
 
     public function testFluentSetters(): void

--- a/tests/Unit/Handlers/AbstractHandlerTest.php
+++ b/tests/Unit/Handlers/AbstractHandlerTest.php
@@ -32,6 +32,11 @@ class AbstractHandlerTest extends TestCase
             }
 
             // Expose protected methods for testing
+            public function testWithCacheHeaders(ServerRequestInterface $request, ResponseInterface $response, int $maxAge = 259200): ResponseInterface
+            {
+                return $this->withCacheHeaders($request, $response, $maxAge);
+            }
+
             public function testValidateRequestMethod(ServerRequestInterface $request): void
             {
                 $this->validateRequestMethod($request);
@@ -272,6 +277,62 @@ class AbstractHandlerTest extends TestCase
 
         self::assertSame(200, $response->getStatusCode());
         self::assertStringContainsString('GET', $response->getHeaderLine('Allow'));
+    }
+
+    // -- Cache headers --
+
+    public function testCacheHeadersAdded(): void
+    {
+        $handler  = $this->createHandler();
+        $request  = new ServerRequest('GET', '/');
+        $body     = '{"hello":"world"}';
+        $response = new \Nyholm\Psr7\Response(200, [], $body);
+
+        $response = $handler->testWithCacheHeaders($request, $response);
+
+        self::assertSame('must-revalidate, max-age=259200', $response->getHeaderLine('Cache-Control'));
+        $expectedEtag = '"' . md5($body) . '"';
+        self::assertSame($expectedEtag, $response->getHeaderLine('ETag'));
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testCacheHeadersCustomMaxAge(): void
+    {
+        $handler  = $this->createHandler();
+        $request  = new ServerRequest('GET', '/');
+        $response = new \Nyholm\Psr7\Response(200, [], 'test');
+
+        $response = $handler->testWithCacheHeaders($request, $response, 86400);
+
+        self::assertSame('must-revalidate, max-age=86400', $response->getHeaderLine('Cache-Control'));
+    }
+
+    public function testCacheHeaders304WhenEtagMatches(): void
+    {
+        $handler = $this->createHandler();
+        $body    = '{"hello":"world"}';
+        $etag    = '"' . md5($body) . '"';
+        $request = new ServerRequest('GET', '/', ['If-None-Match' => $etag]);
+
+        $response = new \Nyholm\Psr7\Response(200, [], $body);
+        $response = $handler->testWithCacheHeaders($request, $response);
+
+        self::assertSame(304, $response->getStatusCode());
+        self::assertSame('', (string) $response->getBody());
+        self::assertSame($etag, $response->getHeaderLine('ETag'));
+    }
+
+    public function testCacheHeadersNoMatchReturns200(): void
+    {
+        $handler  = $this->createHandler();
+        $request  = new ServerRequest('GET', '/', ['If-None-Match' => '"stale-etag"']);
+        $body     = '{"hello":"world"}';
+        $response = new \Nyholm\Psr7\Response(200, [], $body);
+
+        $response = $handler->testWithCacheHeaders($request, $response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame($body, (string) $response->getBody());
     }
 
     // -- Fluent setters --

--- a/tests/Unit/Http/Enum/StatusCodeTest.php
+++ b/tests/Unit/Http/Enum/StatusCodeTest.php
@@ -18,6 +18,7 @@ class StatusCodeTest extends TestCase
         return [
             'OK'                     => [StatusCode::OK, 200, 'OK'],
             'No Content'             => [StatusCode::NO_CONTENT, 204, 'No Content'],
+            'Not Modified'           => [StatusCode::NOT_MODIFIED, 304, 'Not Modified'],
             'Bad Request'            => [StatusCode::BAD_REQUEST, 400, 'Bad Request'],
             'Not Found'              => [StatusCode::NOT_FOUND, 404, 'Not Found'],
             'Method Not Allowed'     => [StatusCode::METHOD_NOT_ALLOWED, 405, 'Method Not Allowed'],


### PR DESCRIPTION
## Summary
- Adds `Cache-Control: must-revalidate, max-age=259200` (3 days) and `ETag` headers to all API responses (quote, metadata, search)
- Returns `304 Not Modified` when the client's `If-None-Match` header matches the response ETag, avoiding redundant data transfer
- Adds `NOT_MODIFIED` (304) to the `StatusCode` enum

Closes #31

## Test plan
- [x] Unit tests for `withCacheHeaders()`: headers added, custom max-age, 304 on ETag match, 200 on mismatch
- [x] `StatusCode::NOT_MODIFIED` added to StatusCode test data provider
- [x] PHPCS, PHPStan level 10, and all unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global HTTP caching applied to API responses with automatic ETag generation, configurable max-age, and Cache-Control headers.
  * 304 Not Modified responses served when client validators match, reducing bandwidth.

* **Tests**
  * Added unit tests covering ETag generation, Cache-Control behavior, and conditional 304 responses (including wildcard and multi-value validators).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->