### PR TITLE
Add rank=relevance ordering to keyword search via ts_rank_cd

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -475,6 +475,20 @@
                         }
                     },
                     {
+                        "name": "rank",
+                        "in": "query",
+                        "description": "Result ordering strategy. `canonical` (default) returns results in book/chapter/verse order, preserving legacy behavior. `relevance` orders by PostgreSQL `ts_rank_cd` cover-density score (highest first), tie-broken by canonical order. With `exactmatch=true` the parameter is accepted but ordering remains canonical.",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "canonical",
+                                "relevance"
+                            ],
+                            "default": "canonical"
+                        }
+                    },
+                    {
                         "name": "return",
                         "in": "query",
                         "description": "Type of data that should be returned in the response",
@@ -661,6 +675,20 @@
                                 "boolean"
                             ],
                             "default": "fulltext"
+                        }
+                    },
+                    {
+                        "name": "rank",
+                        "in": "query",
+                        "description": "Result ordering strategy. `canonical` (default) returns results in book/chapter/verse order, preserving legacy behavior. `relevance` orders by PostgreSQL `ts_rank_cd` cover-density score (highest first), tie-broken by canonical order. Only `match=fulltext` and `match=boolean` produce a relevance score; with `match=exact` the parameter is accepted but ordering remains canonical.",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "canonical",
+                                "relevance"
+                            ],
+                            "default": "canonical"
                         }
                     },
                     {

--- a/src/Handlers/KeywordSearchHandler.php
+++ b/src/Handlers/KeywordSearchHandler.php
@@ -19,6 +19,8 @@ class KeywordSearchHandler extends AbstractHandler
 
     private const VALID_MATCH_MODES = ['fulltext', 'exact', 'boolean'];
 
+    private const VALID_RANK_MODES = ['canonical', 'relevance'];
+
     /** @var list<string>|null */
     private static ?array $cachedValidVersions = null;
 
@@ -51,14 +53,14 @@ class KeywordSearchHandler extends AbstractHandler
         $contentType = $this->resolveResponseContentType($request, $params);
         $response    = $this->initResponse($request, $contentType);
 
-        [$keyword, $version, $matchMode] = $this->extractSearchParams($params);
+        [$keyword, $version, $matchMode, $rankMode] = $this->extractSearchParams($params);
 
         $pdo          = Connection::getConnection();
         $version      = $this->validateVersion($pdo, $version);
         $tsLanguage   = $this->getVersionLanguage($pdo, $version);
         $versionIndex = $this->loadVersionIndex($pdo, $version);
 
-        $searchResult = $this->executeSearch($pdo, $version, $keyword, $matchMode, $tsLanguage);
+        $searchResult = $this->executeSearch($pdo, $version, $keyword, $matchMode, $tsLanguage, $rankMode);
         $results      = $this->mapSearchResults($searchResult, $version, $versionIndex);
 
         $body          = new \stdClass();
@@ -72,7 +74,7 @@ class KeywordSearchHandler extends AbstractHandler
 
     /**
      * @param array<string, mixed> $params
-     * @return array{string, string, string}
+     * @return array{string, string, string, string}
      */
     private function extractSearchParams(array $params): array
     {
@@ -96,6 +98,10 @@ class KeywordSearchHandler extends AbstractHandler
             $match = $exactmatch ? 'exact' : 'fulltext';
         }
 
+        // Resolve rank mode: default `canonical` preserves legacy book/chapter/verse ordering
+        $rankRaw = $params['rank'] ?? '';
+        $rank    = is_string($rankRaw) && $rankRaw !== '' ? strtolower($rankRaw) : 'canonical';
+
         if ($keyword === '') {
             throw new ValidationException('The keyword parameter is required.');
         }
@@ -107,8 +113,13 @@ class KeywordSearchHandler extends AbstractHandler
                 'Invalid match mode: ' . $match . '. Valid modes are: ' . implode(', ', self::VALID_MATCH_MODES)
             );
         }
+        if (!in_array($rank, self::VALID_RANK_MODES, true)) {
+            throw new ValidationException(
+                'Invalid rank mode: ' . $rank . '. Valid modes are: ' . implode(', ', self::VALID_RANK_MODES)
+            );
+        }
 
-        return [$keyword, $version, $match];
+        return [$keyword, $version, $match, $rank];
     }
 
     private function validateVersion(\PDO $pdo, string $version): string
@@ -187,7 +198,8 @@ class KeywordSearchHandler extends AbstractHandler
         string $version,
         string $keyword,
         string $matchMode,
-        string $tsLanguage
+        string $tsLanguage,
+        string $rankMode = 'canonical'
     ): \PDOStatement {
         $this->assertValidVersionFormat($version);
 
@@ -198,7 +210,9 @@ class KeywordSearchHandler extends AbstractHandler
 
         switch ($matchMode) {
             case 'exact':
-                // Escape PostgreSQL regex metacharacters so the keyword is matched literally
+                // Regex match has no native relevance signal, so rank=relevance silently
+                // falls back to canonical order here (match=exact + rank=relevance is accepted
+                // for client convenience but produces the same ordering as rank=canonical).
                 $escapedKeyword = preg_replace('/([.*+?^${}()|[\]\\\\])/', '\\\\\\1', $keyword) ?? $keyword;
                 try {
                     $stmt = $pdo->prepare(
@@ -219,11 +233,15 @@ class KeywordSearchHandler extends AbstractHandler
                         'Search keyword must be at least 4 characters long (use match=exact for shorter keywords).'
                     );
                 }
+                $orderBy = $rankMode === 'relevance'
+                    ? 'ORDER BY ts_rank_cd(to_tsvector(\'' . $tsLanguage . '\', text), to_tsquery(\'' . $tsLanguage . '\', ?)) DESC, book, chapter, verse'
+                    : 'ORDER BY book, chapter, verse';
                 try {
                     $stmt = $pdo->prepare(
-                        'SELECT * FROM "' . $version . '" WHERE to_tsvector(\'' . $tsLanguage . '\', text) @@ to_tsquery(\'' . $tsLanguage . '\', ?) ORDER BY book, chapter, verse'
+                        'SELECT * FROM "' . $version . '" WHERE to_tsvector(\'' . $tsLanguage . '\', text) @@ to_tsquery(\'' . $tsLanguage . '\', ?) ' . $orderBy
                     );
-                    $stmt->execute([$keyword]);
+                    $bindings = $rankMode === 'relevance' ? [$keyword, $keyword] : [$keyword];
+                    $stmt->execute($bindings);
                 } catch (\PDOException) {
                     throw new ValidationException(
                         'Invalid boolean search expression. Use operators like & (AND), | (OR), ! (NOT).'
@@ -238,11 +256,15 @@ class KeywordSearchHandler extends AbstractHandler
                         'Search keyword must be at least 4 characters long (use match=exact for shorter keywords).'
                     );
                 }
+                $orderBy = $rankMode === 'relevance'
+                    ? 'ORDER BY ts_rank_cd(to_tsvector(\'' . $tsLanguage . '\', text), websearch_to_tsquery(\'' . $tsLanguage . '\', ?)) DESC, book, chapter, verse'
+                    : 'ORDER BY book, chapter, verse';
                 try {
                     $stmt = $pdo->prepare(
-                        'SELECT * FROM "' . $version . '" WHERE to_tsvector(\'' . $tsLanguage . '\', text) @@ websearch_to_tsquery(\'' . $tsLanguage . '\', ?) ORDER BY book, chapter, verse'
+                        'SELECT * FROM "' . $version . '" WHERE to_tsvector(\'' . $tsLanguage . '\', text) @@ websearch_to_tsquery(\'' . $tsLanguage . '\', ?) ' . $orderBy
                     );
-                    $stmt->execute([$sanitizedKeyword]);
+                    $bindings = $rankMode === 'relevance' ? [$sanitizedKeyword, $sanitizedKeyword] : [$sanitizedKeyword];
+                    $stmt->execute($bindings);
                 } catch (\PDOException) {
                     throw new ValidationException(
                         'Full-text search failed. Please try a different keyword.'

--- a/src/Handlers/KeywordSearchHandler.php
+++ b/src/Handlers/KeywordSearchHandler.php
@@ -237,7 +237,7 @@ class KeywordSearchHandler extends AbstractHandler
                     ? 'ORDER BY ts_rank_cd(to_tsvector(\'' . $tsLanguage . '\', text), to_tsquery(\'' . $tsLanguage . '\', ?)) DESC, book, chapter, verse'
                     : 'ORDER BY book, chapter, verse';
                 try {
-                    $stmt = $pdo->prepare(
+                    $stmt     = $pdo->prepare(
                         'SELECT * FROM "' . $version . '" WHERE to_tsvector(\'' . $tsLanguage . '\', text) @@ to_tsquery(\'' . $tsLanguage . '\', ?) ' . $orderBy
                     );
                     $bindings = $rankMode === 'relevance' ? [$keyword, $keyword] : [$keyword];
@@ -260,7 +260,7 @@ class KeywordSearchHandler extends AbstractHandler
                     ? 'ORDER BY ts_rank_cd(to_tsvector(\'' . $tsLanguage . '\', text), websearch_to_tsquery(\'' . $tsLanguage . '\', ?)) DESC, book, chapter, verse'
                     : 'ORDER BY book, chapter, verse';
                 try {
-                    $stmt = $pdo->prepare(
+                    $stmt     = $pdo->prepare(
                         'SELECT * FROM "' . $version . '" WHERE to_tsvector(\'' . $tsLanguage . '\', text) @@ websearch_to_tsquery(\'' . $tsLanguage . '\', ?) ' . $orderBy
                     );
                     $bindings = $rankMode === 'relevance' ? [$sanitizedKeyword, $sanitizedKeyword] : [$sanitizedKeyword];

--- a/tests/Integration/Handlers/KeywordSearchHandlerTest.php
+++ b/tests/Integration/Handlers/KeywordSearchHandlerTest.php
@@ -173,7 +173,7 @@ class KeywordSearchHandlerTest extends DatabaseTestCase
     {
         $handler = $this->createHandler();
 
-        $defaultReq = ( new ServerRequest('GET', '/v3/search/keyword') )
+        $defaultReq  = ( new ServerRequest('GET', '/v3/search/keyword') )
             ->withQueryParams(['keyword' => 'light', 'version' => 'TEST1']);
         $explicitReq = ( new ServerRequest('GET', '/v3/search/keyword') )
             ->withQueryParams(['keyword' => 'light', 'version' => 'TEST1', 'rank' => 'canonical']);
@@ -221,21 +221,36 @@ class KeywordSearchHandlerTest extends DatabaseTestCase
     {
         // rank=relevance is accepted (not rejected) with match=exact for client convenience,
         // but exact-mode results are silently kept in canonical order since regex has no
-        // native relevance signal. This guards against a future "throw on combo" regression.
-        $handler  = $this->createHandler();
-        $request  = ( new ServerRequest('GET', '/v3/search/keyword') )
-            ->withQueryParams([
-                'keyword' => 'God',
-                'version' => 'TEST1',
-                'match'   => 'exact',
-                'rank'    => 'relevance',
-            ]);
-        $response = $handler->handle($request);
+        // native relevance signal. This guards against a future "throw on combo" regression
+        // and verifies the silent-fallback contract: rank is ignored for match=exact.
+        $handler         = $this->createHandler();
+        $relevanceParams = [
+            'keyword' => 'God',
+            'version' => 'TEST1',
+            'match'   => 'exact',
+            'rank'    => 'relevance',
+        ];
+        $canonicalParams = ['rank' => 'canonical'] + $relevanceParams;
 
-        self::assertSame(200, $response->getStatusCode());
-        $body = json_decode((string) $response->getBody(), true);
-        self::assertIsArray($body);
-        self::assertNotEmpty($body['results']);
+        $relevanceReq = ( new ServerRequest('GET', '/v3/search/keyword') )->withQueryParams($relevanceParams);
+        $canonicalReq = ( new ServerRequest('GET', '/v3/search/keyword') )->withQueryParams($canonicalParams);
+
+        $relevanceRes = $handler->handle($relevanceReq);
+        $canonicalRes = $handler->handle($canonicalReq);
+
+        self::assertSame(200, $relevanceRes->getStatusCode());
+        self::assertSame(200, $canonicalRes->getStatusCode());
+
+        $relevanceBody = json_decode((string) $relevanceRes->getBody(), true);
+        $canonicalBody = json_decode((string) $canonicalRes->getBody(), true);
+        self::assertIsArray($relevanceBody);
+        self::assertIsArray($canonicalBody);
+        self::assertNotEmpty($relevanceBody['results']);
+        self::assertSame(
+            $canonicalBody['results'],
+            $relevanceBody['results'],
+            'Exact mode must ignore rank: relevance and canonical results should be identical'
+        );
     }
 
     public function testInvalidRankModeThrows(): void

--- a/tests/Integration/Handlers/KeywordSearchHandlerTest.php
+++ b/tests/Integration/Handlers/KeywordSearchHandlerTest.php
@@ -145,6 +145,109 @@ class KeywordSearchHandlerTest extends DatabaseTestCase
         }
     }
 
+    // ── Rank ordering ───────────────────────────────────────
+
+    public function testDefaultRankIsCanonicalBookChapterVerse(): void
+    {
+        // No rank param → canonical (book, chapter, verse) order, matching legacy behavior.
+        $handler  = $this->createHandler();
+        $request  = ( new ServerRequest('GET', '/v3/search/keyword') )
+            ->withQueryParams(['keyword' => 'light', 'version' => 'TEST1']);
+        $response = $handler->handle($request);
+
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($body);
+        self::assertNotEmpty($body['results']);
+
+        $previous = null;
+        foreach ($body['results'] as $verse) {
+            $current = [(int) $verse['booknum'], (int) $verse['chapter'], (int) $verse['verse']];
+            if ($previous !== null) {
+                self::assertGreaterThanOrEqual(0, $current <=> $previous, 'Default ordering must be canonical');
+            }
+            $previous = $current;
+        }
+    }
+
+    public function testExplicitRankCanonicalMatchesDefault(): void
+    {
+        $handler = $this->createHandler();
+
+        $defaultReq = ( new ServerRequest('GET', '/v3/search/keyword') )
+            ->withQueryParams(['keyword' => 'light', 'version' => 'TEST1']);
+        $explicitReq = ( new ServerRequest('GET', '/v3/search/keyword') )
+            ->withQueryParams(['keyword' => 'light', 'version' => 'TEST1', 'rank' => 'canonical']);
+
+        $defaultBody  = json_decode((string) $handler->handle($defaultReq)->getBody(), true);
+        $explicitBody = json_decode((string) $handler->handle($explicitReq)->getBody(), true);
+
+        self::assertIsArray($defaultBody);
+        self::assertIsArray($explicitBody);
+        self::assertSame($defaultBody['results'], $explicitBody['results']);
+    }
+
+    public function testRankRelevanceReturnsResults(): void
+    {
+        $handler  = $this->createHandler();
+        $request  = ( new ServerRequest('GET', '/v3/search/keyword') )
+            ->withQueryParams(['keyword' => 'light', 'version' => 'TEST1', 'rank' => 'relevance']);
+        $response = $handler->handle($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($body);
+        self::assertNotEmpty($body['results']);
+    }
+
+    public function testRankRelevanceWithBooleanModeReturnsResults(): void
+    {
+        $handler  = $this->createHandler();
+        $request  = ( new ServerRequest('GET', '/v3/search/keyword') )
+            ->withQueryParams([
+                'keyword' => 'light & good',
+                'version' => 'TEST1',
+                'match'   => 'boolean',
+                'rank'    => 'relevance',
+            ]);
+        $response = $handler->handle($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($body);
+        self::assertNotEmpty($body['results']);
+    }
+
+    public function testRankRelevanceAcceptedWithExactMode(): void
+    {
+        // rank=relevance is accepted (not rejected) with match=exact for client convenience,
+        // but exact-mode results are silently kept in canonical order since regex has no
+        // native relevance signal. This guards against a future "throw on combo" regression.
+        $handler  = $this->createHandler();
+        $request  = ( new ServerRequest('GET', '/v3/search/keyword') )
+            ->withQueryParams([
+                'keyword' => 'God',
+                'version' => 'TEST1',
+                'match'   => 'exact',
+                'rank'    => 'relevance',
+            ]);
+        $response = $handler->handle($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($body);
+        self::assertNotEmpty($body['results']);
+    }
+
+    public function testInvalidRankModeThrows(): void
+    {
+        $handler = $this->createHandler();
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Invalid rank mode');
+        $request = ( new ServerRequest('GET', '/v3/search/keyword') )
+            ->withQueryParams(['keyword' => 'light', 'version' => 'TEST1', 'rank' => 'magic']);
+        $handler->handle($request);
+    }
+
     // ── Legacy backward compatibility ───────────────────────
 
     public function testLegacyExactmatchParamMapsToExactMode(): void


### PR DESCRIPTION
## Summary

Adds an optional `rank` query parameter to `/v3/search/keyword` (and the legacy `/v3/search` alias) that switches result ordering from canonical book/chapter/verse to PostgreSQL `ts_rank_cd` cover-density score. Default is `canonical`, so every existing client sees identical responses.

Motivated by the closed planning issue #62. A future hybrid search endpoint that fuses keyword and semantic results with reciprocal rank fusion needs each retriever to actually produce a *relevance* rank. Today the keyword retriever returns rows in canonical order regardless of how well they match, so RRF would treat Genesis 1:1 as the most-relevant keyword hit purely by virtue of position. This PR is the smallest unit of work that unblocks that direction.

## Behavior

| `rank` | `match=fulltext` | `match=boolean` | `match=exact` |
|---|---|---|---|
| `canonical` (default) | book/ch/v | book/ch/v | book/ch/v |
| `relevance` | `ts_rank_cd` DESC, then book/ch/v | `ts_rank_cd` DESC, then book/ch/v | book/ch/v (no native relevance score; param accepted but ordering unchanged) |

`ts_rank_cd` (cover-density) was chosen over `ts_rank` because verses are short and term position matters: cover-density scores a hit higher when matched lexemes appear close together in the text. Tie-broken by canonical order so the result set is deterministic.

## SQL safety

- The `tsLanguage` value is constrained to `^[a-z]+$` upstream; reusing it in the new `ORDER BY ts_rank_cd(...)` clause does not widen the existing safe-identifier guarantee.
- The keyword is bound twice as a prepared parameter (once in the WHERE `tsquery`, once in the ORDER BY `tsquery`). No string concatenation of user input.
- ETags are content-derived, so different ranking yields a different ETag automatically; cache headers need no Vary changes.

## Backward compatibility

- No default behavior change. `/v3/search` (legacy alias) is byte-identical for existing clients.
- The legacy `exactmatch=true` path still maps to `match=exact` and ignores `rank` ordering.
- The new `rank` parameter is additive: omitting it preserves canonical ordering.

## Test plan

Six new integration tests in `tests/Integration/Handlers/KeywordSearchHandlerTest.php`:

- [x] `testDefaultRankIsCanonicalBookChapterVerse` - default ordering is canonical
- [x] `testExplicitRankCanonicalMatchesDefault` - `rank=canonical` matches default byte-for-byte
- [x] `testRankRelevanceReturnsResults` - fulltext + relevance returns results
- [x] `testRankRelevanceWithBooleanModeReturnsResults` - boolean + relevance returns results
- [x] `testRankRelevanceAcceptedWithExactMode` - exact + relevance is accepted (silently canonical)
- [x] `testInvalidRankModeThrows` - unknown rank value throws ValidationException

## OpenAPI

`rank` parameter added to `/search/keyword` and `/search` paths with description, enum, and default.

## Out of scope / follow-ups

- Hybrid search endpoint (`/v3/search/hybrid` with reciprocal rank fusion across keyword + semantic) - depends on this PR landing first.
- Possibly flipping the default to `relevance` after a soak window, behind a separate decision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search endpoints now accept an optional `rank` parameter to control result ordering: `canonical` (default, preserves book/chapter/verse order) or `relevance` (orders by computed relevance; ignored for exact-match mode).

* **Tests**
  * Added integration tests covering default/canonical behavior, relevance ordering for fulltext/boolean matches, acceptance with exact match, and invalid-`rank` validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->