### PR TITLE
ci: add deploy workflow for staging and production

### DIFF
--- a/.github/deploy/rsync-exclude.txt
+++ b/.github/deploy/rsync-exclude.txt
@@ -1,0 +1,59 @@
+# Patterns excluded from `rsync --delete` deploys.
+#
+# These patterns serve two purposes:
+#   1. Files matched here are NOT transferred from the runner.
+#   2. Files matched here are NOT removed on the destination by --delete.
+#
+# Anything that should live only on the server (env files, runtime logs,
+# server-managed state) MUST be listed here so it isn't wiped on deploy.
+
+# --- VCS / CI / agent metadata ---
+.git/
+.github/
+.gitignore
+.gitattributes
+.serena/
+.worktrees/
+.claude/
+
+# --- IDE / local tooling ---
+.vscode/
+.idea/
+.phpunit.cache/
+.phpcs.cache
+
+# --- Tests, coverage, dev-only sources ---
+tests/
+coverage/
+docs/
+
+# --- Build / dev configuration that has no runtime role ---
+phpcs.xml
+phpcs.xml.dist
+phpstan.neon
+phpstan.neon.dist
+phpunit.xml
+phpunit.xml.dist
+captainhook.json
+redocly.yaml
+docker-compose.yml
+docker-compose.yaml
+Dockerfile
+docker-entrypoint.sh
+.dockerignore
+
+# --- Local dev scripts (not used in production) ---
+start-server.sh
+stop-server.sh
+restart-server.sh
+server.pid
+server.vscode.pid
+
+# --- Project meta files (optional; comment out to deploy them) ---
+CLAUDE.md
+
+# --- SERVER-MANAGED FILES (never overwrite, never --delete) ---
+.env
+.env.*
+dbcredentials.php
+logs/

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,6 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: ${{ github.event_name == 'release' && 'production' || inputs.target }}
+    permissions:
+      contents: read
 
     steps:
       - name: Resolve ref and deploy path
@@ -119,12 +121,13 @@ jobs:
           DEPLOY_PATH: ${{ steps.params.outputs.deploy_path }}
         run: |
           set -euo pipefail
+          remote_cmd="mkdir -p $(printf '%q' "${DEPLOY_PATH}")"
           ssh -i ~/.ssh/deploy_key -p "${VPS_PORT}" \
             -o IdentitiesOnly=yes \
             -o StrictHostKeyChecking=yes \
             -o UserKnownHostsFile=~/.ssh/known_hosts \
             "${VPS_USER}@${VPS_HOST}" \
-            "mkdir -p \"${DEPLOY_PATH}\""
+            "${remote_cmd}"
 
       - name: Deploy via rsync
         env:
@@ -137,7 +140,7 @@ jobs:
           rsync \
             --archive --no-owner --no-group \
             --compress --human-readable --verbose \
-            --delete \
+            --delete --protect-args \
             --exclude-from=.github/deploy/rsync-exclude.txt \
             -e "ssh -i ~/.ssh/deploy_key -p ${VPS_PORT} -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts" \
             ./ "${VPS_USER}@${VPS_HOST}:${DEPLOY_PATH%/}/"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,128 @@
+name: Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Deployment target'
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+        default: staging
+      tag:
+        description: 'Release tag (production only, e.g. v5.0 or v5.1.2). Ignored for staging.'
+        required: false
+        type: string
+
+concurrency:
+  group: deploy-${{ inputs.target }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy ${{ inputs.target }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: ${{ inputs.target }}
+
+    steps:
+      - name: Resolve ref and deploy path
+        id: params
+        env:
+          TARGET: ${{ inputs.target }}
+          TAG: ${{ inputs.tag }}
+          APP_DIR: ${{ vars.VPS_APP_DIR }}
+        run: |
+          set -euo pipefail
+          if [ -z "${APP_DIR}" ]; then
+            echo "::error::Repository variable VPS_APP_DIR is not set." >&2
+            exit 1
+          fi
+          if [ "${TARGET}" = "production" ]; then
+            if [ -z "${TAG}" ]; then
+              echo "::error::tag input is required for production deploys (e.g. v5.0)." >&2
+              exit 1
+            fi
+            if ! printf '%s' "${TAG}" | grep -qE '^v[0-9]+\.[0-9]+(\.[0-9]+)?(-[A-Za-z0-9.-]+)?$'; then
+              echo "::error::tag must match v<MAJOR>.<MINOR>(.<PATCH>)?(-prerelease)? - got: ${TAG}" >&2
+              exit 1
+            fi
+            MAJOR=$(printf '%s' "${TAG}" | sed -E 's/^v([0-9]+)\..*/\1/')
+            REF="${TAG}"
+            SUBDIR="v${MAJOR}"
+          else
+            REF="development"
+            SUBDIR="dev"
+          fi
+          DEPLOY_PATH="${APP_DIR%/}/${SUBDIR}"
+          {
+            echo "ref=${REF}"
+            echo "deploy_subdir=${SUBDIR}"
+            echo "deploy_path=${DEPLOY_PATH}"
+          } >> "${GITHUB_OUTPUT}"
+          echo "::notice::Deploying ${TARGET}: ref=${REF} -> ${DEPLOY_PATH}"
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ steps.params.outputs.ref }}
+          persist-credentials: false
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
+        with:
+          php-version: '8.4'
+          extensions: pdo_pgsql, json, simplexml, dom
+          tools: composer:v2
+          coverage: none
+
+      - name: Install production dependencies
+        run: composer install --no-dev --optimize-autoloader --no-interaction --no-progress --prefer-dist
+
+      - name: Configure SSH
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.VPS_SSH_PRIVATE_KEY }}
+          SSH_KNOWN_HOSTS: ${{ vars.VPS_SSH_KNOWN_HOSTS }}
+        run: |
+          install -d -m 700 ~/.ssh
+          printf '%s\n' "${SSH_PRIVATE_KEY}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          printf '%s\n' "${SSH_KNOWN_HOSTS}" > ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Ensure deploy directory exists
+        env:
+          VPS_USER: ${{ secrets.VPS_USERNAME }}
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_PORT: ${{ vars.VPS_SSH_PORT || '22' }}
+          DEPLOY_PATH: ${{ steps.params.outputs.deploy_path }}
+        run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/deploy_key -p "${VPS_PORT}" \
+            -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile=~/.ssh/known_hosts \
+            "${VPS_USER}@${VPS_HOST}" \
+            "mkdir -p \"${DEPLOY_PATH}\""
+
+      - name: Deploy via rsync
+        env:
+          VPS_USER: ${{ secrets.VPS_USERNAME }}
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_PORT: ${{ vars.VPS_SSH_PORT || '22' }}
+          DEPLOY_PATH: ${{ steps.params.outputs.deploy_path }}
+        run: |
+          set -euo pipefail
+          rsync \
+            --archive --no-owner --no-group \
+            --compress --human-readable --verbose \
+            --delete \
+            --exclude-from=.github/deploy/rsync-exclude.txt \
+            -e "ssh -i ~/.ssh/deploy_key -p ${VPS_PORT} -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts" \
+            ./ "${VPS_USER}@${VPS_HOST}:${DEPLOY_PATH%/}/"
+
+      - name: Clean up SSH key
+        if: always()
+        run: rm -f ~/.ssh/deploy_key

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,24 +15,29 @@ on:
         description: 'Release tag (production only, e.g. v5.0 or v5.1.2). Ignored for staging.'
         required: false
         type: string
+  release:
+    types: [published]
 
 concurrency:
-  group: deploy-${{ inputs.target }}
+  group: deploy-${{ github.event_name == 'release' && 'production' || inputs.target }}
   cancel-in-progress: false
 
 jobs:
   deploy:
-    name: Deploy ${{ inputs.target }}
+    name: Deploy ${{ github.event_name == 'release' && 'production' || inputs.target }}
+    if: github.event_name != 'release' || github.event.release.prerelease == false
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    environment: ${{ inputs.target }}
+    environment: ${{ github.event_name == 'release' && 'production' || inputs.target }}
 
     steps:
       - name: Resolve ref and deploy path
         id: params
         env:
-          TARGET: ${{ inputs.target }}
-          TAG: ${{ inputs.tag }}
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TARGET: ${{ inputs.target }}
+          INPUT_TAG: ${{ inputs.tag }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
           APP_DIR: ${{ vars.VPS_APP_DIR }}
         run: |
           set -euo pipefail
@@ -40,9 +45,23 @@ jobs:
             echo "::error::Repository variable VPS_APP_DIR is not set." >&2
             exit 1
           fi
+          case "${EVENT_NAME}" in
+            release)
+              TARGET="production"
+              TAG="${RELEASE_TAG}"
+              ;;
+            workflow_dispatch)
+              TARGET="${INPUT_TARGET}"
+              TAG="${INPUT_TAG}"
+              ;;
+            *)
+              echo "::error::Unsupported event: ${EVENT_NAME}" >&2
+              exit 1
+              ;;
+          esac
           if [ "${TARGET}" = "production" ]; then
             if [ -z "${TAG}" ]; then
-              echo "::error::tag input is required for production deploys (e.g. v5.0)." >&2
+              echo "::error::tag is required for production deploys (e.g. v5.0)." >&2
               exit 1
             fi
             if ! printf '%s' "${TAG}" | grep -qE '^v[0-9]+\.[0-9]+(\.[0-9]+)?(-[A-Za-z0-9.-]+)?$'; then

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -105,13 +105,63 @@ jobs:
       - name: Configure SSH
         env:
           SSH_PRIVATE_KEY: ${{ secrets.VPS_SSH_PRIVATE_KEY }}
-          SSH_KNOWN_HOSTS: ${{ vars.VPS_SSH_KNOWN_HOSTS }}
+          SSH_KNOWN_HOSTS: ${{ secrets.VPS_SSH_KNOWN_HOSTS }}
         run: |
+          set -euo pipefail
+          if [ -z "${SSH_KNOWN_HOSTS}" ]; then
+            echo "::error::Secret VPS_SSH_KNOWN_HOSTS is empty. Refusing to deploy without a pinned host key." >&2
+            exit 1
+          fi
           install -d -m 700 ~/.ssh
           printf '%s\n' "${SSH_PRIVATE_KEY}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
           printf '%s\n' "${SSH_KNOWN_HOSTS}" > ~/.ssh/known_hosts
           chmod 644 ~/.ssh/known_hosts
+
+      - name: Sanity-check pinned host key against DNS SSHFP records
+        env:
+          SSH_KNOWN_HOSTS: ${{ secrets.VPS_SSH_KNOWN_HOSTS }}
+          SSHFP_HOST: ${{ secrets.VPS_HOST }}
+        run: |
+          set -euo pipefail
+          if ! command -v dig >/dev/null; then
+            echo "::warning::dig not available; skipping SSHFP drift check."
+            exit 0
+          fi
+          PIN_FPS=$(printf '%s\n' "${SSH_KNOWN_HOSTS}" \
+            | awk '$2 ~ /^(ssh-|ecdsa-)/' \
+            | while read -r _host _alg keyb64 _; do
+                printf '%s' "$keyb64" | base64 -d 2>/dev/null | sha256sum | awk '{print toupper($1)}'
+              done \
+            | sort -u)
+          DNS_FPS=$(dig +short SSHFP "${SSHFP_HOST}" \
+            | awk '$2 == "2" {for (i=3; i<=NF; i++) printf "%s", $i; print ""}' \
+            | tr -d ' ' \
+            | tr 'a-f' 'A-F' \
+            | sort -u)
+          if [ -z "${DNS_FPS}" ]; then
+            echo "::warning::No SHA-256 SSHFP records found for ${SSHFP_HOST}; skipping drift check."
+            exit 0
+          fi
+          if [ -z "${PIN_FPS}" ]; then
+            echo "::warning::Could not derive any fingerprints from VPS_SSH_KNOWN_HOSTS; skipping drift check."
+            exit 0
+          fi
+          PIN_NOT_IN_DNS=$(comm -23 <(echo "${PIN_FPS}") <(echo "${DNS_FPS}"))
+          DNS_NOT_IN_PIN=$(comm -13 <(echo "${PIN_FPS}") <(echo "${DNS_FPS}"))
+          if [ -n "${PIN_NOT_IN_DNS}" ]; then
+            while IFS= read -r fp; do
+              echo "::warning::Pinned key SHA256:${fp} not in DNS SSHFP for ${SSHFP_HOST}. DNS may lag reality, or VPS_SSH_KNOWN_HOSTS is stale."
+            done <<< "${PIN_NOT_IN_DNS}"
+          fi
+          if [ -n "${DNS_NOT_IN_PIN}" ]; then
+            while IFS= read -r fp; do
+              echo "::warning::DNS SSHFP advertises SHA256:${fp} not present in VPS_SSH_KNOWN_HOSTS. Server may have rotated; consider re-pinning."
+            done <<< "${DNS_NOT_IN_PIN}"
+          fi
+          if [ -z "${PIN_NOT_IN_DNS}" ] && [ -z "${DNS_NOT_IN_PIN}" ]; then
+            echo "Pin matches DNS SSHFP records."
+          fi
 
       - name: Ensure deploy directory exists
         env:
@@ -126,6 +176,9 @@ jobs:
             -o IdentitiesOnly=yes \
             -o StrictHostKeyChecking=yes \
             -o UserKnownHostsFile=~/.ssh/known_hosts \
+            -o ConnectTimeout=10 \
+            -o ServerAliveInterval=15 \
+            -o ServerAliveCountMax=2 \
             "${VPS_USER}@${VPS_HOST}" \
             "${remote_cmd}"
 
@@ -142,7 +195,7 @@ jobs:
             --compress --human-readable --verbose \
             --delete --protect-args \
             --exclude-from=.github/deploy/rsync-exclude.txt \
-            -e "ssh -i ~/.ssh/deploy_key -p ${VPS_PORT} -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts" \
+            -e "ssh -i ~/.ssh/deploy_key -p ${VPS_PORT} -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts -o ConnectTimeout=10 -o ServerAliveInterval=15 -o ServerAliveCountMax=2" \
             ./ "${VPS_USER}@${VPS_HOST}:${DEPLOY_PATH%/}/"
 
       - name: Clean up SSH key


### PR DESCRIPTION
## Summary

- New deploy workflow at `.github/workflows/deploy.yaml` with two triggers: `workflow_dispatch` (manual) and `release: published` (auto). On manual runs you pick `target: staging` or `target: production`; production additionally requires a `tag` input (e.g. `v5.0`, `v5.1.2`). On release publish, the deploy is automatically scoped to production and uses the release's tag.
- Prereleases are skipped by the auto-deploy guard (`if: github.event.release.prerelease == false`); they remain manually deployable via workflow_dispatch.
- Staging deploys the `development` branch to `${VPS_APP_DIR}/dev`. Production validates the tag against semver, parses the major version, and deploys to `${VPS_APP_DIR}/v<MAJOR>` — creating the directory on first deploy of a new major, updating it in place otherwise.
- Build runs on the GitHub runner (`composer install --no-dev --optimize-autoloader`, PHP 8.4 to match the server) and the result is shipped via rsync over SSH with `--delete --protect-args`. The companion `.github/deploy/rsync-exclude.txt` doubles as the protect-from-deletion list — `.env`, `.env.*`, `logs/`, `dbcredentials.php`, etc. are preserved across deploys.
- Concurrency is grouped per target (`deploy-staging`, `deploy-production`) so manual re-triggers serialize without cancelling. Each target uses a GitHub `environment:` of the same name, so protection rules (required reviewers, wait timers) can be added later under repo Settings → Environments.
- `permissions: contents: read` at job level for least-privilege `GITHUB_TOKEN` scope.
- SSH commands include `ConnectTimeout=10`, `ServerAliveInterval=15`, `ServerAliveCountMax=2` to avoid hung deploys on flaky links.
- Non-fatal SSHFP drift check compares the pinned host key against DNS SSHFP records via `dig +short SSHFP` and emits GitHub-Actions warnings on divergence. Surfaces both stale pins and DNS lag.

## Required repo configuration

**Secrets**
- `VPS_USERNAME` (already set)
- `VPS_HOST` (already set)
- `VPS_SSH_PRIVATE_KEY` — deploy keypair private key (no passphrase)
- `VPS_SSH_KNOWN_HOSTS` — output of `ssh-keyscan -H <host>` (or `-p <port> -H <host>`). Stored as a secret because `known_hosts` format embeds the hostname.

**Variables**
- `VPS_APP_DIR` — parent path inside the chroot; the workflow appends `/dev` or `/v<MAJOR>`
- `VPS_SSH_PORT` — only if SSH is not on 22

**Server-side**
- Public half of the deploy key in the chrooted user's `~/.ssh/authorized_keys`
- `rsync` available inside the chroot (added via Plesk `update-chroot.sh --add rsync` + `--apply <domain>`)

## Test plan

- [ ] Confirm `VPS_SSH_PRIVATE_KEY` and `VPS_SSH_KNOWN_HOSTS` secrets + `VPS_APP_DIR` variable are set in repo settings
- [ ] Confirm rsync is reachable in the chroot: `ssh <user>@<host> 'command -v rsync && rsync --version | head -1'`
- [ ] Trigger workflow with `target: staging` from the Actions tab; verify files land at `${VPS_APP_DIR}/dev/` and `.env` on the server is untouched
- [ ] Verify the SSHFP drift check reports "Pin matches DNS SSHFP records." (or surfaces actionable warnings if it doesn't)
- [ ] After tagging a `v5.0` release, trigger with `target: production` + `tag: v5.0`; verify `${VPS_APP_DIR}/v5/` is created and populated
- [ ] Re-deploy `v5.0` (or `v5.1` once cut) and verify the existing `v5/` is updated in place, with server-managed files (logs/, .env) preserved
- [ ] Sanity check: trigger production with an invalid tag like `5.0` (no `v`) and confirm the workflow fails fast at the validation step
- [ ] Publish a non-prerelease GitHub Release and confirm the workflow auto-fires (recommend setting up the `production` environment with required reviewers first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)