### PR TITLE
chore: add Serena project memories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ dbcredentials.php
 .env.test
 .env.staging
 .env.production
+
+# Local git worktrees
+.worktrees/

--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/memories/code_style_and_conventions.md
+++ b/.serena/memories/code_style_and_conventions.md
@@ -1,0 +1,90 @@
+# Code Style & Conventions — BibleGet endpoint
+
+## Standards
+- **PHP >= 8.2**
+- **PSR-12** (with custom rules in `phpcs.xml`); enforced by `phpcs`, auto-fix via `phpcbf`
+- **PHPStan level 10** (`phpstan.neon.dist`)
+- **PSR-4** autoload: `BibleGet\Api\` → `src/`; tests `BibleGet\Tests\` → `tests/`
+- Strict PSR-7/15/17 architecture (see project_structure memory)
+
+## Required PHP extensions
+`ext-pdo_pgsql`, `ext-json`, `ext-simplexml`, `ext-dom`
+
+## Architectural conventions
+
+### Adding a new handler
+1. Create class in `src/Handlers/` extending `AbstractHandler`
+2. Implement `handle(ServerRequestInterface $request): ResponseInterface`
+3. Configure allowed methods, accept headers, content types via the constructor / parent
+4. Add a route case in `src/Router.php`
+5. Use built-in content negotiation; return PSR-7 `ResponseInterface`
+
+### Errors
+- Throw `ApiException` subclasses from `src/Http/Exception/`
+- `ErrorHandlingMiddleware` will convert them to RFC 9457 `application/problem+json`
+- Don't catch + transform errors at the handler level — let them propagate
+
+### Logging
+- Use `LoggerFactory::create(...)` in `src/Http/Logs/`
+- PSR-3 Monolog with rotating file handler under `logs/`
+
+### Database access
+- Always go through `Database\Connection` (PDO singleton)
+- `ERRMODE_EXCEPTION` and `FETCH_ASSOC` are default
+- Use parameterized queries — never string-concatenate user input
+- Per-version tables are quoted identifiers: `"{VERSION}"`, `"{VERSION}_idx"` (case-sensitive in PostgreSQL — keep the double-quotes)
+- IPs go into `inet` columns (don't quote as plain strings if writing raw SQL)
+- Full-text search uses `tsvector` columns + GIN indexes; queries via `tsquery`
+
+### Quote pipeline (`src/Pipeline/`)
+- All shared state lives in `QuoteContext` (NOT in handler properties)
+- Order: `QueryValidator` → `QueryFormulator` → `QueryExecutor`
+- `QueryExecutor` is responsible for rate limiting (throws `TooManyRequestsException`) and request logging — don't duplicate that elsewhere
+
+### Bible reference notation
+- ENGLISH (`John 3:16`) vs EUROPEAN (`Giovanni 3,16`) auto-detected
+- A detection result of `MIXED` is invalid — the validator emits an error
+- Return responses always include `info.detectedNotation` with `ENGLISH` | `EUROPEAN` (or `MIXED` on error)
+
+### Verse ordering
+- Use the `verseID` field for ordering — handles Greek subverses correctly
+- Don't sort by `verse` numerically (verses can have letter suffixes)
+
+### Copyright enforcement
+- Versions in the `copyrightversions` set (e.g. `CEI2008`, `NABRE`, `BLPD`) cap a single request to 30 verses
+- Enforcement is server-side — clients can't override
+
+### Rate limits
+- IP-based, 2-day rolling window, thresholds at 10 / 30 / 100 requests
+- Past threshold → `TooManyRequestsException` → HTTP 429 problem+json
+
+### CORS / bot protection (`AbstractHandler`)
+- Dynamic `Access-Control-Allow-Origin` per request
+- Block requests whose User-Agent matches `bot|crawl|slurp|spider`
+
+### Content negotiation
+- `return` query parameter takes priority for back-compat (json|xml|html)
+- Otherwise, `Accept` header (`application/json`, `application/xml`, `text/html`)
+- Default: JSON
+
+## Response data shape (consistent across endpoints)
+- `results` — array (verses or empty)
+- `errors` — array of strings (always check this client-side)
+- `info` — object with at minimum `ENDPOINT_VERSION` ("3.0"), plus endpoint-specific fields:
+  - `/quote` adds `detectedNotation`, `bibleVersionsInfo`
+  - `/metadata/bibleversions` adds `validversions`, `validversions_fullname`, `copyrightversions`
+  - `/metadata/biblebooks` adds `languages`
+  - `/metadata/versionindex` adds `indexes`
+  - `/search` adds `keyword`, `version`
+
+## Naming
+- Namespaces / classes: PascalCase
+- Methods, properties, vars: camelCase
+- Class constants: UPPER_SNAKE_CASE
+- Enum cases: per PHP enum conventions (typically PascalCase)
+
+## Pre-commit (CaptainHook)
+Configured in `captainhook.json`. Don't bypass with `--no-verify` unless explicitly authorized. Reinstall hooks if config changes:
+```bash
+vendor/bin/captainhook install -f
+```

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -34,7 +34,6 @@ Serves the BibleGet WordPress / Google Docs / Microsoft Word / OpenOffice / Libr
 The v3 codebase explicitly follows the same PSR-based architecture as `LiturgicalCalendarAPI` (Router → MiddlewarePipeline → AbstractHandler → response via Negotiator). Familiarity with that codebase carries over here.
 
 ## Repo Location
-`/home/johnrdorazio/development/BibleGet-I-O/endpoint`
 
 Sibling repos under `BibleGet-I-O/`:
 - `bibleget-wordpress` — WP plugin
@@ -53,7 +52,7 @@ PRs target `development`.
 ## Operational notes
 - **Bot protection**: User-Agent regex blocks `bot|crawl|slurp|spider`
 - **CORS**: enabled with dynamic origin headers via `AbstractHandler`
-- **Rate limiting**: IP-based, 2-day windows, thresholds 10/30/100 → `TooManyRequestsException`
+- **Rate limiting**: IP-based, 2-day rolling window. Per-IP+query: 11–29 occurrences add a warning to `errors[]` (request still served); ≥30 throws `TooManyRequestsException`. Per-IP across all queries: ≥101 throws. Same Origin+query follows the same warning/throw pattern.
 - **Copyright versions**: enforce 30-verses-per-request limit (e.g. `CEI2008`, `NABRE`, `BLPD`)
 - **Notation**: auto-detect ENGLISH (`John 3:16`) vs EUROPEAN (`Giovanni 3,16`); MIXED is an error
 - **Verse ordering**: uses `verseID` field to handle Greek subverses correctly

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -1,0 +1,59 @@
+# BibleGet I/O Endpoint — Project Overview
+
+**REST API service** for retrieving Bible quotations across multiple versions and languages.
+
+**Production URL**: `https://query.bibleget.io/v3/`
+**Repo**: `BibleGet-I-O/endpoint` on GitHub
+**Note**: the directory and Serena project are named `endpoint` — the actual project is BibleGet I/O.
+
+## Purpose
+Serves the BibleGet WordPress / Google Docs / Microsoft Word / OpenOffice / LibreOffice plugins (and any third-party apps) with:
+- Bible quote retrieval (multiple versions, JSON/XML/HTML output)
+- Metadata (book names in 25+ languages, available versions, chapter/verse indexes)
+- Keyword search
+
+## Versioning
+- v3 is the current/active major version (this repo's main code)
+- v2 still served at `https://query.bibleget.io/v2/` (legacy)
+- Bare `https://query.bibleget.io` URL is being retired so version is always explicit
+
+## Tech Stack
+- **PHP >= 8.2**
+- **PostgreSQL** (via PDO `ext-pdo_pgsql`) — IPs stored as native `inet`, full-text search uses `tsvector`/`tsquery` + GIN
+- **PSR-7** HTTP messages — `nyholm/psr7`
+- **PSR-15** request handlers + middleware — `psr/http-server-handler`, `psr/http-server-middleware`
+- **PSR-17** factories — `nyholm/psr7` (`Psr17Factory`)
+- **PSR-3** logging — `monolog/monolog` (rotating file handler in `logs/`)
+- **PSR-4** autoload — `BibleGet\Api\` → `src/`; tests `BibleGet\Tests\` → `tests/`
+- **RFC 9457** error responses (`application/problem+json`)
+- Response emission — `laminas/laminas-httphandlerrunner` (`SapiEmitter`)
+- Env: `vlucas/phpdotenv`
+- Quality: PHPUnit 11, PHPStan **level 10**, PHP_CodeSniffer (PSR-12 + custom rules), CaptainHook for git hooks
+
+## Architecture mirrors LiturgicalCalendarAPI
+The v3 codebase explicitly follows the same PSR-based architecture as `LiturgicalCalendarAPI` (Router → MiddlewarePipeline → AbstractHandler → response via Negotiator). Familiarity with that codebase carries over here.
+
+## Repo Location
+`/home/johnrdorazio/development/BibleGet-I-O/endpoint`
+
+Sibling repos under `BibleGet-I-O/`:
+- `bibleget-wordpress` — WP plugin
+- `mediawiki-extensions-BibleGet` — MediaWiki extension
+
+## Branches
+- `master` — stable / production
+- `development` — active development
+PRs target `development`.
+
+## CI/CD
+- GitHub Actions:
+  - `.github/workflows/ci.yaml` — runs phpcs + phpstan + tests on PRs
+  - `readme.yaml` — syncs `openapi.json` to ReadMe.io on push to `master`
+
+## Operational notes
+- **Bot protection**: User-Agent regex blocks `bot|crawl|slurp|spider`
+- **CORS**: enabled with dynamic origin headers via `AbstractHandler`
+- **Rate limiting**: IP-based, 2-day windows, thresholds 10/30/100 → `TooManyRequestsException`
+- **Copyright versions**: enforce 30-verses-per-request limit (e.g. `CEI2008`, `NABRE`, `BLPD`)
+- **Notation**: auto-detect ENGLISH (`John 3:16`) vs EUROPEAN (`Giovanni 3,16`); MIXED is an error
+- **Verse ordering**: uses `verseID` field to handle Greek subverses correctly

--- a/.serena/memories/project_structure.md
+++ b/.serena/memories/project_structure.md
@@ -1,7 +1,7 @@
 # Codebase Structure — BibleGet endpoint
 
 ## Top-level layout
-```
+```text
 endpoint/
 ├── public/                # Web entry point (front controller + .htaccess routing)
 ├── src/                   # PHP source (PSR-4: BibleGet\Api\)
@@ -33,13 +33,17 @@ endpoint/
 3. `src/Router.php` parses URL path and dispatches to a PSR-15 handler
 
 ## Routes (v3)
-| Route                          | Handler           | Description                          |
-|--------------------------------|-------------------|--------------------------------------|
-| `/v3/quote`                    | `QuoteHandler`    | Bible quote retrieval (GET/POST)     |
-| `/v3/metadata/biblebooks`      | `MetadataHandler` | Book names in 25+ languages          |
-| `/v3/metadata/bibleversions`   | `MetadataHandler` | Available Bible versions             |
-| `/v3/metadata/versionindex`    | `MetadataHandler` | Chapter/verse indexes for versions   |
-| `/v3/search`                   | `SearchHandler`   | Keyword search                       |
+
+| Route                          | Handler                  | Description                                       |
+|--------------------------------|--------------------------|---------------------------------------------------|
+| `/v3/quote`                    | `QuoteHandler`           | Bible quote retrieval (GET/POST)                  |
+| `/v3/metadata/biblebooks`      | `MetadataHandler`        | Book names in 25+ languages                       |
+| `/v3/metadata/bibleversions`   | `MetadataHandler`        | Available Bible versions                          |
+| `/v3/metadata/versionindex`    | `MetadataHandler`        | Chapter/verse indexes for versions                |
+| `/v3/search/keyword`           | `KeywordSearchHandler`   | Keyword search (text matches)                     |
+| `/v3/search/semantic`          | `SemanticSearchHandler`  | Semantic vector search                            |
+| `/v3/search/similar`           | `SimilarSearchHandler`   | Similarity search                                 |
+| `/v3/search`                   | `SearchHandler`          | Backward-compat alias → `KeywordSearchHandler`    |
 
 ## Middleware pipeline (for every request)
 1. `ErrorHandlingMiddleware` — outermost; converts exceptions → RFC 9457 `problem+json`
@@ -47,7 +51,7 @@ endpoint/
 3. Endpoint-specific PSR-15 handler
 
 ## src/ layout
-```
+```text
 src/
 ├── Router.php
 ├── Handlers/

--- a/.serena/memories/project_structure.md
+++ b/.serena/memories/project_structure.md
@@ -1,0 +1,117 @@
+# Codebase Structure — BibleGet endpoint
+
+## Top-level layout
+```
+endpoint/
+├── public/                # Web entry point (front controller + .htaccess routing)
+├── src/                   # PHP source (PSR-4: BibleGet\Api\)
+├── tests/                 # PHPUnit (PSR-4: BibleGet\Tests\)
+│                          # Suites: Unit, Integration (PostgreSQL), Server (HTTP)
+├── services/              # External / runtime services
+├── migrations/            # DB migrations
+├── scripts/               # Helper scripts
+├── docs/                  # Project docs
+├── .htaccess              # Apache rewrite to public/index.php
+├── docker-compose.yml     # Local dev: PostgreSQL + PHP/Apache
+├── Dockerfile             # Production image
+├── docker-entrypoint.sh
+├── start-server.sh / stop-server.sh / restart-server.sh
+├── composer.json / composer.lock
+├── phpunit.xml.dist
+├── phpstan.neon.dist      # static analysis (level 10)
+├── phpcs.xml              # PSR-12 + custom
+├── captainhook.json       # git hooks
+├── openapi.json           # OpenAPI 3.0.3 spec (synced to ReadMe.io on master push)
+├── redocly.yaml           # OpenAPI lint config
+├── .env.example, .env.test
+└── CLAUDE.md, README.md, LICENSE
+```
+
+## Front controller / routing
+1. `.htaccess` rewrites all requests → `public/index.php`
+2. `public/index.php` instantiates `Router`
+3. `src/Router.php` parses URL path and dispatches to a PSR-15 handler
+
+## Routes (v3)
+| Route                          | Handler           | Description                          |
+|--------------------------------|-------------------|--------------------------------------|
+| `/v3/quote`                    | `QuoteHandler`    | Bible quote retrieval (GET/POST)     |
+| `/v3/metadata/biblebooks`      | `MetadataHandler` | Book names in 25+ languages          |
+| `/v3/metadata/bibleversions`   | `MetadataHandler` | Available Bible versions             |
+| `/v3/metadata/versionindex`    | `MetadataHandler` | Chapter/verse indexes for versions   |
+| `/v3/search`                   | `SearchHandler`   | Keyword search                       |
+
+## Middleware pipeline (for every request)
+1. `ErrorHandlingMiddleware` — outermost; converts exceptions → RFC 9457 `problem+json`
+2. `LoggingMiddleware` — Monolog request/response logging
+3. Endpoint-specific PSR-15 handler
+
+## src/ layout
+```
+src/
+├── Router.php
+├── Handlers/
+│   ├── AbstractHandler.php           # base PSR-15 handler: CORS, validation, content negotiation
+│   ├── QuoteHandler.php              # /v3/quote
+│   ├── MetadataHandler.php           # /v3/metadata/{biblebooks|bibleversions|versionindex}
+│   └── SearchHandler.php             # /v3/search
+├── Pipeline/
+│   ├── QuoteContext.php              # Shared state for quote pipeline
+│   ├── QueryValidator.php            # Validates Bible reference syntax
+│   ├── QueryFormulator.php           # References → SQL
+│   └── QueryExecutor.php             # Runs SQL, rate limit, logging
+├── Http/
+│   ├── Enum/                         # StatusCode, RequestMethod, RequestContentType, AcceptHeader
+│   ├── Exception/                    # ApiException hierarchy (RFC 9457)
+│   ├── Middleware/                   # ErrorHandlingMiddleware, LoggingMiddleware
+│   ├── Server/MiddlewarePipeline.php
+│   └── Logs/LoggerFactory.php        # Monolog factory
+└── Database/Connection.php           # PDO/PostgreSQL singleton (ERRMODE_EXCEPTION, FETCH_ASSOC)
+```
+
+## Quote pipeline flow
+`QuoteHandler` orchestrates:
+`QuoteContext` → `QueryValidator` → `QueryFormulator` → `QueryExecutor`
+
+- **QuoteContext** holds DB connection, metadata, validated queries, results, errors. Replaced the legacy `BIBLEGET_QUOTE` public properties.
+- **QueryValidator** checks notation (ENGLISH vs EUROPEAN), book names, chapter/verse bounds.
+- **QueryFormulator** assembles SQL WHERE clauses.
+- **QueryExecutor** runs SQL, enforces rate limits (`TooManyRequestsException`), logs to `requests_log__YYYY`.
+
+## Database (PostgreSQL)
+- Credentials via env: `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASS` (via `vlucas/phpdotenv`)
+- Singleton in `src/Database/Connection.php`
+- Key tables:
+  - `versions_available` — list of supported versions
+  - `biblebooks_fullname`, `biblebooks_abbr` — book name metadata
+  - `"{VERSION}_idx"` — per-version index (chapter/verse limits)
+  - `"{VERSION}"` — per-version verse text (one table per version)
+  - `requests_log__YYYY` — annual rolling request log
+- IPs stored as native `inet` type
+- Search: `tsvector` + `tsquery` with GIN indexes
+
+## Error handling (RFC 9457)
+All `ApiException` subclasses (in `src/Http/Exception/`) → caught by `ErrorHandlingMiddleware` → returned as:
+```json
+{
+  "type":   "https://datatracker.ietf.org/doc/html/rfc9110#name-...",
+  "title":  "...",
+  "status": 4xx,
+  "detail": "..."
+}
+```
+
+## Response formats
+- JSON (default), XML, HTML
+- Selected via `return` query param OR `Accept` header content negotiation
+- Accept header values: `application/json`, `application/xml`, `text/html`
+
+## Standard request parameters (key ones)
+- `query` *(required, /quote)* — Bible reference (English `John3:16` or European `Giovanni3,16`)
+- `version` — Bible version acronym(s), comma-separated; default `CEI2008`
+- `appid` *(required, /quote)* — application identifier (no real registration; informal tracking)
+- `pluginversion` — calling plugin's version
+- `domain` — calling website's domain
+- `preferorigin` — `GREEK` | `HEBREW` (for OT books with multiple textual traditions, e.g. Esther)
+- `keyword` *(required, /search)*; `exactmatch` (bool); `versions` *(required, /metadata/versionindex)*
+- `return` — `json` | `xml` | `html` (Accept header preferred)

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -1,0 +1,76 @@
+# Suggested Commands — BibleGet endpoint
+
+## First-time setup
+```bash
+composer install                    # install deps
+composer dump-autoload              # regenerate autoloader if needed
+cp .env.example .env                # then edit (DB credentials, etc.)
+vendor/bin/captainhook install -f   # (re)install git hooks
+```
+
+## Local dev with Docker (PostgreSQL + PHP/Apache)
+```bash
+docker compose up -d
+docker compose down
+docker compose logs -f app          # tail app logs
+```
+
+## Local dev with PHP built-in server (requires external PostgreSQL)
+```bash
+php -S localhost:8000 -t public public/router.php
+# Or via shell scripts:
+composer start         # ./start-server.sh
+composer stop          # ./stop-server.sh
+composer restart       # ./restart-server.sh
+```
+
+## Tests (PHPUnit 11)
+```bash
+composer test                     # all suites: Unit + Integration (PostgreSQL) + Server (HTTP)
+composer test:quick               # excludes @group slow
+composer test:coverage            # text + HTML report → coverage/
+```
+
+## Static analysis
+```bash
+composer analyse                  # phpstan analyse — level 10
+```
+
+## Linting
+```bash
+composer lint                     # phpcs (PSR-12 + custom)
+composer lint:fix                 # phpcbf
+composer lint:openapi             # npx @redocly/cli lint openapi.json
+```
+
+## Hitting the API
+```bash
+# Quote
+curl 'http://localhost:8000/v3/quote?query=Mt1,1-5&version=NABRE&appid=local-test'
+
+# Metadata
+curl http://localhost:8000/v3/metadata/biblebooks
+curl http://localhost:8000/v3/metadata/bibleversions
+curl 'http://localhost:8000/v3/metadata/versionindex?versions=NABRE'
+
+# Search
+curl 'http://localhost:8000/v3/search?keyword=light&version=NABRE'
+
+# Set Accept header instead of return param:
+curl -H 'Accept: application/xml' 'http://localhost:8000/v3/quote?query=Mt1,1&appid=local-test'
+```
+
+## Git workflow
+```bash
+git checkout development
+git pull origin development
+git checkout -b feature/your-feature
+# PRs target `development`; `master` is stable/production
+```
+
+## OpenAPI sync
+- Editing `openapi.json` triggers ReadMe.io sync on push to `master` (via `.github/workflows/readme.yaml`).
+- Lint locally first: `composer lint:openapi`.
+
+## System utilities (Linux/WSL2)
+GNU coreutils. Prefer Serena's `find_file`, `search_for_pattern`, `find_symbol` over shell `find`/`grep` inside the repo.

--- a/.serena/memories/task_completion_checklist.md
+++ b/.serena/memories/task_completion_checklist.md
@@ -1,0 +1,56 @@
+# When a Coding Task Is Complete — BibleGet endpoint
+
+Run before declaring done / committing:
+
+1. **Lint**
+   ```bash
+   composer lint:fix    # phpcbf (auto-fix)
+   composer lint        # phpcs verification
+   ```
+
+2. **Static analysis (PHPStan level 10)**
+   ```bash
+   composer analyse
+   ```
+
+3. **Tests (PHPUnit 11)**
+   ```bash
+   composer test            # full: Unit + Integration (PostgreSQL) + Server (HTTP)
+   composer test:quick      # exclude @group slow for fast iteration
+   ```
+
+   Integration suite needs a running PostgreSQL — easiest is `docker compose up -d` first.
+
+4. **OpenAPI lint** (if `openapi.json` changed)
+   ```bash
+   composer lint:openapi
+   ```
+
+5. **Manual smoke test** — start the server and exercise affected route(s):
+   ```bash
+   composer start
+   curl 'http://localhost:8000/v3/quote?query=Mt1,1-5&version=NABRE&appid=local-test'
+   curl http://localhost:8000/v3/metadata/bibleversions
+   composer stop
+   ```
+
+6. **Verify error path** — for changes that touch validation/exceptions, hit a known-bad input and confirm:
+   - Status code is correct
+   - Response is `application/problem+json`
+   - Body has `type`, `title`, `status`, `detail`
+
+7. **For DB schema changes**
+   - Add migration in `migrations/`
+   - Apply locally and run integration tests against the new schema
+   - Document the change in `CLAUDE.md` if it affects the "Key tables" list
+
+## Pre-commit (CaptainHook)
+Will run automatically. Don't `--no-verify`. If a hook fails, fix the issue and create a NEW commit.
+
+## Branch / PR rules
+- Branch off `development`
+- PRs target `development` (NEVER `master` directly)
+- `master` updates trigger ReadMe.io sync of `openapi.json` — be deliberate
+
+## CI
+`.github/workflows/ci.yaml` runs phpcs + phpstan + tests on PRs. Match local results to that pipeline.

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -133,8 +133,12 @@ default_modes:
 
 # initial prompt for the project. It will always be given to the LLM upon activating the project
 # (contrary to the memories, which are loaded on demand).
-initial_prompt: ""
-
+initial_prompt: |
+  - PRs target `development`. NEVER push directly to `master` — master push triggers ReadMe.io sync of `openapi.json`.
+  - Errors: throw `ApiException` subclasses from `src/Http/Exception/`. Let `ErrorHandlingMiddleware` convert them to RFC 9457 `application/problem+json`. Do NOT catch and transform errors at handler level.
+  - Per-version PostgreSQL tables are quoted, case-sensitive identifiers: `"NABRE"`, `"NABRE_idx"`. Keep the double-quotes in raw SQL.
+  - IPs are stored as native PostgreSQL `inet` type — do not quote as plain strings.
+  - PHPStan level 10; pre-commit runs `composer parallel-lint` and `composer analyse`.
 # time budget (seconds) per tool call for the retrieval of additional symbol information
 # such as docstrings or parameter information.
 # This overrides the corresponding setting in the global configuration; see the documentation there.

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,154 @@
+# the name by which the project can be referenced within Serena
+project_name: "endpoint"
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  bash                clojure             cpp                 csharp
+#   csharp_omnisharp    dart                elixir              elm                 erlang
+#   fortran             fsharp              go                  groovy              haskell
+#   haxe                java                julia               kotlin              lua
+#   markdown
+#   matlab              nix                 pascal              perl                php
+#   php_phpactor        powershell          python              python_jedi         r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   swift               terraform           toml                typescript          typescript_vts
+#   vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- php
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+#
+# Below is the complete list of tools for convenience.
+# To make sure you have the latest list of tools, and to view their descriptions, 
+# execute `uv run scripts/print_tool_overview.py`.
+#
+#  * `activate_project`: Activates a project based on the project name or path.
+#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
+#  * `create_text_file`: Creates/overwrites a file in the project directory.
+#  * `delete_memory`: Delete a memory file. Should only happen if a user asks for it explicitly,
+#       for example by saying that the information retrieved from a memory file is no longer correct
+#       or no longer relevant for the project.
+#  * `edit_memory`: Replaces content matching a regular expression in a memory.
+#  * `execute_shell_command`: Executes a shell command.
+#  * `find_file`: Finds files in the given relative paths
+#  * `find_referencing_symbols`: Finds symbols that reference the given symbol using the language server backend
+#  * `find_symbol`: Performs a global (or local) search using the language server backend.
+#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
+#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
+#  * `initial_instructions`: Provides instructions Serena usage (i.e. the 'Serena Instructions Manual')
+#       for clients that do not read the initial instructions when the MCP server is connected.
+#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
+#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
+#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
+#  * `list_memories`: List available memories. Any memory can be read using the `read_memory` tool.
+#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
+#  * `read_file`: Reads a file within the project directory.
+#  * `read_memory`: Read the content of a memory file. This tool should only be used if the information
+#       is relevant to the current task. You can infer whether the information
+#       is relevant from the memory file name.
+#       You should not read the same memory file multiple times in the same conversation.
+#  * `rename_memory`: Renames or moves a memory. Moving between project and global scope is supported
+#       (e.g., renaming "global/foo" to "bar" moves it from global to project scope).
+#  * `rename_symbol`: Renames a symbol throughout the codebase using language server refactoring capabilities.
+#       For JB, we use a separate tool.
+#  * `replace_content`: Replaces content in a file (optionally using regular expressions).
+#  * `replace_symbol_body`: Replaces the full definition of a symbol using the language server backend.
+#  * `safe_delete_symbol`:
+#  * `search_for_pattern`: Performs a search for a pattern in the project.
+#  * `write_memory`: Write some information (utf-8-encoded) about this project that can be useful for future tasks to a memory in md format.
+#       The memory name should be meaningful.
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+fixed_tools: []
+
+# list of mode names to that are always to be included in the set of active modes
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the base_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this setting overrides the global configuration.
+# Set this to [] to disable base modes for this project.
+# Set this to a list of mode names to always include the respective modes for this project.
+base_modes:
+
+# list of mode names that are to be activated by default.
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+default_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []


### PR DESCRIPTION
## Summary

- Commit Serena MCP memory files generated by onboarding
- Add `.worktrees/` to `.gitignore` (project-local git worktrees convention)

## Why

Serena's `.serena/memories/*.md` files capture project-specific knowledge — overview, structure, suggested commands, code style, and a task-completion checklist — that Serena writes during onboarding. Committing these means:

- Fresh checkouts and new worktrees activate the project with full context immediately
- Teammates using Serena MCP share the same baseline knowledge
- No per-machine, per-branch re-onboarding overhead

## Files

- `.serena/memories/project_overview.md`
- `.serena/memories/project_structure.md`
- `.serena/memories/suggested_commands.md`
- `.serena/memories/code_style_and_conventions.md`
- `.serena/memories/task_completion_checklist.md`

Serena's inner `.serena/.gitignore` (already present in the .serena directory and not part of this PR) excludes `cache/` and `project.local.yml` automatically, so transient state never gets committed.

## Test plan

- [ ] CI is green
- [ ] `git status` shows clean tree after merge (no untracked `.serena/` paths showing as needing commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive project documentation covering API behavior, architecture, coding standards, workflow checklists, and recommended commands for development and testing.

* **Chores**
  * Updated git ignore rules to exclude local worktree, cache, and local config files.
  * Added project configuration for tooling, quality gates, and workflow defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->