### PR TITLE
Use PSR-17 ResponseFactory instead of direct Response instantiation

### DIFF
--- a/src/Handlers/AbstractHandler.php
+++ b/src/Handlers/AbstractHandler.php
@@ -13,8 +13,8 @@ use BibleGet\Api\Http\Exception\NotAcceptableException;
 use BibleGet\Api\Http\Exception\UnsupportedMediaTypeException;
 use BibleGet\Api\Http\Exception\BadRequestException;
 use BibleGet\Api\Http\Exception\ValidationException;
-use Nyholm\Psr7\Response;
 use Nyholm\Psr7\Stream;
+use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -33,13 +33,16 @@ abstract class AbstractHandler implements RequestHandlerInterface
     /** @var string[] */
     protected array $requestPathParams;
 
+    protected ResponseFactoryInterface $responseFactory;
+
     abstract public function handle(ServerRequestInterface $request): ResponseInterface;
 
     /**
      * @param string[] $requestPathParams
      */
-    public function __construct(array $requestPathParams = [])
+    public function __construct(ResponseFactoryInterface $responseFactory, array $requestPathParams = [])
     {
+        $this->responseFactory            = $responseFactory;
         $this->requestPathParams          = $requestPathParams;
         $this->allowedAcceptHeaders       = AcceptHeader::cases();
         $this->allowedRequestMethods      = [RequestMethod::GET, RequestMethod::POST, RequestMethod::OPTIONS];
@@ -333,13 +336,9 @@ abstract class AbstractHandler implements RequestHandlerInterface
      */
     protected function initResponse(ServerRequestInterface $request, string $contentType): ResponseInterface
     {
-        $response = new Response(
-            StatusCode::OK->value,
-            ['Content-Type' => $contentType . '; charset=utf-8'],
-            null,
-            $request->getProtocolVersion(),
-            StatusCode::OK->reason()
-        );
+        $response = $this->responseFactory->createResponse(StatusCode::OK->value, StatusCode::OK->reason())
+            ->withProtocolVersion($request->getProtocolVersion())
+            ->withHeader('Content-Type', $contentType . '; charset=utf-8');
 
         return $this->setAccessControlAllowOriginHeader($request, $response);
     }

--- a/src/Router.php
+++ b/src/Router.php
@@ -14,8 +14,8 @@ use BibleGet\Api\Http\Middleware\LoggingMiddleware;
 use BibleGet\Api\Http\Server\MiddlewarePipeline;
 use Laminas\HttpHandlerRunner\Emitter\SapiEmitter;
 use Nyholm\Psr7\Factory\Psr17Factory;
-use Nyholm\Psr7\Response;
 use Nyholm\Psr7Server\ServerRequestCreator;
+use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -68,33 +68,29 @@ class Router
         switch ($route) {
             case '':
             case 'quote':
-                $this->handler = new QuoteHandler($requestPathParts);
+                $this->handler = new QuoteHandler($this->psr17Factory, $requestPathParts);
                 break;
 
             case 'metadata':
-                $this->handler = new MetadataHandler($requestPathParts);
+                $this->handler = new MetadataHandler($this->psr17Factory, $requestPathParts);
                 break;
 
             case 'search':
-                $this->handler = new SearchHandler($requestPathParts);
+                $this->handler = new SearchHandler($this->psr17Factory, $requestPathParts);
                 break;
 
             default:
-                $protocolVersion = $this->request->getProtocolVersion();
-                $this->handler   = new class ($protocolVersion) implements RequestHandlerInterface {
-                    public function __construct(private readonly string $protocolVersion)
+                $responseFactory = $this->psr17Factory;
+                $this->handler   = new class ($responseFactory) implements RequestHandlerInterface {
+                    public function __construct(private readonly ResponseFactoryInterface $responseFactory)
                     {
                     }
 
                     public function handle(ServerRequestInterface $request): ResponseInterface
                     {
-                        return new Response(
-                            StatusCode::NOT_FOUND->value,
-                            [],
-                            null,
-                            $this->protocolVersion,
-                            StatusCode::NOT_FOUND->reason()
-                        );
+                        return $this->responseFactory
+                            ->createResponse(StatusCode::NOT_FOUND->value, StatusCode::NOT_FOUND->reason())
+                            ->withProtocolVersion($request->getProtocolVersion());
                     }
                 };
                 break;

--- a/tests/Integration/Handlers/MetadataHandlerTest.php
+++ b/tests/Integration/Handlers/MetadataHandlerTest.php
@@ -11,13 +11,14 @@ use BibleGet\Api\Http\Enum\RequestMethod;
 use BibleGet\Api\Http\Exception\NotFoundException;
 use BibleGet\Api\Http\Exception\ValidationException;
 use BibleGet\Tests\Integration\DatabaseTestCase;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7\ServerRequest;
 
 class MetadataHandlerTest extends DatabaseTestCase
 {
     private function createHandler(array $pathParams = []): MetadataHandler
     {
-        $handler = new MetadataHandler($pathParams);
+        $handler = new MetadataHandler(new Psr17Factory(), $pathParams);
         $handler->setAllowedRequestMethods([RequestMethod::GET, RequestMethod::POST, RequestMethod::OPTIONS])
             ->setAllowedRequestContentTypes([RequestContentType::JSON, RequestContentType::FORMDATA])
             ->setAllowedAcceptHeaders([AcceptHeader::JSON, AcceptHeader::XML, AcceptHeader::HTML]);

--- a/tests/Integration/Handlers/QuoteHandlerTest.php
+++ b/tests/Integration/Handlers/QuoteHandlerTest.php
@@ -9,6 +9,7 @@ use BibleGet\Api\Http\Enum\AcceptHeader;
 use BibleGet\Api\Http\Enum\RequestContentType;
 use BibleGet\Api\Http\Enum\RequestMethod;
 use BibleGet\Tests\Integration\DatabaseTestCase;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7\ServerRequest;
 use Nyholm\Psr7\Stream;
 
@@ -28,7 +29,7 @@ class QuoteHandlerTest extends DatabaseTestCase
 
     private function createHandler(): QuoteHandler
     {
-        $handler = new QuoteHandler();
+        $handler = new QuoteHandler(new Psr17Factory());
         $handler->setAllowedRequestMethods([RequestMethod::GET, RequestMethod::POST, RequestMethod::OPTIONS])
             ->setAllowedRequestContentTypes([RequestContentType::JSON, RequestContentType::FORMDATA])
             ->setAllowedAcceptHeaders([AcceptHeader::JSON, AcceptHeader::XML, AcceptHeader::HTML]);

--- a/tests/Integration/Handlers/SearchHandlerTest.php
+++ b/tests/Integration/Handlers/SearchHandlerTest.php
@@ -10,13 +10,14 @@ use BibleGet\Api\Http\Enum\RequestContentType;
 use BibleGet\Api\Http\Enum\RequestMethod;
 use BibleGet\Api\Http\Exception\ValidationException;
 use BibleGet\Tests\Integration\DatabaseTestCase;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7\ServerRequest;
 
 class SearchHandlerTest extends DatabaseTestCase
 {
     private function createHandler(): SearchHandler
     {
-        $handler = new SearchHandler();
+        $handler = new SearchHandler(new Psr17Factory());
         $handler->setAllowedRequestMethods([RequestMethod::GET, RequestMethod::POST, RequestMethod::OPTIONS])
             ->setAllowedRequestContentTypes([RequestContentType::JSON, RequestContentType::FORMDATA])
             ->setAllowedAcceptHeaders([AcceptHeader::JSON, AcceptHeader::XML, AcceptHeader::HTML]);

--- a/tests/Unit/Handlers/AbstractHandlerTest.php
+++ b/tests/Unit/Handlers/AbstractHandlerTest.php
@@ -12,9 +12,11 @@ use BibleGet\Api\Http\Exception\BadRequestException;
 use BibleGet\Api\Http\Exception\MethodNotAllowedException;
 use BibleGet\Api\Http\Exception\NotAcceptableException;
 use BibleGet\Api\Http\Exception\UnsupportedMediaTypeException;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7\ServerRequest;
 use Nyholm\Psr7\Stream;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -22,7 +24,7 @@ class AbstractHandlerTest extends TestCase
 {
     private function createHandler(): AbstractHandler
     {
-        return new class extends AbstractHandler {
+        return new class (new Psr17Factory()) extends AbstractHandler {
             public function handle(ServerRequestInterface $request): ResponseInterface
             {
                 $params      = $this->getRequestParams($request);


### PR DESCRIPTION
## Summary
- Inject `ResponseFactoryInterface` into `AbstractHandler` constructor instead of directly instantiating `Nyholm\Psr7\Response`
- Update `Router` 404 handler to use the factory
- All handler subclasses and tests updated to pass the factory

Decouples handlers from a specific PSR-7 implementation, matching the pattern already used by `ErrorHandlingMiddleware`.

Closes #69

## Test plan
- [x] PHPStan level 10 — 0 errors
- [x] PHPCS PSR-12 — clean
- [x] PHPUnit — 376/376 pass (unit), full CI matrix (PHP 8.2/8.3/8.4) green on fork

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated handler initialization to use dependency injection for response factory management, improving code flexibility and consistency across request handlers.
  * Adjusted test infrastructure to align with updated handler instantiation patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->