### PR TITLE
Restrict CORS credentials to configured allowed origins

### DIFF
--- a/src/Handlers/AbstractHandler.php
+++ b/src/Handlers/AbstractHandler.php
@@ -75,15 +75,31 @@ abstract class AbstractHandler implements RequestHandlerInterface
 
     /**
      * Set CORS Access-Control-Allow-Origin header on the response.
+     *
+     * When CORS_ALLOWED_ORIGINS is configured, only listed origins receive
+     * credentials support. Unknown origins get a plain wildcard header
+     * without Access-Control-Allow-Credentials to prevent any site from
+     * making credentialed cross-origin requests.
      */
     protected function setAccessControlAllowOriginHeader(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
     {
         $origin = $request->getHeaderLine('Origin');
 
         if ($origin !== '') {
+            $allowedRaw     = $_ENV['CORS_ALLOWED_ORIGINS'] ?? '';
+            $allowedOrigins = is_string($allowedRaw) && $allowedRaw !== ''
+                ? array_map('trim', explode(',', $allowedRaw))
+                : [];
+
+            if ($allowedOrigins === [] || in_array($origin, $allowedOrigins, true)) {
+                return $response
+                    ->withHeader('Access-Control-Allow-Origin', $origin)
+                    ->withHeader('Access-Control-Allow-Credentials', 'true')
+                    ->withAddedHeader('Vary', 'Origin');
+            }
+
             return $response
                 ->withHeader('Access-Control-Allow-Origin', $origin)
-                ->withHeader('Access-Control-Allow-Credentials', 'true')
                 ->withAddedHeader('Vary', 'Origin');
         }
 

--- a/src/Handlers/AbstractHandler.php
+++ b/src/Handlers/AbstractHandler.php
@@ -99,10 +99,6 @@ abstract class AbstractHandler implements RequestHandlerInterface
             $response = $response->withStatus(StatusCode::NO_CONTENT->value, StatusCode::NO_CONTENT->reason());
             $response = $this->setAccessControlAllowOriginHeader($request, $response);
 
-            if ($response->getHeaderLine('Access-Control-Allow-Origin') !== '*') {
-                $response = $response->withAddedHeader('Vary', 'Origin');
-            }
-
             $response = $response
                 ->withAddedHeader('Vary', 'Access-Control-Request-Method')
                 ->withAddedHeader('Vary', 'Access-Control-Request-Headers');

--- a/src/Handlers/AbstractHandler.php
+++ b/src/Handlers/AbstractHandler.php
@@ -11,6 +11,7 @@ use BibleGet\Api\Http\Enum\StatusCode;
 use BibleGet\Api\Http\Exception\MethodNotAllowedException;
 use BibleGet\Api\Http\Exception\NotAcceptableException;
 use BibleGet\Api\Http\Exception\UnsupportedMediaTypeException;
+use BibleGet\Api\Http\CorsPolicy;
 use BibleGet\Api\Http\Exception\BadRequestException;
 use BibleGet\Api\Http\Exception\ValidationException;
 use Nyholm\Psr7\Response;
@@ -75,35 +76,10 @@ abstract class AbstractHandler implements RequestHandlerInterface
 
     /**
      * Set CORS Access-Control-Allow-Origin header on the response.
-     *
-     * When CORS_ALLOWED_ORIGINS is configured, only listed origins receive
-     * credentials support. Unknown origins get a plain wildcard header
-     * without Access-Control-Allow-Credentials to prevent any site from
-     * making credentialed cross-origin requests.
      */
     protected function setAccessControlAllowOriginHeader(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
     {
-        $origin = $request->getHeaderLine('Origin');
-
-        if ($origin !== '') {
-            $allowedRaw     = $_ENV['CORS_ALLOWED_ORIGINS'] ?? '';
-            $allowedOrigins = is_string($allowedRaw) && $allowedRaw !== ''
-                ? array_map('trim', explode(',', $allowedRaw))
-                : [];
-
-            if ($allowedOrigins === [] || in_array($origin, $allowedOrigins, true)) {
-                return $response
-                    ->withHeader('Access-Control-Allow-Origin', $origin)
-                    ->withHeader('Access-Control-Allow-Credentials', 'true')
-                    ->withAddedHeader('Vary', 'Origin');
-            }
-
-            return $response
-                ->withHeader('Access-Control-Allow-Origin', $origin)
-                ->withAddedHeader('Vary', 'Origin');
-        }
-
-        return $response->withHeader('Access-Control-Allow-Origin', '*');
+        return ( new CorsPolicy() )->applyHeaders($request, $response);
     }
 
     /**

--- a/src/Http/CorsPolicy.php
+++ b/src/Http/CorsPolicy.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BibleGet\Api\Http;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Applies CORS Access-Control-Allow-Origin headers based on a configurable
+ * origin allowlist (CORS_ALLOWED_ORIGINS environment variable).
+ *
+ * When CORS_ALLOWED_ORIGINS is set, only listed origins receive
+ * Access-Control-Allow-Credentials: true. Unknown origins get the
+ * Access-Control-Allow-Origin header without credentials support,
+ * preventing arbitrary sites from making credentialed cross-origin requests.
+ *
+ * When CORS_ALLOWED_ORIGINS is unset or empty, any origin is treated as
+ * allowed (preserving the previous open behaviour).
+ */
+class CorsPolicy
+{
+    /** @var string[] */
+    private array $allowedOrigins;
+
+    public function __construct()
+    {
+        $raw                  = $_ENV['CORS_ALLOWED_ORIGINS'] ?? '';
+        $this->allowedOrigins = is_string($raw) && $raw !== ''
+            ? array_map('trim', explode(',', $raw))
+            : [];
+    }
+
+    public function applyHeaders(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        $origin = $request->getHeaderLine('Origin');
+
+        if ($origin === '') {
+            return $response->withHeader('Access-Control-Allow-Origin', '*');
+        }
+
+        if ($this->allowedOrigins === [] || in_array($origin, $this->allowedOrigins, true)) {
+            return $response
+                ->withHeader('Access-Control-Allow-Origin', $origin)
+                ->withHeader('Access-Control-Allow-Credentials', 'true')
+                ->withAddedHeader('Vary', 'Origin');
+        }
+
+        return $response
+            ->withHeader('Access-Control-Allow-Origin', $origin)
+            ->withAddedHeader('Vary', 'Origin');
+    }
+}

--- a/src/Http/Middleware/ErrorHandlingMiddleware.php
+++ b/src/Http/Middleware/ErrorHandlingMiddleware.php
@@ -136,9 +136,20 @@ class ErrorHandlingMiddleware implements MiddlewareInterface
     {
         $origin = $request->getHeaderLine('Origin');
         if ($origin !== '') {
+            $allowedRaw     = $_ENV['CORS_ALLOWED_ORIGINS'] ?? '';
+            $allowedOrigins = is_string($allowedRaw) && $allowedRaw !== ''
+                ? array_map('trim', explode(',', $allowedRaw))
+                : [];
+
+            if ($allowedOrigins === [] || in_array($origin, $allowedOrigins, true)) {
+                return $response
+                    ->withHeader('Access-Control-Allow-Origin', $origin)
+                    ->withHeader('Access-Control-Allow-Credentials', 'true')
+                    ->withAddedHeader('Vary', 'Origin');
+            }
+
             return $response
                 ->withHeader('Access-Control-Allow-Origin', $origin)
-                ->withHeader('Access-Control-Allow-Credentials', 'true')
                 ->withAddedHeader('Vary', 'Origin');
         }
         return $response->withHeader('Access-Control-Allow-Origin', '*');

--- a/src/Http/Middleware/ErrorHandlingMiddleware.php
+++ b/src/Http/Middleware/ErrorHandlingMiddleware.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BibleGet\Api\Http\Middleware;
 
+use BibleGet\Api\Http\CorsPolicy;
 use BibleGet\Api\Http\Exception\ApiException;
 use BibleGet\Api\Http\Exception\TooManyRequestsException;
 use BibleGet\Api\Http\Logs\LoggerFactory;
@@ -134,25 +135,7 @@ class ErrorHandlingMiddleware implements MiddlewareInterface
 
     private function applyCorsHeaders(ResponseInterface $response, ServerRequestInterface $request): ResponseInterface
     {
-        $origin = $request->getHeaderLine('Origin');
-        if ($origin !== '') {
-            $allowedRaw     = $_ENV['CORS_ALLOWED_ORIGINS'] ?? '';
-            $allowedOrigins = is_string($allowedRaw) && $allowedRaw !== ''
-                ? array_map('trim', explode(',', $allowedRaw))
-                : [];
-
-            if ($allowedOrigins === [] || in_array($origin, $allowedOrigins, true)) {
-                return $response
-                    ->withHeader('Access-Control-Allow-Origin', $origin)
-                    ->withHeader('Access-Control-Allow-Credentials', 'true')
-                    ->withAddedHeader('Vary', 'Origin');
-            }
-
-            return $response
-                ->withHeader('Access-Control-Allow-Origin', $origin)
-                ->withAddedHeader('Vary', 'Origin');
-        }
-        return $response->withHeader('Access-Control-Allow-Origin', '*');
+        return ( new CorsPolicy() )->applyHeaders($request, $response);
     }
 
     private function logException(\Throwable $e, string $severity = 'error'): void

--- a/tests/Unit/Http/CorsPolicyTest.php
+++ b/tests/Unit/Http/CorsPolicyTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BibleGet\Tests\Unit\Http;
+
+use BibleGet\Api\Http\CorsPolicy;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7\ServerRequest;
+use PHPUnit\Framework\TestCase;
+
+class CorsPolicyTest extends TestCase
+{
+    private Psr17Factory $factory;
+
+    protected function setUp(): void
+    {
+        $this->factory = new Psr17Factory();
+        unset($_ENV['CORS_ALLOWED_ORIGINS']);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_ENV['CORS_ALLOWED_ORIGINS']);
+    }
+
+    private function request(string $origin = ''): ServerRequest
+    {
+        $req = new ServerRequest('GET', 'http://example.com/v3/quote');
+        return $origin !== '' ? $req->withHeader('Origin', $origin) : $req;
+    }
+
+    public function testNoOriginReturnsWildcard(): void
+    {
+        $response = ( new CorsPolicy() )->applyHeaders(
+            $this->request(),
+            $this->factory->createResponse(200)
+        );
+
+        $this->assertSame('*', $response->getHeaderLine('Access-Control-Allow-Origin'));
+        $this->assertSame('', $response->getHeaderLine('Access-Control-Allow-Credentials'));
+    }
+
+    public function testAnyOriginAllowedWhenNoAllowlistConfigured(): void
+    {
+        $response = ( new CorsPolicy() )->applyHeaders(
+            $this->request('https://any-site.example'),
+            $this->factory->createResponse(200)
+        );
+
+        $this->assertSame('https://any-site.example', $response->getHeaderLine('Access-Control-Allow-Origin'));
+        $this->assertSame('true', $response->getHeaderLine('Access-Control-Allow-Credentials'));
+        $this->assertStringContainsString('Origin', $response->getHeaderLine('Vary'));
+    }
+
+    public function testAllowedOriginGetsCredentials(): void
+    {
+        $_ENV['CORS_ALLOWED_ORIGINS'] = 'https://app.bibleget.io,https://staging.bibleget.io';
+
+        $response = ( new CorsPolicy() )->applyHeaders(
+            $this->request('https://app.bibleget.io'),
+            $this->factory->createResponse(200)
+        );
+
+        $this->assertSame('https://app.bibleget.io', $response->getHeaderLine('Access-Control-Allow-Origin'));
+        $this->assertSame('true', $response->getHeaderLine('Access-Control-Allow-Credentials'));
+    }
+
+    public function testUnknownOriginDoesNotGetCredentials(): void
+    {
+        $_ENV['CORS_ALLOWED_ORIGINS'] = 'https://app.bibleget.io';
+
+        $response = ( new CorsPolicy() )->applyHeaders(
+            $this->request('https://evil.example'),
+            $this->factory->createResponse(200)
+        );
+
+        $this->assertSame('https://evil.example', $response->getHeaderLine('Access-Control-Allow-Origin'));
+        $this->assertSame('', $response->getHeaderLine('Access-Control-Allow-Credentials'));
+        $this->assertStringContainsString('Origin', $response->getHeaderLine('Vary'));
+    }
+
+    public function testAllowlistEntriesAreTrimmed(): void
+    {
+        $_ENV['CORS_ALLOWED_ORIGINS'] = '  https://app.bibleget.io  ,  https://staging.bibleget.io  ';
+
+        $response = ( new CorsPolicy() )->applyHeaders(
+            $this->request('https://staging.bibleget.io'),
+            $this->factory->createResponse(200)
+        );
+
+        $this->assertSame('true', $response->getHeaderLine('Access-Control-Allow-Credentials'));
+    }
+}


### PR DESCRIPTION
## Summary
Only set `Access-Control-Allow-Credentials: true` when the requesting origin is listed in the `CORS_ALLOWED_ORIGINS` environment variable. Unknown origins still receive `Access-Control-Allow-Origin` (for basic CORS) but without credentials support, preventing any arbitrary website from making credentialed cross-origin requests.

Applied consistently in both `AbstractHandler::setAccessControlAllowOriginHeader()` and `ErrorHandlingMiddleware::applyCorsHeaders()`.

**Backwards compatible**: when `CORS_ALLOWED_ORIGINS` is unset or empty, the current open behavior is preserved.

Closes #64

## Test plan
- [x] PHPStan level 10 — 0 errors
- [x] PHPCS PSR-12 — clean
- [x] PHPUnit — 376/376 pass, full CI matrix green on fork

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized CORS policy applied across middleware and handlers for consistent cross-origin responses.

* **Bug Fixes**
  * Enhanced CORS security: credentials are now included only for approved origins; wildcard responses used when no Origin is present. Vary header behavior adjusted for accurate caching.

* **Tests**
  * Added unit tests covering wildcard, allowed, disallowed origins and trimming of allowlist entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->