### PR TITLE
Replace TIMESTAMP primary key on usage_counter to prevent collisions

### DIFF
--- a/migrations/production-schema.sql
+++ b/migrations/production-schema.sql
@@ -44,10 +44,12 @@ CREATE TABLE IF NOT EXISTS versions_available (
 );
 
 CREATE TABLE IF NOT EXISTS usage_counter (
-    datetime      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP PRIMARY KEY,
-    currentcount  INT NOT NULL DEFAULT 0,
+    id             SERIAL PRIMARY KEY,
+    datetime       TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    currentcount   INT NOT NULL DEFAULT 0,
     quarthourcount INT NOT NULL DEFAULT 0
 );
+CREATE INDEX IF NOT EXISTS usage_counter_datetime ON usage_counter (datetime);
 
 -- ── Bible book names (25 languages) ─────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
The `usage_counter` table uses `datetime TIMESTAMP` as its primary key. If two inserts arrive within the same timestamp precision, the second fails with a duplicate key violation.

This adds a `SERIAL id` column as the new primary key and demotes `datetime` to an indexed column, preserving query performance on time-based lookups.

Closes #65

## Test plan
- [x] Schema-only change — no PHP code references `usage_counter`
- [x] Full CI matrix green on fork

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized database schema for improved query performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->