### PR TITLE
Sync master with deployed v3.0.0 snapshot (9cbf764)

### DIFF
--- a/includes/BibleGetQuote.php
+++ b/includes/BibleGetQuote.php
@@ -468,7 +468,7 @@ class BIBLEGET_QUOTE {
             $indexes[$variant]["biblebooks"]      = $bbbooks;
             $indexes[$variant]["chapter_limit"]   = $chapter_limit;
             $indexes[$variant]["verse_limit"]     = $verse_limit;
-            $indexes[$variant]["book_num"]        = $book_num;  
+            $indexes[$variant]["book_num"]        = $book_num;
 
         }
 

--- a/includes/QueryExecutor.php
+++ b/includes/QueryExecutor.php
@@ -367,7 +367,7 @@ class QUERY_EXECUTOR {
                 $this->BBQUOTE->div->appendChild( $this->versesParagraph );
                 $metainfo = $this->BBQUOTE->bibleQuote->createElement( "input" );
                 $metainfo->setAttribute( "type", "hidden" );
-                $metainfo->setAttribute( "class", "originalQueries" );
+                $metainfo->setAttribute( "class", "originalQuery" );
                 $metainfo->setAttribute( "value", $response["originalquery"] );
                 $this->BBQUOTE->div->appendChild( $metainfo );
                 $metainfo1 = $this->BBQUOTE->bibleQuote->createElement( "input" );

--- a/includes/QueryFormulator.php
+++ b/includes/QueryFormulator.php
@@ -136,21 +136,22 @@ class QUERY_FORMULATOR {
     }
 
     private function bestGuessBookIdx( array $matchedBook ) : int {
+
         $key1 = $this->currentVariant != "" ? array_search( $matchedBook[0], $this->BBQUOTE->INDEXES[$this->currentVariant]["biblebooks"] ) : false;
         $key2 = $this->currentVariant != "" ? array_search( $matchedBook[0], $this->BBQUOTE->INDEXES[$this->currentVariant]["abbreviations"] ) : false;
         $key3 = $this->BBQUOTE::idxOf( $matchedBook[0], $this->BBQUOTE->BIBLEBOOKS );
-        if ( $key1 ) {
+
+        if ( $key1 !== false ) {
             return $this->BBQUOTE->INDEXES[$this->currentVariant]["book_num"][$key1];
-        } else if ( $key2 ) {
+        } else if ( $key2 !== false ) {
             return $this->BBQUOTE->INDEXES[$this->currentVariant]["book_num"][$key2];
-        } else if ( $key3 ) {
+        } else if ( $key3 !== false ) {
             return $key3 + 1;
         }
     }
 
-    private function setBookAndVariant( array|bool $matchedBook ) {
+    private function setBook( array|bool $matchedBook ) {
         if ( $matchedBook ) {
-            $this->currentVariant = $this->BBQUOTE->validatedVariants[ $this->i ];
             $this->currentBook = $this->bestGuessBookIdx( $matchedBook );
             $this->previousBook = $this->currentBook;
         } else {
@@ -233,11 +234,14 @@ class QUERY_FORMULATOR {
                 $this->currentQuery = $query;
                 $this->currentFullQuery = $query;
                 $this->currentChapter = "";
+                if( !in_array( $version, $this->BBQUOTE->validatedVariants[ $this->i ] ) ) {
+                    continue;
+                } else {
+                    $this->currentVariant = $version;
+                }
 
-                // Retrieve and store the book in the query string,if applicable
                 $matchedBook = $this->captureBookIndicator();
-
-                $this->setBookAndVariant( $matchedBook );
+                $this->setBook( $matchedBook );
 
                 $this->initSQLStatement();
 

--- a/includes/QueryValidator.php
+++ b/includes/QueryValidator.php
@@ -149,6 +149,7 @@ class QUERY_VALIDATOR {
                 return true;
             }
         } else {
+            $this->validateBibleBook();
             return true;
         }
     }

--- a/index.php
+++ b/index.php
@@ -96,9 +96,9 @@ if ( isset( $_SERVER['REQUEST_METHOD'] ) ) {
         header( "Access-Control-Allow-Headers: {$_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']}" );
 }
 
-if( isset( $_SERVER['CONTENT_TYPE'] ) && !in_array( $_SERVER['CONTENT_TYPE'], BIBLEGET_QUOTE::$allowedContentTypes ) ){
+if( isset( $_SERVER['CONTENT_TYPE'] ) && !in_array( $_SERVER['CONTENT_TYPE'], BIBLEGET_QUOTE::ALLOWED_CONTENT_TYPES ) ){
     header( $_SERVER["SERVER_PROTOCOL"]." 415 Unsupported Media Type", true, 415 );
-    die( '{"error":"You seem to be forming a strange kind of request? Allowed Content Types are '.implode( ' and ',BIBLEGET_QUOTE::$allowedContentTypes ).', but your Content Type was '.$_SERVER['CONTENT_TYPE'].'"}' );
+    die( '{"error":"You seem to be forming a strange kind of request? Allowed Content Types are '.implode( ' and ',BIBLEGET_QUOTE::ALLOWED_CONTENT_TYPES ).', but your Content Type was '.$_SERVER['CONTENT_TYPE'].'"}' );
 } else if ( isset( $_SERVER['CONTENT_TYPE'] ) && $_SERVER['CONTENT_TYPE'] === 'application/json' ) {
     $json = file_get_contents( 'php://input' );
     $data = json_decode( $json,true );
@@ -127,6 +127,6 @@ if( isset( $_SERVER['CONTENT_TYPE'] ) && !in_array( $_SERVER['CONTENT_TYPE'], BI
           break;
       default:
           header( $_SERVER["SERVER_PROTOCOL"]." 405 Method Not Allowed", true, 405 );
-          die( '{"error":"You seem to be forming a strange kind of request? Allowed Request Methods are '.implode( ' and ',BIBLEGET_QUOTE::$allowedRequestMethods ).', but your Request Method was '.strtoupper( $_SERVER['REQUEST_METHOD'] ).'"}' );
+          die( '{"error":"You seem to be forming a strange kind of request? Allowed Request Methods are '.implode( ' and ',BIBLEGET_QUOTE::ALLOWED_REQUEST_METHODS ).', but your Request Method was '.strtoupper( $_SERVER['REQUEST_METHOD'] ).'"}' );
   }
 }

--- a/metadata.php
+++ b/metadata.php
@@ -7,10 +7,9 @@
  * accepts all cross-domain requests
  * is CORS enabled (as far as I understand it)
  * 
- * ENDPOINT URL:    https://query.bibleget.io/v3/metadata.php
+ * @link:           https://query.bibleget.io/v3/metadata.php
  * 
- * AUTHOR:          John Romano D'Orazio
- * AUTHOR EMAIL:    priest@johnromanodorazio.com
+ * @author:         John Romano D'Orazio <priest@johnromanodorazio.com>
  * AUTHOR WEBSITE:  https://www.johnromanodorazio.com
  * PROJECT WEBSITE: https://www.bibleget.io
  * PROJECT EMAIL:   admin@bibleget.io | bibleget.io@gmail.com
@@ -28,9 +27,10 @@
  * that would facilitate the usage of the Biblical texts
  * in the modern digital era.
  * 
- * My hope and desire is to be able to add 
- * as many different versions of the Bible in different languages
- * as possible, so that all men may have facilitated access to these texts
+ * My hope and desire is to be able to add as many different versions of the Bible
+ * in different languages as possible, so that all men may have facilitated access to these texts
+ * above all those editions curated by Bible societies and Episcopal Conferences
+ * with an imprimatur and guarantee of quality in the translations.
  * This project will always only utilize original source texts,
  * untouched by any third parties, so as to guarantee the authenticity of said texts.
  *    Deuteronomy 4:2
@@ -39,15 +39,15 @@
  *    of the Lord your God which I command you."
  * 
  * I have no desire for any kind of economical advantage
- * over this project, nobody should speculate eonomically
+ * over this project, nobody should speculate economically
  * over the wisdom of humanity or over the Word of God.
- * May it be of service to mankind. 
+ * May it be of service to mankind.
  * While I wish this endpoint engine to be open source,
  * available to men of good will who might desire to continue this project,
  * especially Biblical societies around the world,
  * and I hope the Pontifical Biblical Commission,
  * I cannot however offer the source texts and the databases they are held in
- * for public access, they are not all open source, 
+ * for public access, they are not all open source,
  * they are often covered by copyright by Episcopal Conferences or by Biblical societies.
  * 
  * I wish for the code of this engine to be open source,
@@ -97,6 +97,7 @@ class BIBLEGET_METADATA {
   private array $requestHeaders;
   private string $returntype;
   private string $acceptHeader;
+  //private ?string $contenttype;
   private mysqli $mysqli;
   private array $validversions;
   //private bool $is_ajax;
@@ -108,7 +109,7 @@ class BIBLEGET_METADATA {
   function __construct($DATA) {
     $this->requestHeaders = getallheaders();
     $this->DATA = $DATA;
-    $this->contenttype = isset($_SERVER['CONTENT_TYPE']) && in_array($_SERVER['CONTENT_TYPE'], self::$allowed_content_types) ? $_SERVER['CONTENT_TYPE'] : NULL;
+    //$this->contenttype = isset($_SERVER['CONTENT_TYPE']) && in_array($_SERVER['CONTENT_TYPE'], self::$allowed_content_types) ? $_SERVER['CONTENT_TYPE'] : NULL;
     $this->acceptHeader = isset($this->requestHeaders["Accept"]) && in_array($this->requestHeaders["Accept"], self::$allowed_accept_headers) ? self::$returntypes[array_search($this->requestHeaders["Accept"], self::$allowed_accept_headers)] : "";
     $this->returntype = (isset($DATA["return"]) && in_array(strtolower($DATA["return"]), self::$returntypes)) ? strtolower($DATA["return"]) : ($this->acceptHeader !== "" ? $this->acceptHeader : self::$returntypes[0]);
     //$this->isAjax = ( isset( $_SERVER['HTTP_X_REQUESTED_WITH'] ) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest' );

--- a/openapi.json
+++ b/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.3",
   "info": {
-      "version": '3.0',
+      "version": "3.0",
       "title": "BibleGet",
       "description": "Get Bible quotes from different Bible versions either requesting by reference (book - chapter - verse) or searching by keyword",
       "license": {

--- a/openapi.json
+++ b/openapi.json
@@ -1,1359 +1,2066 @@
 {
-  "openapi" : "3.0.3",
-  "info" : {
-    "version" : "2.8",
-    "title" : "BibleGet",
-    "description" : "Get Bible quotes from different Bible versions either requesting by reference (book - chapter - verse) or searching by keyword",
-    "license" : {
-      "name" : "Apache 2.0",
-      "url" : "http://www.apache.org/licenses/LICENSE-2.0"
-    },
-    "termsOfService" : "https://www.bibleget.io/BibleGetIOTermsofService.html",
-    "contact" : {
-      "name" : "John D'Orazio",
-      "url" : "https://www.bibleget.io",
-      "email" : "admin@bibleget.io"
-    }
+  "openapi": "3.0.3",
+  "info": {
+      "version": '3.0',
+      "title": "BibleGet",
+      "description": "Get Bible quotes from different Bible versions either requesting by reference (book - chapter - verse) or searching by keyword",
+      "license": {
+          "name": "Apache 2.0",
+          "url": "http://www.apache.org/licenses/LICENSE-2.0"
+      },
+      "termsOfService": "https://www.bibleget.io/BibleGetIOTermsofService.html",
+      "contact": {
+          "name": "John D'Orazio",
+          "url": "https://www.bibleget.io",
+          "email": "admin@bibleget.io"
+      }
   },
-  "servers" : [ {
-    "url" : "https://query.bibleget.io"
-  } ],
-  "paths" : {
-    "/index.php" : {
-      "get" : {
-        "summary" : "Retrieve Bible quotes by reference (book - chapter - verse)",
-        "description" : "The API endpoint from which one can retrieve Bible quotes by reference (book - chapter - verse)",
-        "operationId" : "getVersesByGET",
-        "tags" : [ "MainAPI" ],
-        "parameters" : [ {
-          "$ref" : "#/components/parameters/query"
-        }, {
-          "$ref" : "#/components/parameters/version"
-        }, {
-          "$ref" : "#/components/parameters/return"
-        }, {
-          "$ref" : "#/components/parameters/appid"
-        }, {
-          "$ref" : "#/components/parameters/pluginversion"
-        }, {
-          "$ref" : "#/components/parameters/domain"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Structured data containing the Bible verses requested and all associated information",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/BibleQuoteJSON"
-                }
-              },
-              "application/xml" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/BibleQuoteXML"
-                }
-              },
-              "text/html" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/BibleQuoteJSON"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post" : {
-        "summary" : "Retrieve Bible quotes by reference (book - chapter - verse)",
-        "description" : "The API endpoint from which one can retrieve Bible quotes by reference (book - chapter - verse)",
-        "operationId" : "getVersesByPOST",
-        "tags" : [ "MainAPI" ],
-        "requestBody" : {
-          "content" : {
-            "application/x-www-form-urlencoded" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/BibleQuotePOST"
-              },
-              "encoding" : {
-                "version" : {
-                  "style" : "form",
-                  "explode" : false
-                }
-              }
-            }
-          }
-        },
-        "responses" : {
-          "200" : {
-            "description" : "Structured data containing the Bible verses requested and all associated information",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/BibleQuoteJSON"
-                }
-              },
-              "application/xml" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/BibleQuoteXML"
-                }
-              },
-              "text/html" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/BibleQuoteJSON"
-                }
-              }
-            }
-          }
-        }
+  "servers": [
+      {
+          "url": "https://query.bibleget.io/v3"
       }
-    },
-    "/metadata.php" : {
-      "get" : {
-        "summary" : "Retrieve metadata about Bible versions that are available and their relative book/chapter/verse indexes",
-        "description" : "The API endpoint for querying metadata such as Bible versions that are available and their relative book/chapter/verse indexes. **N.B. Applications or plugins should CACHE the information returned by the METADATA endpoint. This data does not change often, there is no need to request it for every Bible quote requested from the main API endpoint. It can be a good idea to refresh this information about, let's say once a month, or create a user interface with a button that will allow the end user to refresh the information from the server if they think the cached information might be old.**",
-        "operationId" : "getMetadataByGET",
-        "tags" : [ "MetadataAPI" ],
-        "parameters" : [ {
-          "name" : "query",
-          "in" : "query",
-          "description" : "Specifies the subset of metadata to retrieve. **`biblebooks`**: retrieve the list of valid **book names** and **abbreviations** in various languages that are currently supported / recognized by the main BibleGet API endpoint. **`bibleversions`**: retrieve the list of **Bible versions** that are currently supported by the main BibleGet API endpoint. **`versionindex`**: retrieve the **indices of chapters and verses** for any of the Bible versions currently supported by the BibleGet engine (this value requires the usage of a second parameter `versions`).",
-          "required" : true,
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "biblebooks", "bibleversions", "versionindex" ]
-          },
-          "examples" : {
-            "biblebooks" : {
-              "summary" : "Retrieve the list of valid book names and abbreviations in various languages that are currently supported / recognized by the main BibleGet API endpoint",
-              "value" : "biblebooks"
-            },
-            "bibleversions" : {
-              "summary" : "Retrieve the list of Bible versions that are currently supported by the main BibleGet API endpoint.",
-              "value" : "bibleversions"
-            },
-            "versionindex" : {
-              "summary" : "Retrieve the **indices of chapters and verses** for any of the Bible versions currently supported by the BibleGet engine. Requires the usage of a second parameter `versions`.",
-              "value" : "versionindex"
-            }
-          }
-        }, {
-          "name" : "versions",
-          "in" : "query",
-          "description" : "*(required in the case of a `query=versionindex` request)* Indicates for which Bible versions the indices data should be returned. The acronyms for valid Bible versions as returned by `query=bibleversions` should be used, either as a single string value or as a comma separated list of values.",
-          "required" : false,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            },
-            "default" : [ "CEI2008" ]
-          },
-          "style" : "form",
-          "explode" : false,
-          "examples" : {
-            "singleVersion" : {
-              "summary" : "Single Bible version",
-              "value" : [ "NABRE" ]
-            },
-            "multipleVersions" : {
-              "summary" : "Multiple Bible versions",
-              "value" : [ "NABRE", "NVBSE" ]
-            }
-          }
-        }, {
-          "name" : "return",
-          "in" : "query",
-          "description" : "Type of data that should be returned in the response",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "json", "xml", "html" ],
-            "default" : "json"
-          },
-          "examples" : {
-            "json" : {
-              "summary" : "Request that the data be returned in JSON format",
-              "value" : "json"
-            },
-            "xml" : {
-              "summary" : "Request that the data be returned in XML format",
-              "value" : "xml"
-            },
-            "html" : {
-              "summary" : "Request that the data be returned in HTML format",
-              "value" : "html"
-            }
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Structured data containing the required metadata about either Bible versions available, Bible version indexes, or the names and abbreviations of Bible books for any given Bible version",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "oneOf" : [ {
-                    "$ref" : "#/components/schemas/MetadataBibleVersions"
-                  }, {
-                    "$ref" : "#/components/schemas/MetadataBibleBooks"
-                  }, {
-                    "$ref" : "#/components/schemas/MetadataVersionIndex"
-                  } ]
-                }
-              },
-              "application/xml" : {
-                "schema" : {
-                  "oneOf" : [ {
-                    "$ref" : "#/components/schemas/MetadataBibleVersions"
-                  }, {
-                    "$ref" : "#/components/schemas/MetadataBibleBooks"
-                  }, {
-                    "$ref" : "#/components/schemas/MetadataVersionIndex"
-                  } ]
-                }
-              },
-              "text/html" : {
-                "schema" : {
-                  "oneOf" : [ {
-                    "$ref" : "#/components/schemas/MetadataBibleVersions"
-                  }, {
-                    "$ref" : "#/components/schemas/MetadataBibleBooks"
-                  }, {
-                    "$ref" : "#/components/schemas/MetadataVersionIndex"
-                  } ]
-                }
-              }
-            }
-          }
-        }
-      },
-      "post" : {
-        "summary" : "Retrieve metadata about Bible versions that are available and their relative book/chapter/verse indexes",
-        "description" : "The API endpoint for querying metadata such as Bible versions that are available and their relative book/chapter/verse indexes",
-        "operationId" : "getMetadataByPOST",
-        "tags" : [ "MetadataAPI" ],
-        "requestBody" : {
-          "content" : {
-            "application/x-www-form-urlencoded" : {
-              "schema" : {
-                "type" : "object",
-                "properties" : {
-                  "query" : {
-                    "type" : "string",
-                    "description" : "Specifies the subset of metadata to retrieve. **`biblebooks`**: retrieve the list of valid **book names** and **abbreviations** in various languages that are currently supported / recognized by the main BibleGet API endpoint. **`bibleversions`**: retrieve the list of **Bible versions** that are currently supported by the main BibleGet API endpoint. **`versionindex`**: retrieve the **indices of chapters and verses** for any of the Bible versions currently supported by the BibleGet engine (this value requires the usage of a second parameter `versions`).",
-                    "enum" : [ "biblebooks", "bibleversions", "versionindex" ],
-                    "example" : "bibleversions"
+  ],
+  "paths": {
+      "/index.php": {
+          "get": {
+              "summary": "Retrieve Bible quotes by reference (book - chapter - verse)",
+              "description": "The API endpoint from which one can retrieve Bible quotes by reference (book - chapter - verse)",
+              "operationId": "getVersesByGET",
+              "tags": ["MainAPI"],
+              "parameters": [
+                  {
+                      "$ref": "#/components/parameters/query"
                   },
-                  "versions" : {
-                    "type" : "array",
-                    "description" : "Bible version or versions from which to retrieve the Bible quote. A list of valid versions can be retrieved from the `metadata.php` API using `query=bibleversions`",
-                    "items" : {
-                      "type" : "string"
-                    },
-                    "example" : [ "NABRE", "NVBSE" ],
-                    "default" : [ "CEI2008" ]
+                  {
+                      "$ref": "#/components/parameters/version"
                   },
-                  "return" : {
-                    "type" : "string",
-                    "description" : "Type of data that should be returned in the response",
-                    "enum" : [ "json", "xml", "html" ],
-                    "example" : "json",
-                    "default" : "json"
+                  {
+                      "$ref": "#/components/parameters/return"
+                  },
+                  {
+                      "$ref": "#/components/parameters/appid"
+                  },
+                  {
+                      "$ref": "#/components/parameters/pluginversion"
+                  },
+                  {
+                      "$ref": "#/components/parameters/domain"
+                  },
+                  {
+                      "$ref": "#/components/parameters/preferorigin"
                   }
-                },
-                "required" : [ "query" ]
-              },
-              "encoding" : {
-                "versions" : {
-                  "style" : "form",
-                  "explode" : false
-                }
-              }
-            }
-          }
-        },
-        "responses" : {
-          "200" : {
-            "description" : "Structured data containing the required metadata about either Bible versions available, Bible version indexes, or the names and abbreviations of Bible books for any given Bible version",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "oneOf" : [ {
-                    "$ref" : "#/components/schemas/MetadataBibleVersions"
-                  }, {
-                    "$ref" : "#/components/schemas/MetadataBibleBooks"
-                  }, {
-                    "$ref" : "#/components/schemas/MetadataVersionIndex"
-                  } ]
-                }
-              },
-              "application/xml" : {
-                "schema" : {
-                  "oneOf" : [ {
-                    "$ref" : "#/components/schemas/MetadataBibleVersions"
-                  }, {
-                    "$ref" : "#/components/schemas/MetadataBibleBooks"
-                  }, {
-                    "$ref" : "#/components/schemas/MetadataVersionIndex"
-                  } ]
-                }
-              },
-              "text/html" : {
-                "schema" : {
-                  "oneOf" : [ {
-                    "$ref" : "#/components/schemas/MetadataBibleVersions"
-                  }, {
-                    "$ref" : "#/components/schemas/MetadataBibleBooks"
-                  }, {
-                    "$ref" : "#/components/schemas/MetadataVersionIndex"
-                  } ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/search.php" : {
-      "get" : {
-        "summary" : "Search for Bible verses that contain a given keyword. In the future, search by topic may also be implemented.",
-        "description" : "The API endpoint for performing search queries for Bible verses by keyword (or topic).",
-        "operationId" : "searchVersesByGET",
-        "tags" : [ "SearchAPI" ],
-        "parameters" : [ {
-          "name" : "query",
-          "in" : "query",
-          "description" : "Specifies the kind of search to perform. As of v2.8 of the search API only a value of `keywordsearch` is available.",
-          "required" : true,
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "keywordsearch" ]
-          },
-          "examples" : {
-            "keywordsearch" : {
-              "summary" : "Perfom a search for Bible verses that contain the indicated keyword. Requires the usage of a second parameter: keyword. As of v2.8 of the search API endpoint, Search by topic is not yet available.",
-              "value" : "keywordsearch"
-            }
-          }
-        }, {
-          "name" : "keyword",
-          "in" : "query",
-          "description" : "*(required when making a request where `query=keywordsearch`)* indicates the keyword that will be searched in the text of the Bible verses",
-          "schema" : {
-            "type" : "string"
-          },
-          "examples" : {
-            "creation" : {
-              "summary" : "Perform a search for Bible verses that contain the keyword 'creation'.",
-              "value" : "creation"
-            }
-          }
-        }, {
-          "name" : "version",
-          "in" : "query",
-          "description" : "The acronym of the Bible version within which to perform the search by keyword. Can only be a single value, not a comma delimited list of values.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "examples" : {
-            "NABRE" : {
-              "summary" : "perform a search for Bible verses containing a given keyword in the *NABRE* Bible version.",
-              "value" : "NABRE"
-            },
-            "NVBSE" : {
-              "summary" : "perform a search for Bible verses containing a given keyword in the *NVBSE* Bible version.",
-              "value" : "NVBSE"
-            }
-          }
-        }, {
-          "name" : "exactmatch",
-          "in" : "query",
-          "description" : "since the default behaviour for a keyword search is to find any word of 4 or more letters which matches or contains the keyword, this option will try to find only exact matches and will also allow to search for words of even only 3 letters (parts of speech excluded)",
-          "required" : false,
-          "schema" : {
-            "type" : "boolean"
-          },
-          "examples" : {
-            "true" : {
-              "summary" : "find only exact matches of words that are made up of 3 or more letters (parts of speech excluded)",
-              "value" : "true"
-            },
-            "false" : {
-              "summary" : "find both exact and partial matches of words made up of 4 or more letters",
-              "value" : "false"
-            }
-          }
-        }, {
-          "name" : "return",
-          "in" : "query",
-          "description" : "Type of data that should be returned in the response",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "json", "xml", "html" ],
-            "default" : "json"
-          },
-          "examples" : {
-            "json" : {
-              "summary" : "Request that the data be returned in JSON format",
-              "value" : "json"
-            },
-            "xml" : {
-              "summary" : "Request that the data be returned in XML format",
-              "value" : "xml"
-            },
-            "html" : {
-              "summary" : "Request that the data be returned in HTML format",
-              "value" : "html"
-            }
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "oneOf" : [ {
-                    "$ref" : "#/components/schemas/KeywordSearchJSON"
-                  } ]
-                }
-              },
-              "application/xml" : {
-                "schema" : {
-                  "oneOf" : [ {
-                    "$ref" : "#/components/schemas/KeywordSearchXML"
-                  } ]
-                }
-              },
-              "application/html" : {
-                "schema" : {
-                  "oneOf" : [ {
-                    "$ref" : "#/components/schemas/KeywordSearchJSON"
-                  } ]
-                }
-              }
-            }
-          }
-        }
-      },
-      "post" : {
-        "summary" : "Search for Bible verses that contain a given keyword. In the future, search by topic may also be implemented.",
-        "description" : "The API endpoint for performing search queries for Bible verses by keyword (or topic).",
-        "operationId" : "searchVersesByPOST",
-        "tags" : [ "SearchAPI" ],
-        "requestBody" : {
-          "content" : {
-            "application/x-www-form-urlencoded" : {
-              "schema" : {
-                "type" : "object",
-                "properties" : {
-                  "query" : {
-                    "type" : "string",
-                    "description" : "Specifies the kind of search to perform. As of v2.8 of the search API only a value of `keywordsearch` is available.",
-                    "enum" : [ "keywordsearch" ],
-                    "example" : "keywordsearch"
+              ],
+              "responses": {
+                  "200": {
+                      "description": "Structured data containing the Bible verses requested and all associated information",
+                      "content": {
+                          "application/json": {
+                              "schema": {
+                                  "$ref": "#/components/schemas/BibleQuoteResponseJSON"
+                              }
+                          },
+                          "application/xml": {
+                              "schema": {
+                                  "$ref": "#/components/schemas/BibleQuoteResponseXML"
+                              }
+                          },
+                          "text/html": {
+                              "schema": {
+                                  "$ref": "#/components/schemas/MainAPIHtmlResponse"
+                              }
+                          }
+                      }
                   },
-                  "keyword" : {
-                    "type" : "string",
-                    "description" : "*(required when `query=keywordsearch`)* indicates the keyword that will be searched in the text of the Bible verses",
-                    "example" : "creation"
+                  "415": {
+                      "description": "Unsupported media type. Will be returned if a content type other than `application/json`,`application/xml` or `text/html` is requested."
                   },
-                  "version" : {
-                    "type" : "string",
-                    "description" : "The acronym of the Bible version within which to perform the search by keyword. Can only be a single value, not a comma delimited list of values.",
-                    "example" : "NVBSE"
+                  "400": {
+                      "description": "Bad request. Will be returned for example if a content type of `application/json` was set in the request, but no JSON data or malformed JSON data was sent in the body of the request."
                   },
-                  "exactmatch" : {
-                    "type" : "boolean",
-                    "description" : "since the default behaviour for a keyword search is to find any word of 4 or more letters which matches or contains the keyword, this option will try to find only exact matches and will also allow to search for words of even only 3 letters (parts of speech excluded)",
-                    "example" : "true"
-                  },
-                  "return" : {
-                    "type" : "string",
-                    "description" : "Type of data that should be returned in the response",
-                    "enum" : [ "json", "xml", "html" ],
-                    "example" : "json",
-                    "default" : "json"
+                  "405": {
+                      "description": "Method not allowed. Will be returned if a method other than `GET` or `POST` is utilized. `PUT`, `PATCH` and `DELETE` methods are not supported."
                   }
-                },
-                "required" : [ "query", "version" ]
               }
-            }
-          }
-        },
-        "responses" : {
-          "200" : {
-            "description" : "",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "oneOf" : [ {
-                    "$ref" : "#/components/schemas/KeywordSearchJSON"
-                  } ]
-                }
+          },
+          "post": {
+              "summary": "Retrieve Bible quotes by reference (book - chapter - verse)",
+              "description": "The API endpoint from which one can retrieve Bible quotes by reference (book - chapter - verse)",
+              "operationId": "getVersesByPOST",
+              "tags": ["MainAPI"],
+              "requestBody": {
+                  "content": {
+                      "application/x-www-form-urlencoded": {
+                          "schema": {
+                            "$ref": "#/components/schemas/BibleQuotePOST"
+                          },
+                          "encoding": {
+                              "version": {
+                                  "style": "form",
+                                  "explode": false
+                              }
+                          }
+                      },
+                      "application/json": {
+                        "schema": {
+                          "$ref": "#/components/schemas/BibleQuotePOST"
+                        },
+                        "examples": {
+                          "SimpleRequest": {
+                            "value": {
+                              "query": "John3:16",
+                              "version": "NABRE",
+                              "appid": "swaggerhub"
+                            }
+                          },
+                          "RequestVerseRange": {
+                            "value": {
+                              "query": "1Corinthians13:4-8",
+                              "version": "NABRE",
+                              "appid": "swaggerhub"
+                            }
+                          },
+                          "RequestDiscontinuousVerses": {
+                            "value": {
+                              "query": "1Corinthians13:4,8",
+                              "version": "NABRE",
+                              "appid": "swaggerhub"
+                            }
+                          },
+                          "RequestVerseRangeAndDiscontinuousVerse": {
+                            "value": {
+                              "query": "1Corinthians13:4-8,13",
+                              "version": "NABRE",
+                              "appid": "swaggerhub"
+                            }
+                          },
+                          "RequestDiscontinousVerseRanges": {
+                            "value": {
+                              "query": "1Corinthians13:4-8,11-12",
+                              "version": "NABRE",
+                              "appid": "swaggerhub"
+                            }
+                          },
+                          "RequestMultipleChaptersSameBook": {
+                            "value": {
+                              "query": "1Corinthians13:4-8;14:1",
+                              "version": "NABRE",
+                              "appid": "swaggerhub"
+                            }
+                          },
+                          "RequestMultipleBooks": {
+                            "value": {
+                              "query": "John3:16;1John4:7-8",
+                              "version": "NABRE",
+                              "appid": "swaggerhub"
+                            }
+                          },
+                          "RequestMultipleVersions": {
+                            "value": {
+                              "query": "John3:16",
+                              "version": "NABRE,DRB",
+                              "appid": "swaggerhub"
+                            }
+                          },
+                          "RequestGreekOrigin": {
+                            "value": {
+                              "query": "Esther1:1",
+                              "version": "NABRE",
+                              "appid": "swaggerhub",
+                              "preferorigin": "GREEK"
+                            }
+                          },
+                          "RequestHebrewOrigin": {
+                            "value": {
+                              "query": "Esther1:1",
+                              "version": "NABRE",
+                              "appid": "swaggerhub",
+                              "preferorigin": "HEBREW"
+                            }
+                          },
+                          "RequestEuropeanFormat": {
+                            "value": {
+                              "query": "Giovanni3,16;1Gv4,7-8",
+                              "version": "CEI2008",
+                              "appid": "swaggerhub"
+                            }
+                          }
+                        }
+                      }
+                  }
               },
-              "application/xml" : {
-                "schema" : {
-                  "oneOf" : [ {
-                    "$ref" : "#/components/schemas/KeywordSearchXML"
-                  } ]
-                }
-              },
-              "application/html" : {
-                "schema" : {
-                  "oneOf" : [ {
-                    "$ref" : "#/components/schemas/KeywordSearchJSON"
-                  } ]
-                }
+              "responses": {
+                  "200": {
+                      "description": "Structured data containing the Bible verses requested and all associated information",
+                      "content": {
+                          "application/json": {
+                              "schema": {
+                                  "$ref": "#/components/schemas/BibleQuoteResponseJSON"
+                              }
+                          },
+                          "application/xml": {
+                              "schema": {
+                                  "$ref": "#/components/schemas/BibleQuoteResponseXML"
+                              }
+                          },
+                          "text/html": {
+                              "schema": {
+                                  "$ref": "#/components/schemas/MainAPIHtmlResponse"
+                              }
+                          }
+                      }
+                  },
+                  "415": {
+                      "description": "Unsupported media type. Will be returned if a content type other than `application/json`,`application/xml` or `text/html` is requested."
+                  },
+                  "400": {
+                      "description": "Bad request. Will be returned for example if a content type of `application/json` was set in the request, but no JSON data or malformed JSON data was sent in the body of the request."
+                  },
+                  "405": {
+                      "description": "Method not allowed. Will be returned if a method other than `GET` or `POST` is utilized. `PUT`, `PATCH` and `DELETE` methods are not supported."
+                  }
               }
-            }
           }
-        }
+      },
+      "/metadata.php": {
+          "get": {
+              "summary": "Retrieve metadata about Bible versions that are available and their relative book/chapter/verse indexes",
+              "description": "The API endpoint for querying metadata such as Bible versions that are available and their relative book/chapter/verse indexes. **N.B. Applications or plugins should CACHE the information returned by the METADATA endpoint. This data does not change often, there is no need to request it for every Bible quote requested from the main API endpoint. It can be a good idea to refresh this information about, let's say once a month, or create a user interface with a button that will allow the end user to refresh the information from the server if they think the cached information might be old.**",
+              "operationId": "getMetadataByGET",
+              "tags": ["MetadataAPI"],
+              "parameters": [
+                  {
+                      "name": "query",
+                      "in": "query",
+                      "description": "Specifies the subset of metadata to retrieve. **`biblebooks`**: retrieve the list of valid **book names** and **abbreviations** in various languages that are currently supported / recognized by the main BibleGet API endpoint. **`bibleversions`**: retrieve the list of **Bible versions** that are currently supported by the main BibleGet API endpoint. **`versionindex`**: retrieve the **indices of chapters and verses** for any of the Bible versions currently supported by the BibleGet engine (this value requires the usage of a second parameter `versions`).",
+                      "required": true,
+                      "schema": {
+                          "type": "string",
+                          "enum": [
+                              "biblebooks",
+                              "bibleversions",
+                              "versionindex"
+                          ]
+                      },
+                      "examples": {
+                          "biblebooks": {
+                              "summary": "Retrieve the list of valid book names and abbreviations in various languages that are currently supported / recognized by the main BibleGet API endpoint",
+                              "value": "biblebooks"
+                          },
+                          "bibleversions": {
+                              "summary": "Retrieve the list of Bible versions that are currently supported by the main BibleGet API endpoint.",
+                              "value": "bibleversions"
+                          },
+                          "versionindex": {
+                              "summary": "Retrieve the **indices of chapters and verses** for any of the Bible versions currently supported by the BibleGet engine. Requires the usage of a second parameter `versions`.",
+                              "value": "versionindex"
+                          }
+                      }
+                  },
+                  {
+                      "name": "versions",
+                      "in": "query",
+                      "description": "*(required in the case of a `query=versionindex` request)* Indicates for which Bible versions the indices data should be returned. The acronyms for valid Bible versions as returned by `query=bibleversions` should be used, either as a single string value or as a comma separated list of values.",
+                      "required": false,
+                      "schema": {
+                          "type": "array",
+                          "items": {
+                              "type": "string"
+                          },
+                          "default": ["CEI2008"]
+                      },
+                      "style": "form",
+                      "explode": false,
+                      "examples": {
+                          "singleVersion": {
+                              "summary": "Single Bible version",
+                              "value": ["NABRE"]
+                          },
+                          "multipleVersions": {
+                              "summary": "Multiple Bible versions",
+                              "value": ["NABRE","NVBSE"]
+                          }
+                      }
+                  },
+                  {
+                      "name": "return",
+                      "in": "query",
+                      "description": "Type of data that should be returned in the response",
+                      "required": false,
+                      "schema": {
+                          "type": "string",
+                          "enum": [
+                              "json",
+                              "xml",
+                              "html"
+                          ],
+                          "default": "json"
+                      },
+                      "examples": {
+                          "json": {
+                              "summary": "Request that the data be returned in JSON format",
+                              "value": "json"
+                          },
+                          "xml": {
+                              "summary": "Request that the data be returned in XML format",
+                              "value": "xml"
+                          },
+                          "html": {
+                              "summary": "Request that the data be returned in HTML format",
+                              "value": "html"
+                          }
+                      }
+                  }
+              ],
+              "responses": {
+                  "200": {
+                      "description": "Structured data containing the required metadata about either Bible versions available, Bible version indexes, or the names and abbreviations of Bible books for any given Bible version",
+                      "content": {
+                          "application/json": {
+                              "schema": {
+                                  "oneOf": [
+                                      { "$ref": "#/components/schemas/MetadataBibleVersions" },
+                                      { "$ref": "#/components/schemas/MetadataBibleBooks" },
+                                      { "$ref": "#/components/schemas/MetadataVersionIndex" }
+                                  ]
+                              }
+                          },
+                          "application/xml": {
+                              "schema": {
+                                  "oneOf": [
+                                      { "$ref": "#/components/schemas/MetadataBibleVersionsXML" },
+                                      { "$ref": "#/components/schemas/MetadataBibleBooks" },
+                                      { "$ref": "#/components/schemas/MetadataVersionIndex" }
+                                  ]
+                              }
+                          },
+                          "text/html": {
+                              "schema": {
+                                  "oneOf": [
+                                      { "$ref": "#/components/schemas/MetadataBibleVersionsHTML" },
+                                      { "$ref": "#/components/schemas/MetadataBibleBooksHTML" },
+                                      { "$ref": "#/components/schemas/MetadataVersionIndexHTML" }
+                                  ]
+                              }
+                          }
+                      }
+                  },
+                  "415": {
+                      "description": "Unsupported media type. Will be returned if a content type other than `application/json`,`application/xml` or `text/html` is requested."
+                  },
+                  "400": {
+                      "description": "Bad request. Will be returned for example if a content type of `application/json` was set in the request, but no JSON data or malformed JSON data was sent in the body of the request."
+                  },
+                  "405": {
+                      "description": "Method not allowed. Will be returned if a method other than `GET` or `POST` is utilized. `PUT`, `PATCH` and `DELETE` methods are not supported."
+                  }
+              }
+          },
+          "post": {
+              "summary": "Retrieve metadata about Bible versions that are available and their relative book/chapter/verse indexes",
+              "description": "The API endpoint for querying metadata such as Bible versions that are available and their relative book/chapter/verse indexes",
+              "operationId": "getMetadataByPOST",
+              "tags": ["MetadataAPI"],
+              "requestBody": {
+                  "content": {
+                      "application/x-www-form-urlencoded": {
+                          "schema": {
+                              "$ref": "#/components/schemas/MetadataPOST"
+                          },
+                          "encoding": {
+                              "versions": {
+                                  "style": "form",
+                                  "explode": false
+                              }
+                          }
+                      },
+                      "application/json": {
+                          "schema": {
+                              "$ref": "#/components/schemas/MetadataPOST"
+                          }
+                      }
+                  }
+              },
+              "responses": {
+                  "200": {
+                      "description": "Structured data containing the required metadata about either Bible versions available, Bible version indexes, or the names and abbreviations of Bible books for any given Bible version",
+                      "content": {
+                          "application/json": {
+                              "schema": {
+                                  "oneOf": [
+                                      { "$ref": "#/components/schemas/MetadataBibleVersions" },
+                                      { "$ref": "#/components/schemas/MetadataBibleBooks" },
+                                      { "$ref": "#/components/schemas/MetadataVersionIndex" }
+                                  ]
+                              }
+                          },
+                          "application/xml": {
+                              "schema": {
+                                  "oneOf": [
+                                      { "$ref": "#/components/schemas/MetadataBibleVersionsXML" },
+                                      { "$ref": "#/components/schemas/MetadataBibleBooks" },
+                                      { "$ref": "#/components/schemas/MetadataVersionIndex" }
+                                  ]
+                              }
+                          },
+                          "text/html": {
+                              "schema": {
+                                  "oneOf": [
+                                      { "$ref": "#/components/schemas/MetadataBibleVersionsHTML" },
+                                      { "$ref": "#/components/schemas/MetadataBibleBooksHTML" },
+                                      { "$ref": "#/components/schemas/MetadataVersionIndexHTML" }
+                                  ]
+                              }
+                          }
+                      }
+                  },
+                  "415": {
+                      "description": "Unsupported media type. Will be returned if a content type other than `application/json`,`application/xml` or `text/html` is requested."
+                  },
+                  "400": {
+                      "description": "Bad request. Will be returned for example if a content type of `application/json` was set in the request, but no JSON data or malformed JSON data was sent in the body of the request."
+                  },
+                  "405": {
+                      "description": "Method not allowed. Will be returned if a method other than `GET` or `POST` is utilized. `PUT`, `PATCH` and `DELETE` methods are not supported."
+                  }
+              }
+          }
+      },
+      "/search.php": {
+          "get": {
+              "summary": "Search for Bible verses that contain a given keyword. In the future, search by topic may also be implemented.",
+              "description": "The API endpoint for performing search queries for Bible verses by keyword (or topic).",
+              "operationId": "searchVersesByGET",
+              "tags": ["SearchAPI"],
+              "parameters": [
+                  {
+                      "name": "query",
+                      "in": "query",
+                      "description": "Specifies the kind of search to perform. As of v3.0 of the search API only a value of `keywordsearch` is available.",
+                      "required": true,
+                      "schema": {
+                          "type": "string",
+                          "enum": [
+                              "keywordsearch"
+                          ]
+                      },
+                      "examples": {
+                          "keywordsearch": {
+                              "summary": "Perfom a search for Bible verses that contain the indicated keyword. Requires the usage of a second parameter: keyword. As of v2.8 of the search API endpoint, Search by topic is not yet available.",
+                              "value": "keywordsearch"
+                          }
+                      }
+                  },
+                  {
+                      "name": "keyword",
+                      "in": "query",
+                      "description": "*(required when making a request where `query=keywordsearch`)* indicates the keyword that will be searched in the text of the Bible verses",
+                      "schema": {
+                          "type": "string"
+                      },
+                      "examples": {
+                          "creation": {
+                              "summary": "Perform a search for Bible verses that contain the keyword 'creation'.",
+                              "value": "creation"
+                          }
+                      }
+                  },
+                  {
+                      "name": "version",
+                      "in": "query",
+                      "description": "The acronym of the Bible version within which to perform the search by keyword. Can only be a single value, not a comma delimited list of values.",
+                      "required": true,
+                      "schema": {
+                          "type": "string"
+                      },
+                      "examples": {
+                          "NABRE": {
+                              "summary": "perform a search for Bible verses containing a given keyword in the *NABRE* Bible version.",
+                              "value": "NABRE"
+                          },
+                          "NVBSE": {
+                              "summary": "perform a search for Bible verses containing a given keyword in the *NVBSE* Bible version.",
+                              "value": "NVBSE"
+                          }
+                      }
+                  },
+                  {
+                      "name": "exactmatch",
+                      "in": "query",
+                      "description": "since the default behaviour for a keyword search is to find any word of 4 or more letters which matches or contains the keyword, this option will try to find only exact matches and will also allow to search for words of even only 3 letters (parts of speech excluded)",
+                      "required": false,
+                      "schema": {
+                          "type": "boolean"
+                      },
+                      "examples": {
+                          "true": {
+                            "summary": "find only exact matches of words that are made up of 3 or more letters (parts of speech excluded)",
+                            "value": "true"
+                          },
+                          "false": {
+                            "summary": "find both exact and partial matches of words made up of 4 or more letters",
+                            "value": "false"
+                          }
+                      }
+                  },
+                  {
+                      "name": "return",
+                      "in": "query",
+                      "description": "Type of data that should be returned in the response",
+                      "required": false,
+                      "schema": {
+                          "type": "string",
+                          "enum": [
+                              "json",
+                              "xml",
+                              "html"
+                          ],
+                          "default": "json"
+                      },
+                      "examples": {
+                        "json": {
+                          "summary": "Request that the data be returned in JSON format",
+                          "value": "json"
+                        },
+                        "xml": {
+                          "summary": "Request that the data be returned in XML format",
+                          "value": "xml"
+                        },
+                        "html": {
+                          "summary": "Request that the data be returned in HTML format",
+                          "value": "html"
+                        }
+                      }
+                  }
+              ],
+              "responses": {
+                  "200": {
+                      "description": "",
+                      "content": {
+                          "application/json": {
+                              "schema": {
+                                  "oneOf": [
+                                      { "$ref": "#/components/schemas/KeywordSearchResponseJSON" }
+                                  ]
+                              }
+                          },
+                          "application/xml": {
+                              "schema": {
+                                  "oneOf": [
+                                      { "$ref": "#/components/schemas/KeywordSearchResponseXML" }
+                                  ]
+                              }
+                          },
+                          "application/html": {
+                              "schema": {
+                                  "oneOf": [
+                                      { "$ref": "#/components/schemas/KeywordSearchResponseHTML" }
+                                  ]
+                              }
+                          }
+                      }
+                  },
+                  "415": {
+                      "description": "Unsupported media type. Will be returned if a content type other than `application/json`,`application/xml` or `text/html` is requested."
+                  },
+                  "400": {
+                      "description": "Bad request. Will be returned for example if a content type of `application/json` was set in the request, but no JSON data or malformed JSON data was sent in the body of the request."
+                  },
+                  "405": {
+                      "description": "Method not allowed. Will be returned if a method other than `GET` or `POST` is utilized. `PUT`, `PATCH` and `DELETE` methods are not supported."
+                  }
+              }                
+          },
+          "post": {
+              "summary": "Search for Bible verses that contain a given keyword. In the future, search by topic may also be implemented.",
+              "description": "The API endpoint for performing search queries for Bible verses by keyword (or topic).",
+              "operationId": "searchVersesByPOST",
+              "tags": ["SearchAPI"],
+              "requestBody": {
+                  "content": {
+                      "application/x-www-form-urlencoded": {
+                          "schema": {
+                              "$ref": "#/components/schemas/KeywordSearchPOST"
+                          }
+                      },
+                      "application/json": {
+                          "schema": {
+                              "$ref": "#/components/schemas/KeywordSearchPOST"
+                          }
+                      }
+                  }
+              },
+              "responses": {
+                  "200": {
+                      "description": "",
+                      "content": {
+                          "application/json": {
+                              "schema": {
+                                  "oneOf": [
+                                      { "$ref": "#/components/schemas/KeywordSearchResponseJSON" }
+                                  ]
+                              }
+                          },
+                          "application/xml": {
+                              "schema": {
+                                  "oneOf": [
+                                      { "$ref": "#/components/schemas/KeywordSearchResponseXML" }
+                                  ]
+                              }
+                          },
+                          "application/html": {
+                              "schema": {
+                                  "oneOf": [
+                                      { "$ref": "#/components/schemas/KeywordSearchResponseHTML" }
+                                  ]
+                              }
+                          }
+                      }
+                  },
+                  "415": {
+                      "description": "Unsupported media type. Will be returned if a content type other than `application/json`,`application/xml` or `text/html` is requested."
+                  },
+                  "400": {
+                      "description": "Bad request. Will be returned for example if a content type of `application/json` was set in the request, but no JSON data or malformed JSON data was sent in the body of the request."
+                  },
+                  "405": {
+                      "description": "Method not allowed. Will be returned if a method other than `GET` or `POST` is utilized. `PUT`, `PATCH` and `DELETE` methods are not supported."
+                  }
+              }
+          }
       }
-    }
   },
-  "components" : {
-    "schemas" : {
-      "BibleQuotePOST" : {
-        "type" : "object",
-        "properties" : {
-          "query" : {
-            "type" : "string",
-            "description" : "Bible reference using standard Bible citation notation.",
-            "example" : "Genesis1:1-10"
+  "components": {
+      "schemas": {
+          "BibleQuotePOST": {
+              "type": "object",
+              "properties": {
+                  "query": {
+                      "type": "string",
+                      "description": "Bible reference using standard Bible citation notation.",
+                      "example": "Genesis1:1-10"
+                  },
+                  "version": {
+                      "type": "array",
+                      "description": "Bible version or versions from which to retrieve the Bible quote. A list of valid versions can be retrieved from the `metadata.php` API using `query=bibleversions`",
+                      "items": {
+                          "type": "string"
+                      },
+                      "example": [
+                          "NABRE",
+                          "NVBSE"
+                      ]
+                  },
+                  "return": {
+                      "type": "string",
+                      "description": "Desired content type for the response data. An `Accept` header can be used instead, and should be preferred to using the `return` parameter / property",
+                      "enum": [
+                          "json",
+                          "xml",
+                          "html"
+                      ],
+                      "example": "json",
+                      "default": "json"
+                  },
+                  "appid": {
+                      "type": "string",
+                      "description": "Unique identifier of the application making the request, to be agreed upon with the owner of the API endpoint",
+                      "example": "swaggerhub"
+                  },
+                  "pluginversion": {
+                      "type": "string",
+                      "description": "Version number of the application making the request. Useful not only for statistics, to help understand which version of an application is being actively used, but also (especially in the case of the official applications) to help deal with possibly breaking changes between the application version and versions of the API endpoint",
+                      "example": "v1.0"
+                  },
+                  "domain": {
+                      "type": "string",
+                      "description": "In the case of web based applications, should indicate the domain from which the request is generated. Currently used by the official plugin for WordPress to better understand usage of the plugin and monitor requests. When the application or plugin making the request can be installed on different domains (as is the case with the WordPress plugin), this value should be generated dynamically from a server variable identifying the domain. If instead it will always be the same domain making the requests, the value can be hardcoded with the actual domain.",
+                      "example": "app.swaggerhub.com"
+                  },
+                  "preferorigin": {
+                      "type": "string",
+                      "description": "whether to retrieve Bible verses that are based on the GREEK original text or on the HEBREW original text, when there are multiple possibilities. This occurs generally in Catholic versions of the Bible for certain Books and chapters (e.g. Esther)",
+                      "enum": [
+                        "GREEK",
+                        "HEBREW"
+                      ],
+                      "example": "GREEK"
+                  }
+              },
+              "required": [
+                  "query",
+                  "version",
+                  "appid"
+              ]
+            
           },
-          "version" : {
-            "type" : "array",
-            "description" : "Bible version or versions from which to retrieve the Bible quote. A list of valid versions can be retrieved from the `metadata.php` API using `query=bibleversions`",
-            "items" : {
-              "type" : "string"
-            },
-            "example" : [ "NABRE", "NVBSE" ]
+          "BibleQuoteResponseJSON": {
+              "type": "object",
+              "properties": {
+                  "results": {
+                      "type": "array",
+                      "description": "Array of objects each of which represents a Bible verse with all associated information",
+                      "items": {
+                          "type": "object",
+                          "properties": {
+                              "testament": {
+                                  "type": "integer",
+                                  "enum": [
+                                      1,
+                                      2
+                                  ],
+                                  "description": "`1` = *Old Testament*, `2` = *New Testament*",
+                                  "xml": {
+                                      "attribute": true
+                                  },
+                                  "example": 2
+                              },
+                              "section": {
+                                  "type": "integer",
+                                  "enum": [
+                                      1,
+                                      2,
+                                      3,
+                                      4,
+                                      5,
+                                      6,
+                                      7,
+                                      8,
+                                      9
+                                  ],
+                                  "description": "`1` = *Pentateuch*, `2` = *Historical Books*, `3` = *Wisdom Books*, `4` = *Prophets*, `5` = *Gospels*, `6` = *Acts of the Apostles*, `7` = *Letters of Saint Paul*, `8` = *Catholic Letters*, `9` = *Apocalypse*",
+                                  "xml": {
+                                      "attribute": true
+                                  },
+                                  "example": 8
+                              },
+                              "book": {
+                                  "type": "string",
+                                  "description": "Name of the book of the Bible in the language of the Bible version being quoted from",
+                                  "xml": {
+                                      "attribute": true
+                                  },
+                                  "example": "1John"
+                              },
+                              "bookabbrev": {
+                                  "type": "string",
+                                  "description": "Abbreviated form of the book of the Bible in the language of the Bible version being quoted from",
+                                  "xml": {
+                                      "attribute": true
+                                  },
+                                  "example": "1Jn"
+                              },
+                              "booknum": {
+                                  "type": "integer",
+                                  "description": "0 based index of the Book of the Bible in the Bible version being quoted from (not all versions have the same books in the same order, especially when considering differences between Catholic and evangelical versions). The value is returned as a number value ready to be used against index information for the Bible version being quoted from. The corresponding name of the Book of the Bible as used in the printed edition of the current Bible version can be retrieved using the `metadata.php` API endpoint, as can index information about the number of chapters in the book and the number of verses in each chapter.",
+                                  "xml": {
+                                      "attribute": true
+                                  },
+                                  "example": 68
+                              },
+                              "univbooknum": {
+                                  "type": "string",
+                                  "description": "A number identifying the Book of the Bible according to the universally recognized Catholic version of the Canon of the Sacred Scriptures (*i.e. universally recognized by the Roman Catholic Church*). This is not a 0 based index, but rather `1` = *Genesis*, `2` = *Exodus*, etc. Therefore it is returned as a string, but can be treated as a number.",
+                                  "enum": [
+                                      "1",
+                                      "2",
+                                      "3",
+                                      "4",
+                                      "5",
+                                      "6",
+                                      "7",
+                                      "8",
+                                      "9",
+                                      "10",
+                                      "11",
+                                      "12",
+                                      "13",
+                                      "14",
+                                      "15",
+                                      "16",
+                                      "17",
+                                      "18",
+                                      "19",
+                                      "20",
+                                      "21",
+                                      "22",
+                                      "23",
+                                      "24",
+                                      "25",
+                                      "26",
+                                      "27",
+                                      "28",
+                                      "29",
+                                      "30",
+                                      "31",
+                                      "32",
+                                      "33",
+                                      "34",
+                                      "35",
+                                      "36",
+                                      "37",
+                                      "38",
+                                      "39",
+                                      "40",
+                                      "41",
+                                      "42",
+                                      "43",
+                                      "44",
+                                      "45",
+                                      "46",
+                                      "47",
+                                      "48",
+                                      "49",
+                                      "50",
+                                      "51",
+                                      "52",
+                                      "53",
+                                      "54",
+                                      "55",
+                                      "56",
+                                      "57",
+                                      "58",
+                                      "59",
+                                      "60",
+                                      "61",
+                                      "62",
+                                      "63",
+                                      "64",
+                                      "65",
+                                      "66",
+                                      "67",
+                                      "68",
+                                      "69",
+                                      "70",
+                                      "71",
+                                      "72",
+                                      "73"
+                                  ],
+                                  "xml": {
+                                      "attribute": true
+                                  },
+                                  "example": "69"
+                              },
+                              "chapter": {
+                                  "type": "integer",
+                                  "description": "Chapter of the book of the Bible in the Bible version that the verse is being quoted from",
+                                  "xml": {
+                                      "attribute": true
+                                  },
+                                  "example": 4
+                              },
+                              "versedescr": {
+                                  "type": "string",
+                                  "description": "Not currently used, comes back as a `null` value. Could possible be used in the future for scholarly notes associated with a Bible verse",
+                                  "nullable": true,
+                                  "xml": {
+                                      "attribute": true
+                                  },
+                                  "example": null
+                              },
+                              "verse": {
+                                  "type": "string",
+                                  "description": "Verse Number of the verse being quoted. *N.B. this is returned as a string because it will not always necessarily be a number value, there are verses that have letters in them. The value must be treated as a string and not as a number.*",
+                                  "xml": {
+                                      "attribute": true
+                                  },
+                                  "example": "7"
+                              },
+                              "verseequiv": {
+                                  "type": "integer",
+                                  "description": "I'm not actually sure if this is currently being used or not, I believe the idea was to have a number value for those verses that have a letter in the verse number... Will mostly return a `null` value.",
+                                  "nullable": true,
+                                  "xml": {
+                                      "attribute": true
+                                  },
+                                  "example": null
+                              },
+                              "text": {
+                                  "type": "string",
+                                  "description": "Contains the actual text of the verse being quoted. May contain `newline` characters that may need to be dealt with. The **NABRE** version will contain ***it's own formatting tags that need to be dealt with***, whether that means producing the proper formatting associated with these tags, or removing them to have a basic formatting. The legal requirements for usage of the NABRE version require the proper formatting to be used where possible. Please [contact the project author](mailto:admin@bibleget.io) for information on how to deal with these tags and their formatting.",
+                                  "xml": {
+                                      "attribute": true
+                                  },
+                                  "example": " Beloved, let us love one another, because love is of God; everyone who loves is begotten by God and knows God. "
+                              },
+                              "version": {
+                                  "type": "string",
+                                  "description": "the acronym of the Bible version being quoted from. For data associated with any given Bible version, for example index information, the `metadata.php` API endpoint can be used",
+                                  "xml": {
+                                      "attribute": true
+                                  },
+                                  "example": "NABRE"
+                              },
+                              "title1": {
+                                  "type": "string",
+                                  "description": "not currently used. The original idea (which may yet be implemented) was for this to contain any first-level title text preceding the given verse in the version of the Bible being quoted from.",
+                                  "xml": {
+                                      "attribute": true
+                                  },
+                                  "example": ""
+                              },
+                              "title2": {
+                                  "type": "string",
+                                  "description": "not currently used. The original idea (which may yet be implemented) was for this to contain any second-level title text preceding the given verse in the version of the Bible being quoted from.",
+                                  "xml": {
+                                      "attribute": true
+                                  },
+                                  "example": ""
+                              },
+                              "title3": {
+                                  "type": "string",
+                                  "description": "not currently used. The original idea (which may yet be implemented) was for this to contain any third-level title text preceding the given verse in the version of the Bible being quoted from.",
+                                  "xml": {
+                                      "attribute": true
+                                  },
+                                  "example": ""
+                              },
+                              "originalquery": {
+                                  "type": "string",
+                                  "description": "The original query (Bible reference indicated in the `query` parameter of the sent request) that the endpoint received, which produced this result. Will always be returned in EUROPEAN notation, even if the original query was actually in ENGLISH notation.",
+                                  "xml": {
+                                      "attribute": true
+                                  },
+                                  "example": "1John4,7-8"
+                              }
+                          }
+                      },
+                      "xml": {
+                          "wrapped": true,
+                          "name": "results"
+                      }
+                  },
+                  "errors": {
+                      "type": "array",
+                      "description": "An array of any error messages that may have been generated indicating a badly formed `query` parameter, a bad value for the `version` parameter, or an API server error",
+                      "items": {
+                          "type": "string"
+                      }
+                  },
+                  "info": {
+                      "type": "object",
+                      "description": "An object containing metadata about the API endpoint",
+                      "properties": {
+                          "ENDPOINT_VERSION": {
+                              "type": "string",
+                              "example": "3.0"
+                          },
+                          "detectedNotation": {
+                              "type": "string",
+                              "enum": [
+                                "ENGLISH",
+                                "EUROPEAN",
+                                "MIXED"
+                              ],
+                              "description": "Feedback on the type of Bible quotation notation that the endpoint engine detected in the request. `ENGLISH` and `EUROPEAN` are valid values. `MIXED` means that the engine cannot detect a definite notation, and will most probably be accompanied by an error message.",
+                              "example": "ENGLISH"
+                          },
+                          "bibleVersionsInfo": {
+                              "type": "object",
+                              "description": "key-value pairs where the keys will be the abbreviated form of the requested Bible versions, and the values will be a pipe separated list containing information about the relative Bible version. Splitting this list will give these values: <ol><li>Bible version fullname</li><li>Year in which the edition was published</li><li>Language</li><li>Whether the Bible version has an imprimatur</li><li>Canon of the Scriptures for this Bible version (can have a value of `CATHOLIC` or `PROTESTANT`)</li><li>Copyright holder for this edition</li><li>Notes about this Bible edition</li>",
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "example": { "NABRE" : "New American Bible - Revised Edition|2011|en|1|CATHOLIC|United States Conference of Catholic Bishops|" }
+                          }
+                      }
+                  }
+              }
           },
-          "return" : {
-            "type" : "string",
-            "description" : "Type of data that should be returned in the response",
-            "enum" : [ "json", "xml", "html" ],
-            "example" : "json",
-            "default" : "json"
+          "BibleQuoteResponseXML": {
+              "type": "object",
+              "properties": {
+                  "results": {
+                      "type": "array",
+                      "description": "Array of objects each of which represents a Bible verse with all associated information",
+                      "items": {
+                          "$ref": "#/components/schemas/BibleQuoteResult"
+                      },
+                      "xml": {
+                          "name": "results",
+                          "wrapped": true
+                      }
+                  },
+                  "errors": {
+                      "type": "array",
+                      "description": "An array of any error messages that may have been generated indicating a badly formed `query` parameter, an unsupported value for the `version` parameter, or an API server error",
+                      "items": {
+                          "type": "string"
+                      }
+                  },
+                  "info": {
+                      "type": "object",
+                      "description": "An object containing metadata about the API endpoint",
+                      "properties": {
+                          "ENDPOINT_VERSION": {
+                              "type": "string",
+                              "description": "Version of the endpoint being interrogated",
+                              "xml": {
+                                  "attribute": true
+                              },
+                              "example": "3.0"
+                          },
+                          "detectedNotation": {
+                              "type": "string",
+                              "enum": [
+                                "ENGLISH",
+                                "EUROPEAN",
+                                "MIXED"
+                              ],
+                              "description": "Feedback on the type of Bible quotation notation that the endpoint engine detected in the request. `ENGLISH` and `EUROPEAN` are valid values. `MIXED` means that the engine cannot detect a definite notation, and will most probably be accompanied by an error message.",
+                              "xml": {
+                                  "attribute": true
+                              }
+                          },
+                          "bibleVersionsInfo": {
+                              "type": "string",
+                              "description": "JSON encoded string, representing key - value pairs in which the keys are the abbreviated names of the Bible versions that were requested, and the values are pipe separated lists of information about the Bible version requested. Splitting this list will give these values: <ol><li>Bible version fullname</li><li>Year in which the edition was published</li><li>Language</li><li>Whether the Bible version has an imprimatur</li><li>Canon of the Scriptures for this Bible version (can have a value of `CATHOLIC` or `PROTESTANT`)</li><li>Copyright holder for this edition</li><li>Notes about this Bible edition</li>",
+                              "xml": {
+                                  "attribute": true
+                              },
+                              "example": "{\"NABRE\":\"New American Bible - Revised Edition|2011|en|1|CATHOLIC|United States Conference of Catholic Bishops|\"}"
+                          }
+                      }
+                  }
+              },
+              "xml": {
+                  "name": "BibleQuote"
+              }
           },
-          "appid" : {
-            "type" : "string",
-            "description" : "Unique identifier of the application making the request, to be agreed upon with the owner of the API endpoint",
-            "example" : "swaggerhub"
+          "BibleQuoteResult": {
+              "type": "object",
+              "properties": {
+                  "testament": {
+                      "type": "integer",
+                      "enum": [
+                          1,
+                          2
+                      ],
+                      "description": "`1` = *Old Testament*, `2` = *New Testament*",
+                      "xml": {
+                          "attribute": true
+                      },
+                      "example": 2
+                  },
+                  "section": {
+                      "type": "integer",
+                      "enum": [
+                          1,
+                          2,
+                          3,
+                          4,
+                          5,
+                          6,
+                          7,
+                          8,
+                          9
+                      ],
+                      "description": "`1` = *Pentateuch*, `2` = *Historical Books*, `3` = *Wisdom Books*, `4` = *Prophets*, `5` = *Gospels*, `6` = *Acts of the Apostles*, `7` = *Letters of Saint Paul*, `8` = *Catholic Letters*, `9` = *Apocalypse*",
+                      "xml": {
+                          "attribute": true
+                      },
+                      "example": 8
+                  },
+                  "book": {
+                      "type": "string",
+                      "description": "Name of the book of the Bible in the language of the Bible version being quoted from",
+                      "xml": {
+                          "attribute": true
+                      },
+                      "example": "1John"
+                  },
+                  "bookabbrev": {
+                      "type": "string",
+                      "description": "Abbreviated form of the book of the Bible in the language of the Bible version being quoted from",
+                      "xml": {
+                          "attribute": true
+                      },
+                      "example": "1Jn"
+                  },
+                  "booknum": {
+                      "type": "integer",
+                      "description": "0 based index of the Book of the Bible in the Bible version being quoted from (not all versions have the same books in the same order, especially when considering differences between Catholic and evangelical versions). The value is returned as a number value ready to be used against index information for the Bible version being quoted from. The corresponding name of the Book of the Bible as used in the printed edition of the current Bible version can be retrieved using the `metadata.php` API endpoint, as can index information about the number of chapters in the book and the number of verses in each chapter.",
+                      "xml": {
+                          "attribute": true
+                      },
+                      "example": 68
+                  },
+                  "univbooknum": {
+                      "type": "string",
+                      "description": "A number identifying the Book of the Bible according to the universally recognized Catholic version of the Canon of the Sacred Scriptures (*i.e. universally recognized by the Roman Catholic Church*). This is not a 0 based index, but rather `1` = *Genesis*, `2` = *Exodus*, etc. Therefore it is returned as a string, but can be treated as a number.",
+                      "enum": [
+                          "1",
+                          "2",
+                          "3",
+                          "4",
+                          "5",
+                          "6",
+                          "7",
+                          "8",
+                          "9",
+                          "10",
+                          "11",
+                          "12",
+                          "13",
+                          "14",
+                          "15",
+                          "16",
+                          "17",
+                          "18",
+                          "19",
+                          "20",
+                          "21",
+                          "22",
+                          "23",
+                          "24",
+                          "25",
+                          "26",
+                          "27",
+                          "28",
+                          "29",
+                          "30",
+                          "31",
+                          "32",
+                          "33",
+                          "34",
+                          "35",
+                          "36",
+                          "37",
+                          "38",
+                          "39",
+                          "40",
+                          "41",
+                          "42",
+                          "43",
+                          "44",
+                          "45",
+                          "46",
+                          "47",
+                          "48",
+                          "49",
+                          "50",
+                          "51",
+                          "52",
+                          "53",
+                          "54",
+                          "55",
+                          "56",
+                          "57",
+                          "58",
+                          "59",
+                          "60",
+                          "61",
+                          "62",
+                          "63",
+                          "64",
+                          "65",
+                          "66",
+                          "67",
+                          "68",
+                          "69",
+                          "70",
+                          "71",
+                          "72",
+                          "73"
+                      ],
+                      "xml": {
+                          "attribute": true
+                      },
+                      "example": "69"
+                  },
+                  "chapter": {
+                      "type": "integer",
+                      "description": "Chapter of the book of the Bible in the Bible version that the verse is being quoted from",
+                      "xml": {
+                          "attribute": true
+                      },
+                      "example": 4
+                  },
+                  "versedescr": {
+                      "type": "string",
+                      "description": "Not currently used, comes back as a `null` value. Could possible be used in the future for scholarly notes associated with a Bible verse",
+                      "nullable": true,
+                      "xml": {
+                          "attribute": true
+                      }
+                  },
+                  "verse": {
+                      "type": "string",
+                      "description": "Verse Number of the verse being quoted. *N.B. this is returned as a string because it will not always necessarily be a number value, there are verses that have letters in them. The value must be treated as a string and not as a number.*",
+                      "xml": {
+                          "attribute": true
+                      },
+                      "example": "7"
+                  },
+                  "verseequiv": {
+                      "type": "integer",
+                      "description": "I'm not actually sure if this is currently being used or not, I believe the idea was to have a number value for those verses that have a letter in the verse number... Will mostly return a `null` value.",
+                      "nullable": true,
+                      "xml": {
+                          "attribute": true
+                      },
+                      "example": ""
+                  },
+                  "text": {
+                      "type": "string",
+                      "description": "Contains the actual text of the verse being quoted. May contain `newline` characters that may need to be dealt with. The **NABRE** version will contain ***it's own formatting tags that need to be dealt with***, whether that means producing the proper formatting associated with these tags, or removing them to have a basic formatting. The legal requirements for usage of the NABRE version require the proper formatting to be used where possible. Please [contact the project author](mailto:admin@bibleget.io) for information on how to deal with these tags and their formatting.",
+                      "xml": {
+                          "attribute": true
+                      },
+                      "example": " Beloved, let us love one another, because love is of God; everyone who loves is begotten by God and knows God. "
+                  },
+                  "version": {
+                      "type": "string",
+                      "description": "the acronym of the Bible version being quoted from. For data associated with any given Bible version, for example index information, the `metadata.php` API endpoint can be used",
+                      "xml": {
+                          "attribute": true
+                      },
+                      "example": "NABRE"
+                  },
+                  "title1": {
+                      "type": "string",
+                      "description": "not currently used. The original idea (which may yet be implemented) was for this to contain any first-level title text preceding the given verse in the version of the Bible being quoted from.",
+                      "xml": {
+                          "attribute": true
+                      },
+                      "example": ""
+                  },
+                  "title2": {
+                      "type": "string",
+                      "description": "not currently used. The original idea (which may yet be implemented) was for this to contain any second-level title text preceding the given verse in the version of the Bible being quoted from.",
+                      "xml": {
+                          "attribute": true
+                      },
+                      "example": ""
+                  },
+                  "title3": {
+                      "type": "string",
+                      "description": "not currently used. The original idea (which may yet be implemented) was for this to contain any third-level title text preceding the given verse in the version of the Bible being quoted from.",
+                      "xml": {
+                          "attribute": true
+                      },
+                      "example": ""
+                  },
+                  "originalquery": {
+                      "type": "string",
+                      "description": "The original query (Bible reference indicated in the `query` parameter of the sent request) that the endpoint received, which produced this result. Will always be in EUROPEAN notation, even if the actual original query was in ENGLISH notation.",
+                      "xml": {
+                          "attribute": true
+                      },
+                      "example": "1John4,7-8"
+                  }
+              },
+              "xml": {
+                  "name": "result"
+              }
           },
-          "pluginversion" : {
-            "type" : "string",
-            "description" : "Version number of the application making the request. Useful not only for statistics, to help understand which version of an application is being actively used, but also (especially in the case of the official applications) to help deal with possibly breaking changes between the application version and versions of the API endpoint",
-            "example" : "v1.0"
+          "MetadataBibleVersions": {
+              "type": "object",
+              "properties": {
+                  "validversions": {
+                      "type": "array",
+                      "description": "An array of the acronyms of the Bible versions that are currently supported by the main BibleGet API endpoint",
+                      "items": {
+                          "type": "string"
+                      }
+                  },
+                  "validversions_fullname": {
+                      "type": "object",
+                      "description": "An object the keys of which are the acronyms of the Bible versions that are currently supported by the main BibleGet API endpoint, and the values of which are a pipe separated list of 1. The full name of the Bible version 2. The year it was published 3. The two letter ISO 639-1 code of the **language** of the Bible version",
+                      "additionalProperties": {
+                          "type": "string"
+                      }
+                  },
+                  "copyrightversions": {
+                      "type": "array",
+                      "description": "An array containing the acronyms of Bible versions that have a copyright holder, the usage of which is regulated under a legally binding agreement with the copyright holder. For example, some copyright holders (usually Episcopal Conferences for Catholic versions) may request that no more than a certain number of verses be issued from a single request to the endpoint (in other words, please don't try to copy the whole Bible through the BibleGet endpoint!). Enforcement of the usage required by the copyright holder is done by the endpoint itself, so applications cannot overcome these limits. If the owner of the endpoint notices that an application attempts in a sly manner to overcome these limitations, access to the main API endpoint may be denied to the application and authorization mechanisms will be necessarily put in place for usage of the endpoints. We are assuming a model of responsible usage for the time being, but if it becomes necessary access will be restricted and authorization will be required",
+                      "items": {
+                          "type": "string"
+                      }
+                  },
+                  "errors": {
+                      "type": "array",
+                      "description": "An array of any error messages that may have been generated indicating a badly formed `query` parameter or an API server error",
+                      "items": {
+                          "type": "string"
+                      }
+                  },
+                  "info": {
+                      "type": "object",
+                      "description": "An object containing metadata about the API endpoint",
+                      "properties": {
+                          "ENDPOINT_VERSION": {
+                              "type": "string"
+                          }
+                      }
+                  }
+              },
+              "xml": {
+                  "name": "BibleGetMetadata"
+              },
+              "example": {"results":[],"errors":[],"info":{"ENDPOINT_VERSION":"3.0"},"validversions":["CEI2008","DRB","LUZZI","NABRE","NVBSE","VGCL","BLPD"],"validversions_fullname":{"CEI2008":"Conferenza Episcopale Italiana|2008|it|1|CATHOLIC|Fondazione di Religione “Santi Francesco d’Assisi e Caterina da Siena”|source: https:\/\/www.bibbiaedu.it","DRB":"Douay–Rheims Challoner Revision|1752|en|1|CATHOLIC||The Douay–Rheims is a translation of the Bible from the Latin Vulgate into English made by members of the English College, Douai, in the service of the Catholic Church. The New Testament portion was published in Reims, France, in 1582, in one volume with extensive commentary and notes. The Old Testament portion was published in two volumes twenty-seven years later in 1609 and 1610 by the University of Douai. The Whole Revised and Diligently Compared with the Latin Vulgate by Bishop Richard Challoner 1749-1752\r\nsource: http:\/\/www.gutenberg.org\/ebooks\/1581\r\nsource: http:\/\/catholicbible.online\/","LUZZI":"Riveduta - Luzzi|1924|it|0|PROTESTANT||","NABRE":"New American Bible - Revised Edition|2011|en|1|CATHOLIC|United States Conference of Catholic Bishops|","NVBSE":"Nova Vulgata - Bibliorum Sacrorum Editio|1979|la|1|CATHOLIC||source: http:\/\/www.vatican.va\/archive\/bible\/nova_vulgata\/documents\/nova-vulgata_index_lt.html","VGCL":"Vulgata Clementina|1592|la|1|CATHOLIC||There is a single, definitive Clementine text, namely the Editio Typica published by the Typographus Vaticanus in 1598 under the title \"Biblia Sacra Vulgatæ editionis, Sixti V Pontificis Maximi jussu recognita et edita\". However, the text here has necessarily been derived from later sources, principally that edited by A. Colunga and L. Turrado (La Editorial Católica, Madrid, 1946). For dubious readings, the editions of C. Vercellone (Typis S. Congregationis de Propaganda Fide, Rome, 1861) and M. Hetzenauer (Pustet & Co, 1914) were also consulted. Only the canonical books are included (many printed versions include an appendix with the apocryphal books Oratio Manassæ and Esdræ III and IV).","BLPD":"Libro del Pueblo de Dios|2015|es|1|CATHOLIC|Fundación Palabra de Vida y Editorial Verbo Divino|La Fundación Palabra de Vida se creó para la difusión de “El Libro del Pueblo de Dios. La Biblia”, una traducción que llevó a dos de sus  miembros, los Padres Alfredo Bernardo Trusso y Armando Jorge Levoratti, veintidos años de intenso trabajo. Lógicamente en un tiempo en el cual no había computadoras y las imprentas no tenían la tecnología que tienen hoy en día.\r\nEsta traducción fue aceptada inmediatamente en nuestro país y fue así que la Conferencia Episcopal Argentina la reconoció como texto oficial de la Iglesia. Y no sólo nuestro país, sino también las Conferencias Episcopales de Chile, Paraguay y Uruguay.\r\nAños más tarde del fallecimiento del Padre Trusso, el Padre Levoratti se dedicó a actualizar varias introducciones y notas de este Libro. Y a raíz de esta nueva  versión se puso en contacto con la Editorial Verbo Divino y le cedió sus derechos de la traducción. Por su parte el Padre Trusso había cedido sus derechos a la Fundación.\r\nEl P. Levoratti junto con los otros miembros de la Fundación reunidos con la Editorial Verbo Divino decidieron titularla “La Biblia. Libro del Pueblo de Dios”, para seguir la continuidad de la traducción original. El Padre Levoratti falleció hace ya unos años.\r\nLa edición “El Libro del Pueblo de Dios. La Biblia”, que nos edita la Editorial San Pablo, sigue teniendo vigencia  con las introducciones parciales a los principales capítulos, mientras que en la posterior fueron agregadas a las notas."},"copyrightversions":["CEI2008","NABRE","BLPD"]}
           },
-          "domain" : {
-            "type" : "string",
-            "description" : "In the case of web based applications, should indicate the domain from which the request is generated. Currently used by the official plugin for WordPress to better understand usage of the plugin and monitor requests. When the application or plugin making the request can be installed on different domains (as is the case with the WordPress plugin), this value should be generated dynamically from a server variable identifying the domain. If instead it will always be the same domain making the requests, the value can be hardcoded with the actual domain.",
-            "example" : "app.swaggerhub.com"
+          "MetadataBibleVersionsXML": {
+              "type": "object",
+              "properties": {
+                  "ValidVersions": {
+                      "type": "object",
+                      "description": "A list of the acronyms of the Bible versions that are currently supported by the main BibleGet API endpoint",
+                      "additionalProperties": {
+                          "type": "string"
+                      },
+                      "example": {
+                        "CEI2008": "",
+                        "DRB": "",
+                        "LUZZI": "",
+                        "NABRE": "",
+                        "NVBSE": "",
+                        "VGCL": "",
+                        "BLPD": ""
+                      }
+                  },
+                  "ValidVersionsFullname": {
+                      "type": "object",
+                      "description": "An object the keys of which are the acronyms of the Bible versions that are currently supported by the main BibleGet API endpoint, and the values of which are further properties describing various info about the relative Bible version",
+                      "additionalProperties": {
+                          "type": "object",
+                          "properties": {
+                            "Fullname": {
+                              "type": "string",
+                              "description": "The full name of the Bible version"
+                            },
+                            "Year": {
+                              "type": "string",
+                              "description": "Year in which the Bible version was published"
+                            },
+                            "Language": {
+                              "type": "string",
+                              "description": "Two letter ISO 639-1 code of the **language** of the Bible version"
+                            },
+                            "Imprimatur": {
+                              "type": "integer",
+                              "description": "`0` = no imprimatur, `1` = has imprimatur"
+                            },
+                            "Canon": {
+                              "type": "string",
+                              "enum": [
+                                "CATHOLIC",
+                                "PROTESTANT"
+                              ],
+                              "description": "Canon of the Scriptures for this Bible version, whether `CATHOLIC` or `PROTESTANT`"
+                            },
+                            "CopyrightHolder": {
+                              "type": "string",
+                              "description": "Copyright holder for this Bible version"
+                            },
+                            "Notes": {
+                              "type": "string",
+                              "description": "Info about this Bible version. May indicate the source of the Bible text used in the BibleGet project."
+                            }
+                          }
+                      }
+                  },
+                  "CopyrightVersions": {
+                      "type": "array",
+                      "description": "An array containing the acronyms of Bible versions that have a copyright holder, the usage of which is regulated under a legally binding agreement with the copyright holder. For example, some copyright holders (usually Episcopal Conferences for Catholic versions) may request that no more than a certain number of verses be issued from a single request to the endpoint (in other words, please don't try to copy the whole Bible through the BibleGet endpoint!). Enforcement of the usage required by the copyright holder is done by the endpoint itself, so applications cannot overcome these limits. If the owner of the endpoint notices that an application attempts in a sly manner to overcome these limitations, access to the main API endpoint may be denied to the application and authorization mechanisms will be necessarily put in place for usage of the endpoints. We are assuming a model of responsible usage for the time being, but if it becomes necessary access will be restricted and authorization will be required",
+                      "items": {
+                          "type": "string"
+                      }
+                  },
+                  "errors": {
+                      "type": "array",
+                      "description": "An array of any error messages that may have been generated indicating a badly formed `query` parameter or an API server error",
+                      "items": {
+                          "type": "string"
+                      }
+                  },
+                  "info": {
+                      "type": "object",
+                      "description": "An object containing metadata about the API endpoint",
+                      "properties": {
+                          "ENDPOINT_VERSION": {
+                              "type": "string"
+                          }
+                      }
+                  }
+              },
+              "xml": {
+                  "name": "BibleGetMetadata"
+              }
+          },
+          "MetadataBibleBooks": {
+              "type": "object",
+              "properties": {
+                  "languages": {
+                      "type": "array",
+                      "description": "An array indicating the languages supported by the main BibleGet endpoint, for the names of the Books of the Bible. The single languages are returned in the English form, all caps. The implict numbered index of this array will be useful for the data associated with the `results` key.",
+                      "items": {
+                          "type": "string"
+                      }
+                  },
+                  "results": {
+                      "type": "array",
+                      "description": "An array containing information about the names of the Bible books that can be used to make queries to the main endpoint. The implict numbered index of this array corresponds with the Bible books universally recognized by the Roman Catholic Church. Bible versions used by evangelicals will generally have a few less Bible books, so the index of reference is the Canon of the Scriptures as recognized by the Roman Catholic Church.",
+                      "items": {
+                          "$ref": "#/components/schemas/MetadataBibleBooksResult"
+                      }
+                  },
+                  "errors": {
+                      "type": "array",
+                      "description": "An array of any error messages that may have been generated indicating a badly formed `query` parameter or an API server error",
+                      "items": {
+                          "type": "string"
+                      }
+                  },
+                  "info": {
+                      "type": "object",
+                      "description": "An object containing metadata about the API endpoint",
+                      "properties": {
+                          "ENDPOINT_VERSION": {
+                              "type": "string"
+                          }
+                      }
+                  }
+              },
+              "xml": {
+                  "name": "BibleGetMetadata"
+              },
+              "example": {"results":[[["Genesis","Gen","Genesis"],["Génesis","Gn","Génesis"],["Zanafilla","Gen","Zanafilla"],["","",""],["تكوين","Gen","تكوين"],["創世紀","Gen","創世紀"],["","Gen",""],["Genesis","Gen","Genesis"],["Genesis","Gen","Genesis"],["Genèse","Gen","Genèse"],["Genesis | 1Mose","Gen","Genesis","1Mose"],["Γένεση","Gen","Γένεση"],["1Mózes","Gen","1Mózes"],["Genesi","Gen | Gn | Ge","Genesi","Gen","Gn","Ge"],["創世記","Gen","創世記"],["창세기","창세 | 창","창세기","창세","창"],["Genesis","Gen","Genesis"],["Rodzaju","Rdz","Rodzaju"],["Génesis","Gen","Génesis"],["Geneza","Gen","Geneza"],["Бытие","Быт","Бытие"],["Génesis","Gen | Gén | Gn","Génesis","Gen","Gén","Gn"],["தொடக்க நூல்","Gen","தொடக்கநூல்"],["ปฐมกาล","Gen","ปฐมกาล"],["Sáng Thế","Gen","Sángthế"]],[["Exodus","Ex","Exodus"],["Exodus","Ex","Exodus"],["Eksodi","Ex","Eksodi"],["","",""],["خروج","Ex","خروج"],["出谷紀","Ex","出谷紀"],["","Ex",""],["Exodus","Ex","Exodus"],["Exodo","Exo","Exodo"],["Exode","Ex","Exode"],["Exodus | 2Mose","Ex","Exodus","2Mose"],["Έξοδος","Ex","Έξοδος"],["2Mózes","Ex","2Mózes"],["Esodo","Es","Esodo"],["出エジプト記","Ex","出エジプト記"],["출애굽기 | 탈출기","탈출 | 출","출애굽기","탈출기","탈출","출"],["Exodus","Ex","Exodus"],["Wyjścia","Wj","Wyjścia"],["Êxodo","Ex","Êxodo"],["Exod","Ex","Exod"],["Исход","Исх","Исход"],["Éxodo","Ex | Éx","Éxodo","Ex","Éx"],["விடுதலைப் பயணம்","Ex","விடுதலைப்பயணம்"],["อพยพ","Ex","อพยพ"],["Xuất Hành","Ex","Xuấthành"]],[["Leviticus","Lev | Lv","Leviticus","Lev","Lv"],["Levitikus","Lv","Levitikus"],["Levitiku","Lev | Lv","Levitiku","Lev","Lv"],["","",""],["لاويين","Lev | Lv","لاويين","Lev","Lv"],["肋未紀","Lev | Lv","肋未紀","Lev","Lv"],["","Lev | Lv","","Lev","Lv"],["Levitikus","Lev | Lv","Levitikus","Lev","Lv"],["Levitico","Lev","Levitico"],["Lévitique","Lev | Lv","Lévitique","Lev","Lv"],["Levitikus | 3Mose","Lev | Lv","Levitikus","3Mose","Lev","Lv"],["Λευιτικό","Lev | Lv","Λευιτικό","Lev","Lv"],["3Mózes","Lev | Lv","3Mózes","Lev","Lv"],["Levitico","Lv","Levitico"],["レビ記","Lev | Lv","レビ記","Lev","Lv"],["레위기","레위 | 레","레위기","레위","레"],["Leviticus","Lev | Lv","Leviticus","Lev","Lv"],["Kapłańska","Kpł","Kapłańska"],["Levítico","Lev | Lv","Levítico","Lev","Lv"],["Levitic","Lev | Lv","Levitic","Lev","Lv"],["Левит","Лев","Левит"],["Levítico","Lv | Lev","Levítico","Lv","Lev"],["லேவியர்","Lev | Lv","லேவியர்","Lev","Lv"],["เลวีนิติ","Lev | Lv","เลวีนิติ","Lev","Lv"],["Lêvi","Lev | Lv","Lêvi","Lev","Lv"]],[["Numbers","Num | Nm","Numbers","Num","Nm"],["Númeri","Nm","Númeri"],["Numrat","Num | Nm","Numrat","Num","Nm"],["","",""],["عدد","Num | Nm","عدد","Num","Nm"],["戶籍紀","Num | Nm","戶籍紀","Num","Nm"],["","Num | Nm","","Num","Nm"],["Numeri","Num | Nm","Numeri","Num","Nm"],["Bilang | Mga Bilang","Bil","Bilang","Mgabilang"],["Nombres","Num | Nm","Nombres","Num","Nm"],["Numeri | 4Mose","Num | Nm","Numeri","4Mose","Num","Nm"],["Αριθμοί","Num | Nm","Αριθμοί","Num","Nm"],["4Mózes","Num | Nm","4Mózes","Num","Nm"],["Numeri","Nm","Numeri"],["民数記","Num | Nm","民数記","Num","Nm"],["민수기","민수 | 민","민수기","민수","민"],["Numeri","Num | Nm","Numeri","Num","Nm"],["Liczb","Lb","Liczb"],["Números","Num | Nm","Números","Num","Nm"],["Numeri","Num | Nm","Numeri","Num","Nm"],["Числа","Чис","Числа"],["Números","Nm | Núm","Números","Nm","Núm"],["எண்ணிக்கை","Num | Nm","எண்ணிக்கை","Num","Nm"],["กันดารวิถี","Num | Nm","กันดารวิถี","Num","Nm"],["Dân Số","Num | Nm","Dânsố","Num","Nm"]],[["Deuteronomy","Deut | Dt","Deuteronomy","Deut","Dt"],["Deuteronómium","Dt","Deuteronómium"],["Përtërirë | Ligji i Përtërirë","Deut | Dt","Përtërirë","Ligjiipërtërirë","Deut","Dt"],["","",""],["تثنية","Deut | Dt","تثنية","Deut","Dt"],["申命紀","Deut | Dt","申命紀","Deut","Dt"],["","Deut | Dt","","Deut","Dt"],["Deuteronomium","Deut | Dt","Deuteronomium","Deut","Dt"],["Deuteronomio","Deut","Deuteronomio"],["Deutéronome","Deut | Dt","Deutéronome","Deut","Dt"],["Deuteronomium | 5Mose","Deut | Dt","Deuteronomium","5Mose","Deut","Dt"],["Δευτερονόμιο","Deut | Dt","Δευτερονόμιο","Deut","Dt"],["5Mózes","Deut | Dt","5Mózes","Deut","Dt"],["Deuteronomio","Dt","Deuteronomio"],["申命記","Deut | Dt","申命記","Deut","Dt"],["신명기","신명 | 신","신명기","신명","신"],["Deuteronomii","Deut | Dt","Deuteronomii","Deut","Dt"],["Powtórzonego | Powtórzonego Prawa","Pwt","Powtórzonego","Powtórzonegoprawa"],["Deuteronómio","Deut | Dt","Deuteronómio","Deut","Dt"],["Deuteronom","Deut | Dt","Deuteronom","Deut","Dt"],["Второзаконие","Втор","Второзаконие"],["Deuteronomio","Dt","Deuteronomio"],["இணைச் சட்டம்","Deut | Dt","இணைச்சட்டம்","Deut","Dt"],["เฉลยธรรมบัญญัติ","Deut | Dt","เฉลยธรรมบัญญัติ","Deut","Dt"],["Đệ Nhị Luật","Deut | Dt","Đệnhịluật","Deut","Dt"]],[["Joshua","Josh","Joshua"],["Josua","Js","Josua"],["Jozueu","Josh","Jozueu"],["","",""],["يشوع","Josh","يشوع"],["若蘇厄書","Josh","若蘇厄書"],["","Josh",""],["Jozue","Josh","Jozue"],["Josue","Jos","Josue"],["Josué","Josh","Josué"],["Josua","Josh","Josua"],["Ιησού του Ναυή","Josh","Ιησούτουναυή"],["Józsué","Josh","Józsué"],["Giosue","Gs","Giosue"],["ヨシュア記","Josh","ヨシュア記"],["여호수아","수","여호수아"],["Iosue","Ios | Jos","Iosue","Ios","Jos"],["Jozuego","Joz","Jozuego"],["Josué","Josh","Josué"],["Iosua","Josh","Iosua"],["Иисус Навин","Нав","Иисуснавин"],["Josué","Jos","Josué"],["யோசுவா","Josh","யோசுவா"],["โยชูวา","Josh","โยชูวา"],["Giôsuê","Josh","Giôsuê"]],[["Judges","Jdg | Jgs","Judges","Jdg","Jgs"],["Rigters","Jg","Rigters"],["Gjyqtarët","Jdg | Jgs","Gjyqtarët","Jdg","Jgs"],["","",""],["قضاة","Jdg | Jgs","قضاة","Jdg","Jgs"],["民長紀","Jdg | Jgs","民長紀","Jdg","Jgs"],["","Jdg | Jgs","","Jdg","Jgs"],["Soudců","Jdg | Jgs","Soudců","Jdg","Jgs"],["Hukom | Mga Hukom","Huk","Hukom","Mgahukom"],["Juges","Jdg | Jgs","Juges","Jdg","Jgs"],["Richter","Jdg | Jgs","Richter","Jdg","Jgs"],["Κριτές","Jdg | Jgs","Κριτές","Jdg","Jgs"],["Birák","Jdg | Jgs","Birák","Jdg","Jgs"],["Giudici","Gdc","Giudici"],["士師記","Jdg | Jgs","士師記","Jdg","Jgs"],["사사기 | 판관기","삿","사사기","판관기"],["Iudicum","Iudc | Judc","Iudicum","Iudc","Judc"],["Sędziów","Sdz","Sędziów"],["Juízes","Jdg | Jgs","Juízes","Jdg","Jgs"],["Judecatori","Jdg | Jgs","Judecatori","Jdg","Jgs"],["Книга Судей","Суд","Книгасудей"],["Jueces","Jc | Jue","Jueces","Jc","Jue"],["நீதித் தலைவர்கள்","Jdg | Jgs","நீதித்தலைவர்கள்","Jdg","Jgs"],["ผู้วินิจฉัย","Jdg | Jgs","ผู้วินิจฉัย","Jdg","Jgs"],["Thủ Lãnh","Jdg | Jgs","Thủlãnh","Jdg","Jgs"]],[["Ruth","Ru","Ruth"],["Rut","Rt","Rut"],["Ruthi","Ru","Ruthi"],["","",""],["راعوث","Ru","راعوث"],["盧德紀","Ru","盧德紀"],["","Ru",""],["Rút","Ru","Rút"],["Ruth","Ruth","Ruth"],["Ruth","Ru","Ruth"],["Rut","Ru","Rut"],["Ρουθ","Ru","Ρουθ"],["Ruth","Ru","Ruth"],["Rut","Rt","Rut"],["ルツ記","Ru","ルツ記"],["룻기","룻","룻기"],["Ruth","Ru","Ruth"],["Rut","Rt","Rut"],["Rute","Ru","Rute"],["Rut","Ru","Rut"],["Руфь","Руф","Руфь"],["Rut","Rt","Rut"],["ரூத்து","Ru","ரூத்து"],["นางรูธ","Ru","นางรูธ"],["Rút","Ru","Rút"]],[["1 Samuel","1Sam","1Samuel"],["1 Samuel","1Sm","1Samuel"],["1Samuelit","1Sam","1Samuelit"],["","",""],["1صموئيل","1Sam","1صموئيل"],["撒慕爾紀上","1Sam","撒慕爾紀上"],["","1Sam",""],["1Samuelova","1Sam","1Samuelova"],["1 Samuel","1Sam","1Samuel"],["1Samuel","1Sam","1Samuel"],["1Samuel","1Sam","1Samuel"],["Α Σαμουήλ","1Sam","Ασαμουήλ"],["1Sámuel","1Sam","1Sámuel"],["1Samuele","1Sam","1Samuele"],["サムエル記上","1Sam","サムエル記上"],["사무엘 상","삼상","사무엘상"],["I Samuelis","I Sam","Isamuelis"],["1Samuela","1Sm","1Samuela"],["1 Samuel","1Sam","1Samuel"],["1Samuel","1Sam","1Samuel"],["1Царств","1Цар","1Царств"],["1Samuel","1Sa | 1Sam","1Samuel","1Sa","1Sam"],["1 சாமுவேல்","1Sam","1சாமுவேல்"],["1 ซามูเอล | ซามูเอลฉบับที่หึ่ง","1Sam","1ซามูเอล","ซามูเอลฉบับที่หึ่ง"],["1Samuen","1Sam","1Samuen"]],[["2 Samuel","2Sam","2Samuel"],["2 Samuel","2Sm","2Samuel"],["2Samuelit","2Sam","2Samuelit"],["","",""],["2صموئيل","2Sam","2صموئيل"],["撒慕爾記下","2Sam","撒慕爾記下"],["","2Sam",""],["2Samuelova","2Sam","2Samuelova"],["2 Samuel","2Sam","2Samuel"],["2Samuel","2Sam","2Samuel"],["2Samuel","2Sam","2Samuel"],["Β Σαμουήλ","2Sam","Βσαμουήλ"],["2Sámuel","2Sam","2Sámuel"],["2Samuele","2Sam","2Samuele"],["サムエル記下","2Sam","サムエル記下"],["사무엘 하","삼하","사무엘하"],["II Samuelis","II Sam","Iisamuelis"],["2Samuela","2Sm","2Samuela"],["2 Samuel","2Sam","2Samuel"],["2Samuel","2Sam","2Samuel"],["2Царств","2Цар","2Царств"],["2Samuel","2Sa | 2Sam","2Samuel","2Sa","2Sam"],["2 சாமுவேல்","2Sam","2சாமுவேல்"],["2 ซามูเอล | ซามูเอลฉบับที่สอง","2Sam","2ซามูเอล","ซามูเอลฉบับที่สอง"],["2Samuen","2Sam","2Samuen"]],[["1 Kings","1Kgs","1Kings"],["1 Konings","1Kn","1Konings"],["1Mbretërve","1Kgs","1Mbretërve"],["","",""],["1ملوك","1Kgs","1ملوك"],["列王紀上","1Kgs","列王紀上"],["","1Kgs",""],["1Královská","1Kgs","1Královská"],["1 Hari | 1 Mga Hari","1Ha","1Hari","1Mgahari"],["1Rois","1Kgs","1Rois"],["1Könige","1Kgs","1Könige"],["Α Βασιλέων","1Kgs","Αβασιλέων"],["1Királyok","1Kgs","1Királyok"],["1Re","1Re","1Re"],["列王紀上","1Kgs","列王紀上"],["열왕기 상","왕상","열왕기상"],["I Regum","I Reg","Iregum"],["1Królewska","1Krl","1Królewska"],["1 Reis","1Kgs","1Reis"],["1Imparati","1Kgs","1Imparati"],["3Царств","3Цар","3Царств"],["1Reyes","1Re","1Reyes"],["1 அரசர்கள்","1Kgs","1அரசர்கள்"],["1 พงศ์กษัตริย์ | พงศ์กษัตริย์ฉบับที่หึ่ง","1Kgs","1พงศ์กษัตริย์","พงศ์กษัตริย์ฉบับที่หึ่ง"],["1 Các Vua","1Kgs","1Cácvua"]],[["2 Kings","2Kgs","2Kings"],["2 Konings","2Kn","2Konings"],["2Mbretërve","2Kgs","2Mbretërve"],["","",""],["2ملوك","2Kgs","2ملوك"],["列王紀下","2Kgs","列王紀下"],["","2Kgs",""],["2Královská","2Kgs","2Královská"],["2 Hari | 2 Mga Hari","2Ha","2Hari","2Mgahari"],["2Rois","2Kgs","2Rois"],["2Könige","2Kgs","2Könige"],["Β Βασιλέων","2Kgs","Ββασιλέων"],["2Királyok","2Kgs","2Királyok"],["2Re","2Re","2Re"],["列王紀下","2Kgs","列王紀下"],["열왕기 하","왕하","열왕기하"],["II Regum","II Reg","Iiregum"],["2Królewska","2Krl","2Królewska"],["2 Reis","2Kgs","2Reis"],["2Imparati","2Kgs","2Imparati"],["4Царств","4Цар","4Царств"],["2Reyes","2Re","2Reyes"],["2 அரசர்கள்","2Kgs","2அரசர்கள்"],["2 พงศ์กษัตริย์ | พงศ์กษัตริย์ฉบับที่สอง","2Kgs","2พงศ์กษัตริย์","พงศ์กษัตริย์ฉบับที่สอง"],["2 Các Vua","2Kgs","2Cácvua"]],[["1 Chronicles","1Chron | 1Chr","1Chronicles","1Chron","1Chr"],["1 Kronieke","1Ch","1Kronieke"],["1Kronikave","1Chron | 1Chr","1Kronikave","1Chron","1Chr"],["","",""],["1اخبار","1Chron | 1Chr","1اخبار","1Chron","1Chr"],["編年紀上","1Chron | 1Chr","編年紀上","1Chron","1Chr"],["","1Chron | 1Chr","","1Chron","1Chr"],["1Paralipomenon","1Chron | 1Chr","1Paralipomenon","1Chron","1Chr"],["1 Cronica | 1 Mga Cronica","1Cro","1Cronica","1Mgacronica"],["1Chroniques","1Chron | 1Chr","1Chroniques","1Chron","1Chr"],["1Chronik","1Chron | 1Chr","1Chronik","1Chron","1Chr"],["Α Χρονικών","1Chron | 1Chr","Αχρονικών","1Chron","1Chr"],["1Krónika","1Chron | 1Chr","1Krónika","1Chron","1Chr"],["1Cronache","1Cr","1Cronache"],["歴代志上","1Chron | 1Chr","歴代志上","1Chron","1Chr"],["역대상 | 역대기 상","대상","역대상","역대기상"],["I Paralipomenon","I Paral","Iparalipomenon"],["1Kronik","1Krn","1Kronik"],["1 Crónicas","1Chron | 1Chr","1Crónicas","1Chron","1Chr"],["1Cronici","1Chron | 1Chr","1Cronici","1Chron","1Chr"],["1Паралипоменон","1Пар","1Паралипоменон"],["1Crónicas","1Cro | 1Crón","1Crónicas","1Cro","1Crón"],["1 குறிப்பேடு","1Chron | 1Chr","1குறிப்பேடு","1Chron","1Chr"],["1 พงศาวดาร | พงศาวดารฉบับที่หึ่ง","1Chron | 1Chr","1พงศาวดาร","พงศาวดารฉบับที่หึ่ง","1Chron","1Chr"],["1 Sử Biên Niên","1Chron | 1Chr","1Sửbiênniên","1Chron","1Chr"]],[["2 Chronicles","2Chron | 2Chr","2Chronicles","2Chron","2Chr"],["2 Kronieke","2Ch","2Kronieke"],["2Kronikave","2Chron | 2Chr","2Kronikave","2Chron","2Chr"],["","",""],["2اخبار","2Chron | 2Chr","2اخبار","2Chron","2Chr"],["編年記下","2Chron | 2Chr","編年記下","2Chron","2Chr"],["","2Chron | 2Chr","","2Chron","2Chr"],["2Paralipomenon","2Chron | 2Chr","2Paralipomenon","2Chron","2Chr"],["2 Cronica | 2 Mga Cronica","2Cro","2Cronica","2Mgacronica"],["2Chroniques","2Chron | 2Chr","2Chroniques","2Chron","2Chr"],["2Chronik","2Chron | 2Chr","2Chronik","2Chron","2Chr"],["Β Χρονικών","2Chron | 2Chr","Βχρονικών","2Chron","2Chr"],["2Krónika","2Chron | 2Chr","2Krónika","2Chron","2Chr"],["2Cronache","2Cr","2Cronache"],["歴代志下","2Chron | 2Chr","歴代志下","2Chron","2Chr"],["역대하 | 역대기 하","대하","역대하","역대기하"],["II Paralipomenon","II Paral","Iiparalipomenon"],["2Kronik","2Krn","2Kronik"],["2 Crónicas","2Chron | 2Chr","2Crónicas","2Chron","2Chr"],["2Cronici","2Chron | 2Chr","2Cronici","2Chron","2Chr"],["2Паралипоменон","2Пар","2Паралипоменон"],["2Crónicas","2Cro | 2Crón","2Crónicas","2Cro","2Crón"],["2 குறிப்பேடு","2Chron | 2Chr","2குறிப்பேடு","2Chron","2Chr"],["2 พงศาวดาร | พงศาวดารฉบับที่สอง","2Chron | 2Chr","2พงศาวดาร","พงศาวดารฉบับที่สอง","2Chron","2Chr"],["2 Sử Biên Niên","2Chron | 2Chr","2Sửbiênniên","2Chron","2Chr"]],[["Ezra","Ezr","Ezra"],["Esra","Ezr","Esra"],["Esdra","Ezr","Esdra"],["","",""],["عزرا","Ezr","عزرا"],["厄斯德拉上","Ezr","厄斯德拉上"],["","Ezr",""],["Ezdráš","Ezr","Ezdráš"],["Ezra","Ezr","Ezra"],["Esdras","Ezr","Esdras"],["Esra","Ezr","Esra"],["Έσδρας","Ezr","Έσδρας"],["Ezsdrás","Ezr","Ezsdrás"],["Esdra","Esd","Esdra"],["エズラ記","Ezr","エズラ記"],["에스라 | 에즈라","스","에스라","에즈라"],["Esdræ | Esdrae","Esd","Esdræ","Esdrae"],["Ezdrasza","Ezd","Ezdrasza"],["Esdras","Ezr","Esdras"],["Ezra","Ezr","Ezra"],["Ездра","Езд","Ездра"],["Esdras","Esd","Esdras"],["எஸ்ரா","Ezr","எஸ்ரா"],["เอสรา","Ezr","เอสรา"],["Étra","Ezr","Étra"]],[["Nehemiah","Neh","Nehemiah"],["Nehemia","Nh","Nehemia"],["Nehemía","Neh","Nehemía"],["","",""],["نحميا","Neh","نحميا"],["厄斯德拉下","Neh","厄斯德拉下"],["","Neh",""],["Nehemjáš","Neh","Nehemjáš"],["Nehemias","Neh","Nehemias"],["Néhémie","Neh","Néhémie"],["Nehemia","Neh","Nehemia"],["Νεεμίας","Neh","Νεεμίας"],["Nehemiás","Neh","Nehemiás"],["Neemia","Ne","Neemia"],["ネヘミヤ記","Neh","ネヘミヤ記"],["느헤미야","느","느헤미야"],["Nehemiæ | Nehemiae","Neh","Nehemiæ","Nehemiae"],["Nehemiasza","Ne","Nehemiasza"],["Neemias","Neh","Neemias"],["Neemia","Neh","Neemia"],["Неемия","Неем","Неемия"],["Nehemías","Ne | Neh","Nehemías","Ne","Neh"],["நெகேமியா","Neh","நெகேமியா"],["เนหะมีย์","Neh","เนหะมีย์"],["Nơkhemia","Neh","Nơkhemia"]],[["Tobit | Tobias","Tob","Tobit","Tobias"],["Tobias","","Tobias"],["Tobit","Tob","Tobit"],["","",""],["طوبيا","Tob","طوبيا"],["多俾亞傳","Tob","多俾亞傳"],["","Tob",""],["Tobiáš","Tob","Tobiáš"],["Tobit","Tob","Tobit"],["Tobie","Tob","Tobie"],["Tobit | Tobias","Tob","Tobit","Tobias"],["Τωβίτ","Tob","Τωβίτ"],["Tóbiás","Tob","Tóbiás"],["Tobia","Tb","Tobia"],["トビト記","Tob","トビト記"],["토비트","Tob","토비트"],["Thobis","Tob","Thobis"],["Tobiasza","Tb","Tobiasza"],["Tobias","Tob","Tobias"],["Tobit","Tob","Tobit"],["Тови́та","Тов","Тови́та"],["Tobías","Tb | Tob","Tobías","Tb","Tob"],["தோபித்து","Tob","தோபித்து"],["โทบิต","Tob","โทบิต"],["Tobit","Tob","Tobit"]],[["Judith","Jdt","Judith"],["Judith","","Judith"],["Judith","Jdt","Judith"],["","",""],["يهوديت","Jdt","يهوديت"],["友弟德傳","Jdt","友弟德傳"],["","Jdt",""],["Júdit","Jdt","Júdit"],["Judith","Jdt","Judith"],["Judith","Jdt","Judith"],["Judit","Jdt","Judit"],["Ιουδίθ","Jdt","Ιουδίθ"],["Judit","Jdt","Judit"],["Giuditta","Gdt","Giuditta"],["ユディト記","Jdt","ユディト記"],["유딧","Jdt","유딧"],["Iudith | Judith","Idt","Iudith","Judith"],["Judyty","Jdt","Judyty"],["Judite","Jdt","Judite"],["Iudita","Jdt","Iudita"],["Юдифи | Иудифи","Иудифь","Юдифи","Иудифи"],["Judit","Jdt","Judit"],["யூதித்து","Jdt","யூதித்து"],["ยูดิธ","Jdt","ยูดิธ"],["Judith","Jdt","Judith"]],[["Esther","Est","Esther"],["Ester","Es","Ester"],["Ester","Est","Ester"],["","",""],["استير","Est","استير"],["艾斯德爾傳","Est","艾斯德爾傳"],["","Est",""],["Ester","Est","Ester"],["Ester","Est","Ester"],["Esther","Est","Esther"],["Ester","Est","Ester"],["Εσθήρ","Est","Εσθήρ"],["Eszter","Est","Eszter"],["Ester","Est","Ester"],["エステル記","Est","エステル記"],["에스더 | 에스테르(에)","에","에스더","에스테르(에)"],["Esther","Est","Esther"],["Estery","Est","Estery"],["Ester","Est","Ester"],["Estera","Est","Estera"],["Есфирь","Есф","Есфирь"],["Ester","Est","Ester"],["எஸ்தர்","Est","எஸ்தர்"],["เอสเธอร์","Est","เอสเธอร์"],["Étte","Est","Étte"]],[["1 Maccabees","1Macc | 1Mc","1Maccabees","1Macc","1Mc"],["1 Makkabeërs","","1Makkabeërs"],["1 Maccabees","1Macc | 1Mc","1Maccabees","1Macc","1Mc"],["","",""],["المكابيين1","1Macc | 1Mc","المكابيين1","1Macc","1Mc"],["瑪加伯上","1Macc | 1Mc","瑪加伯上","1Macc","1Mc"],["","1Macc | 1Mc","","1Macc","1Mc"],["1Makabejská","1Macc | 1Mc","1Makabejská","1Macc","1Mc"],["1 Macabeo","1Mcb","1Macabeo"],["1 Maccabées","1Macc | 1Mc","1Maccabées","1Macc","1Mc"],["1Makkabäer","1Macc | 1Mc","1Makkabäer","1Macc","1Mc"],["A Μακκαβαίοι","1Macc | 1Mc","Aμακκαβαίοι","1Macc","1Mc"],["1 Makkabeusok","1Macc | 1Mc","1Makkabeusok","1Macc","1Mc"],["1Maccabei","1Mac","1Maccabei"],["マカバイ記1","1Macc | 1Mc","マカバイ記1","1Macc","1Mc"],["마카베오상","1Macc | 1Mc","마카베오상","1Macc","1Mc"],["I Maccabæorum | I Maccabaeorum","I Macc","Imaccabæorum","Imaccabaeorum"],["1Machabejska","1Mch","1Machabejska"],["1 Macabeus","1Macc | 1Mc","1Macabeus","1Macc","1Mc"],["1Macabei","1Macc | 1Mc","1Macabei","1Macc","1Mc"],["1Маккавейские","1Macc | 1Mc","1Маккавейские","1Macc","1Mc"],["1Macabeos","1Mac","1Macabeos"],["1 மக்கபேயர்","1Macc | 1Mc","1மக்கபேயர்","1Macc","1Mc"],["1 มัคคาบี | มัคคาบีฉบับที่หึ่ง","1Macc | 1Mc","1มัคคาบี","มัคคาบีฉบับที่หึ่ง","1Macc","1Mc"],["1 Maccabee","1Macc | 1Mc","1Maccabee","1Macc","1Mc"]],[["2 Maccabees","2Macc | 2Mc","2Maccabees","2Macc","2Mc"],["2 Makkabeërs","","2Makkabeërs"],["2 Maccabees","2Macc | 2Mc","2Maccabees","2Macc","2Mc"],["","",""],["المكابيين2","2Macc | 2Mc","المكابيين2","2Macc","2Mc"],["瑪加伯下","2Macc | 2Mc","瑪加伯下","2Macc","2Mc"],["","2Macc | 2Mc","","2Macc","2Mc"],["2Makabejská","2Macc | 2Mc","2Makabejská","2Macc","2Mc"],["2 Macabeo","2Mcb","2Macabeo"],["2 Maccabées","2Macc | 2Mc","2Maccabées","2Macc","2Mc"],["2Makkabäer","2Macc | 2Mc","2Makkabäer","2Macc","2Mc"],["B Μακκαβαίοι","2Macc | 2Mc","Bμακκαβαίοι","2Macc","2Mc"],["2 Makkabeusok","2Macc | 2Mc","2Makkabeusok","2Macc","2Mc"],["2Maccabei","2Mac","2Maccabei"],["マカバイ記2","2Macc | 2Mc","マカバイ記2","2Macc","2Mc"],["마카베오하","2Macc | 2Mc","마카베오하","2Macc","2Mc"],["II Maccabæorum | II Maccabaeorum","II Macc","Iimaccabæorum","Iimaccabaeorum"],["2Machabejska","2Mch","2Machabejska"],["2 Macabeus","2Macc | 2Mc","2Macabeus","2Macc","2Mc"],["2Macabei","2Macc | 2Mc","2Macabei","2Macc","2Mc"],["2Маккавейские","2Macc | 2Mc","2Маккавейские","2Macc","2Mc"],["2Macabeos","2Mac","2Macabeos"],["2 மக்கபேயர்","2Macc | 2Mc","2மக்கபேயர்","2Macc","2Mc"],["2 มัคคาบี | มัคคาบีฉบับที่สอง","2Macc | 2Mc","2มัคคาบี","มัคคาบีฉบับที่สอง","2Macc","2Mc"],["2 Maccabee","2Macc | 2Mc","2Maccabee","2Macc","2Mc"]],[["Job","Jb","Job"],["Job","Jb","Job"],["Jobi","Jb","Jobi"],["","",""],["ايوب","Jb","ايوب"],["約伯傳","Jb","約伯傳"],["","Jb",""],["Jób","Jb","Jób"],["Job","Job","Job"],["Job","Jb","Job"],["Ijob | Hiob","Jb","Ijob","Hiob"],["Ιώβ","Jb","Ιώβ"],["Jób","Jb","Jób"],["Giobbe","Gb","Giobbe"],["ヨブ記","Jb","ヨブ記"],["욥기","욥","욥기"],["Iob | Job","Iob","Iob","Job"],["Hioba","Hi","Hioba"],["Job","Jb","Job"],["Iov","Jb","Iov"],["Иов | Иова","Иов","Иов","Иова"],["Job","Jb","Job"],["யோபு","Jb","யோபு"],["โยบ","Jb","โยบ"],["Gióp","Jb","Gióp"]],[["Psalms | Psalm","Ps","Psalms","Psalm"],["Psalms | Psalm","Ps","Psalms","Psalm"],["Psalmet","Ps","Psalmet"],["","",""],["مزامير","Ps","مزامير"],["聖詠集","Ps","聖詠集"],["","Ps",""],["Žalmy | Žalm","Ps","Žalmy","Žalm"],["Awit | Mga Awit","Awit","Awit","Mgaawit"],["Psaumes | Psaume","Ps","Psaumes","Psaume"],["Psalter","Ps","Psalter"],["Ψαλμοί | Ψαλμός","Ps","Ψαλμοί","Ψαλμός"],["Zsoltárok | Zsoltár","Ps","Zsoltárok","Zsoltár"],["Salmi | Salmo","Sal","Salmi","Salmo"],["詩篇","Ps","詩篇"],["시편","시","시편"],["Psalmorum","Psal","Psalmorum"],["Psalmów","Ps","Psalmów"],["Salmos | Salmo","Ps","Salmos","Salmo"],["Psalmi","Ps","Psalmi"],["Псалтирь","Пс | Псал","Псалтирь","Пс","Псал"],["Salmos | Salmo","Sal","Salmos","Salmo"],["திருப்பாடல்கள்","Ps","திருப்பாடல்கள்"],["สดุดี | เพลงสดุดี","Ps","สดุดี","เพลงสดุดี"],["Thánh Vịnh | Thi Thiên","Ps","Thánhvịnh","Thithiên"]],[["Proverbs","Prov | Pr","Proverbs","Prov","Pr"],["Spreuke | Spreuke van Salomo","Pr","Spreuke","Spreukevansalomo"],["Fjalët e urta","Prov | Pr","Fjalëteurta","Prov","Pr"],["","",""],["امثال","Prov | Pr","امثال","Prov","Pr"],["箴言","Prov | Pr","箴言","Prov","Pr"],["","Prov | Pr","","Prov","Pr"],["Přísloví","Prov | Pr","Přísloví","Prov","Pr"],["Kawikaan | Mga Kawikaan","Kaw","Kawikaan","Mgakawikaan"],["Proverbes","Prov | Pr","Proverbes","Prov","Pr"],["Sprichwörter | Sprüche","Prov | Pr","Sprichwörter","Sprüche","Prov","Pr"],["Παροιμίες","Prov | Pr","Παροιμίες","Prov","Pr"],["Példabeszédek","Prov | Pr","Példabeszédek","Prov","Pr"],["Proverbi","Pr","Proverbi"],["箴言","Prov | Pr","箴言","Prov","Pr"],["잠언","잠","잠언"],["Proverbiorum","Prov","Proverbiorum"],["Przysłów","Prz","Przysłów"],["Provérbios","Prov | Pr","Provérbios","Prov","Pr"],["Proverbe","Prov | Pr","Proverbe","Prov","Pr"],["Притчи","Прит","Притчи"],["Proverbios","Pr | Prov","Proverbios","Pr","Prov"],["நீதிமொழிகள்","Prov | Pr","நீதிமொழிகள்","Prov","Pr"],["สุภาษิต","Prov | Pr","สุภาษิต","Prov","Pr"],["Châm Ngôn","Prov | Pr","Châmngôn","Prov","Pr"]],[["Ecclesiastes | Qoelet","Eccl | Qo","Ecclesiastes","Qoelet","Eccl","Qo"],["Prediker","Ec","Prediker"],["Predikuesi","Eccl | Qo","Predikuesi","Eccl","Qo"],["","",""],["جامعة","Eccl | Qo","جامعة","Eccl","Qo"],["訓道篇","Eccl | Qo","訓道篇","Eccl","Qo"],["","Eccl | Qo","","Eccl","Qo"],["Kazatel","Eccl | Qo","Kazatel","Eccl","Qo"],["Mangangaral | Ang Mangangaral","Manga","Mangangaral","Angmangangaral"],["Ecclésiaste","Eccl | Qo","Ecclésiaste","Eccl","Qo"],["Ecclesiastes","Eccl | Qo","Ecclesiastes","Eccl","Qo"],["Εκκλησιαστής","Eccl | Qo","Εκκλησιαστής","Eccl","Qo"],["Prédikátor","Eccl | Qo","Prédikátor","Eccl","Qo"],["Qoelet | Ecclesiaste","Qo","Qoelet","Ecclesiaste"],["伝道の書","Eccl | Qo","伝道の書","Eccl","Qo"],["전도서 | 코헬렛","전","전도서","코헬렛"],["Ecclesiastes","Eccl","Ecclesiastes"],["Koheleta","Koh","Koheleta"],["Coelet","Eccl | Qo","Coelet","Eccl","Qo"],["Ecclesiast","Eccl | Qo","Ecclesiast","Eccl","Qo"],["Екклесиаст | Екклесиаста","Екк","Екклесиаст","Екклесиаста"],["Eclesiastés | Qohélet | Qoélet | Cohélet","Qo | Ec | Ecl","Eclesiastés","Qohélet","Qoélet","Cohélet","Qo","Ec","Ecl"],["சபை உரையாளர்","Eccl | Qo","சபைஉரையாளர்","Eccl","Qo"],["ปัญญาจารย์","Eccl | Qo","ปัญญาจารย์","Eccl","Qo"],["Truyền đạo","Eccl | Qo","Truyềnđạo","Eccl","Qo"]],[["Song of Songs | Song | Canticle | Canticle of Canticles | Song of Solomon","Sg","Songofsongs","Song","Canticle","Canticleofcanticles","Songofsolomon"],["Hooglied | Hooglied van Salomo","Sn","Hooglied","Hoogliedvansalomo"],["Kantiku | Kantiku i Kantikëve","Sg","Kantiku","Kantikuikantikëve"],["","",""],["نشيدالانشاد","Sg","نشيدالانشاد"],["雅歌","Sg","雅歌"],["","Sg",""],["Píseň písní","Sg","Píseňpísní"],["Awit ni Solomon | Ang Awit ni Solomon","Aw ni S | Awnis","Awitnisolomon","Angawitnisolomon","Awnis","Awnis"],["Cantique | Cantique des Cantiques","Sg","Cantique","Cantiquedescantiques"],["Hoheslied","Sg","Hoheslied"],["Άσμα Ασμάτων","Sg","Άσμαασμάτων"],["Énekek | Énekek Éneke","Sg","Énekek","Énekekéneke"],["Cantico | Cantico dei Cantici","Ct","Cantico","Canticodeicantici"],["雅歌","Sg","雅歌"],["아가","아","아가"],["Canticum Canticorum | Canticum","Cant","Canticumcanticorum","Canticum"],["Pieśń nad Pieśniami","Pnp","Pieśńnadpieśniami"],["Cântico","Sg","Cântico"],["Cantarea | Cantarea Cantarilor","Sg","Cantarea","Cantareacantarilor"],["Песни Песней | Песнь песней Соломона","Песн","Песнипесней","Песньпеснейсоломона"],["Cantares | Cantar de los Cantares","Cant","Cantares","Cantardeloscantares"],["இனிமைமிகு பாடல்","Sg","இனிமைமிகுபாடல்"],["เพลงโซโลมอน | เพลงซาโลมอน","Sg","เพลงโซโลมอน","เพลงซาโลมอน"],["Diễm Ca | Nhã ca","Sg","Diễmca","Nhãca"]],[["Wisdom","Ws | Wis","Wisdom","Ws","Wis"],["Wysheid","","Wysheid"],["Wisdom","Ws | Wis","Wisdom","Ws","Wis"],["","",""],["الحكمة","Ws | Wis","الحكمة","Ws","Wis"],["智慧篇","Ws | Wis","智慧篇","Ws","Wis"],["","Ws | Wis","","Ws","Wis"],["Moudrosti","Ws | Wis","Moudrosti","Ws","Wis"],["Karunungan | Ang Karunungan | Ang Karunungan ni Solomon","Kar","Karunungan","Angkarunungan","Angkarunungannisolomon"],["Sagesse","Ws | Wis","Sagesse","Ws","Wis"],["Weisheit","Ws | Wis","Weisheit","Ws","Wis"],["Σοφία","Ws | Wis","Σοφία","Ws","Wis"],["Bölcsesség","Ws | Wis","Bölcsesség","Ws","Wis"],["Sapienza","Sap","Sapienza"],["知恵の書","Ws | Wis","知恵の書","Ws","Wis"],["지혜서","Ws | Wis","지혜서","Ws","Wis"],["Sapientiæ | Sapientiae","Sap","Sapientiæ","Sapientiae"],["Mądrości","Mdr","Mądrości"],["Sabedoria","Ws | Wis","Sabedoria","Ws","Wis"],["Înţelepciunea","Ws | Wis","Înţelepciunea","Ws","Wis"],["Премудрость | Премудрость Соломона","Ws | Wis","Премудрость","Премудростьсоломона","Ws","Wis"],["Sabiduría","Sb | Sab","Sabiduría","Sb","Sab"],["சாலமோனின் ஞானம்","Ws | Wis","சாலமோனின்ஞானம்","Ws","Wis"],["ปรีชาญาณ","Ws | Wis","ปรีชาญาณ","Ws","Wis"],["Khôn Ngoan","Ws | Wis","Khônngoan","Ws","Wis"]],[["Ecclesiasticus | Sirach","Sir","Ecclesiasticus","Sirach"],["Sirag","","Sirag"],["Sirach","Sir","Sirach"],["","",""],["يشوع بن سيراخ","Sir","يشوعبنسيراخ"],["德訓篇","Sir","德訓篇"],["","Sir",""],["Sírachovcova","Sir","Sírachovcova"],["Ecclesiastico","Ecc","Ecclesiastico"],["Siracide","Sir","Siracide"],["Sirach","Sir","Sirach"],["Σειράχ","Sir","Σειράχ"],["Sirák fia","Sir","Sirákfia"],["Siracide","Sir","Siracide"],["シラ書","Sir","シラ書"],["집회서","Sir","집회서"],["Ecclesiasticus","Ecc","Ecclesiasticus"],["Syracha","Syr","Syracha"],["Eclesiástico","Sir","Eclesiástico"],["Sirah","Sir","Sirah"],["Иисуса | Премудрости Иисуса","Sir","Иисуса","Премудростииисуса"],["Sirácides | Eclesiástico","Si | Sir | Ecli","Sirácides","Eclesiástico","Si","Sir","Ecli"],["சீராக்கின் ஞானம்","Sir","சீராக்கின்ஞானம்"],["บุตรสิรา","Sir","บุตรสิรา"],["Huấn Ca | Truyền Đạo","Sir","Huấnca","Truyềnđạo"]],[["Isaiah","Is","Isaiah"],["Jesaja","Is","Jesaja"],["Isaia","Is","Isaia"],["","",""],["اشعياء","Is","اشعياء"],["依撒意亞","Is","依撒意亞"],["","Is",""],["Izajáš","Is","Izajáš"],["Isaias","Isa","Isaias"],["Isaïe","Is","Isaïe"],["Jesaja","Is","Jesaja"],["Ησαΐας","Is","Ησαΐας"],["Ézsaiás","Is","Ézsaiás"],["Isaia","Is","Isaia"],["イザヤ書","Is","イザヤ書"],["이사야","사","이사야"],["Isaiæ | Isaiae","Is","Isaiæ","Isaiae"],["Izajasza","Iz","Izajasza"],["Isaías","Is","Isaías"],["Isaia","Is","Isaia"],["Исаия","Ис | Исаи","Исаия","Ис","Исаи"],["Isaías","Is","Isaías"],["எசாயா","Is","எசாயா"],["อิสยาห์","Is","อิสยาห์"],["Isaia | Yeshvahu","Is","Isaia","Yeshvahu"]],[["Jeremiah","Jer","Jeremiah"],["Jeremia","Jr","Jeremia"],["Jeremia","Jer","Jeremia"],["","",""],["ارميا","Jer","ارميا"],["耶肋米亞","Jer","耶肋米亞"],["","Jer",""],["Jeremjáš","Jer","Jeremjáš"],["Jeremias","Jer","Jeremias"],["Jérémie","Jer","Jérémie"],["Jeremia","Jer","Jeremia"],["Ιερεμίας","Jer","Ιερεμίας"],["Jeremiás","Jer","Jeremiás"],["Geremia","Ger","Geremia"],["エレミヤ書","Jer","エレミヤ書"],["예레미야","렘","예레미야"],["Ieremiæ | Ieremiae | Jeremiæ | Jeremiae","Ier","Ieremiæ","Ieremiae","Jeremiæ","Jeremiae"],["Jeremiasza","Jr","Jeremiasza"],["Jeremias","Jer","Jeremias"],["Ieremia","Jer","Ieremia"],["Иеремия","Иер","Иеремия"],["Jeremías","Jr | Jer","Jeremías","Jr","Jer"],["எரேமியா","Jer","எரேமியா"],["เยเรมีย์","Jer","เยเรมีย์"],["Giêrêmia | Yirmiyahu","Jer","Giêrêmia","Yirmiyahu"]],[["Lamentations","Lam","Lamentations"],["Klaagliedere | Klaagliedere van Jeremia","Lm","Klaagliedere","Klaagliederevanjeremia"],["Vajtimet","Lam","Vajtimet"],["","",""],["مراثي","Lam","مراثي"],["耶肋米亞哀歌","Lam","耶肋米亞哀歌"],["","Lam",""],["Pláč","Lam","Pláč"],["Panaghoy | Mga Panaghoy","Panag","Panaghoy","Mgapanaghoy"],["Lamentations","Lam","Lamentations"],["Klagelieder","Lam","Klagelieder"],["Θρήνοι","Lam","Θρήνοι"],["Jeremiás sír","Lam","Jeremiássír"],["Lamentazioni","Lam","Lamentazioni"],["哀歌","Lam","哀歌"],["예레미야애가 | 애가","애","예레미야애가","애가"],["Lamentationes","Lam","Lamentationes"],["Lamentacje","Lm","Lamentacje"],["Lamentações","Lam","Lamentações"],["Plângeri","Lam","Plângeri"],["ПлачИеремии","Плач","Плачиеремии"],["Lamentaciones","Lam","Lamentaciones"],["புலம்பல்","Lam","புலம்பல்"],["เพลงคร่ำครวญ","Lam","เพลงคร่ำครวญ"],["Ai Ca | Ca Thương","Lam","Aica","Cathương"]],[["Baruch","Bar","Baruch"],["Baruch","","Baruch"],["Baruku","Bar","Baruku"],["","",""],["باروك","Bar","باروك"],["巴路克","Bar","巴路克"],["","Bar",""],["Báruch","Bar","Báruch"],["Baruc","Bar","Baruc"],["Baruch","Bar","Baruch"],["Baruch","Bar","Baruch"],["Βαρούχ","Bar","Βαρούχ"],["Báruk","Bar","Báruk"],["Baruc","Bar","Baruc"],["バルク書","Bar","バルク書"],["바룩","Bar","바룩"],["Baruch","Bar","Baruch"],["Barucha","Ba","Barucha"],["Baruc","Bar","Baruc"],["Baruh","Bar","Baruh"],["Варуха","Bar","Варуха"],["Baruc","Ba | Bar","Baruc","Ba","Bar"],["பாரூக்கு","Bar","பாரூக்கு"],["บารุค","Bar","บารุค"],["Baruch","Bar","Baruch"]],[["Ezekiel","Ez","Ezekiel"],["Eségiël","Ek","Eségiël"],["Ezekieli","Ez","Ezekieli"],["","",""],["حزقيال","Ez","حزقيال"],["厄則克爾","Ez","厄則克爾"],["","Ez",""],["Ezechiel","Ez","Ezechiel"],["Ezekiel","Eze","Ezekiel"],["Ézéchiel","Ez","Ézéchiel"],["Ezechiel | Hesekiel","Ez","Ezechiel","Hesekiel"],["Ιεζεκιήλ","Ez","Ιεζεκιήλ"],["Ezékiel","Ez","Ezékiel"],["Ezechiele","Ez","Ezechiele"],["エゼキエル書","Ez","エゼキエル書"],["에스겔 | 에제키엘","겔","에스겔","에제키엘"],["Ezechielis","Ez","Ezechielis"],["Ezechiela","Ez","Ezechiela"],["Ezequiel","Ez","Ezequiel"],["Ezechiel","Ez","Ezechiel"],["Иезекииль","Иез","Иезекииль"],["Ezequiel","Ez","Ezequiel"],["எசேக்கியேல்","Ez","எசேக்கியேல்"],["เอเสเคียล","Ez","เอเสเคียล"],["Êdêkien | Êxêkiên","Ez","Êdêkien","Êxêkiên"]],[["Daniel","Dan | Dn","Daniel","Dan","Dn"],["Daniël","Dn","Daniël"],["Danieli","Dan | Dn","Danieli","Dan","Dn"],["","",""],["دانيال","Dan | Dn","دانيال","Dan","Dn"],["達尼爾","Dan | Dn","達尼爾","Dan","Dn"],["","Dan | Dn","","Dan","Dn"],["Daniel","Dan | Dn","Daniel","Dan","Dn"],["Daniel","Dan | Dn","Daniel","Dan","Dn"],["Daniel","Dan | Dn","Daniel","Dan","Dn"],["Daniel","Dan | Dn","Daniel","Dan","Dn"],["Δανιήλ","Dan | Dn","Δανιήλ","Dan","Dn"],["Dániel","Dan | Dn","Dániel","Dan","Dn"],["Daniele","Dn","Daniele"],["ダニエル書","Dan | Dn","ダニエル書","Dan","Dn"],["다니엘","단","다니엘"],["Danielis","Dan","Danielis"],["Daniela","Dn","Daniela"],["Daniel","Dan | Dn","Daniel","Dan","Dn"],["Daniel","Dan | Dn","Daniel","Dan","Dn"],["Даниил","Дан","Даниил"],["Daniel","Dn | Dan","Daniel","Dn","Dan"],["தானியேல்","Dan | Dn","தானியேல்","Dan","Dn"],["ดาเนียล","Dan | Dn","ดาเนียล","Dan","Dn"],["Daniel","Dan | Dn","Daniel","Dan","Dn"]],[["Hosea","Hos","Hosea"],["Hoséa","Hs","Hoséa"],["Osea","Hos","Osea"],["","",""],["هوشع","Hos","هوشع"],["甌瑟亞","Hos","甌瑟亞"],["","Hos",""],["Ozeáš","Hos","Ozeáš"],["Hosea","Hos","Hosea"],["Osée","Hos","Osée"],["Hosea","Hos","Hosea"],["Ωσηέ","Hos","Ωσηέ"],["Hóseás","Hos","Hóseás"],["Osea","Os","Osea"],["ホセア書","Hos","ホセア書"],["호세아","호","호세아"],["Osee","Os","Osee"],["Ozeasza","Oz","Ozeasza"],["Oseias","Hos","Oseias"],["Osea","Hos","Osea"],["Осия","Ос","Осия"],["Oseas","Os","Oseas"],["ஓசேயா","Hos","ஓசேயா"],["โฮเชยา","Hos","โฮเชยา"],["Hosea | Hoshea","Hos","Hosea","Hoshea"]],[["Joel","Jl","Joel"],["Joël","Jl","Joël"],["Joeli","Jl","Joeli"],["","",""],["يوئيل","Jl","يوئيل"],["岳厄爾","Jl","岳厄爾"],["","Jl",""],["Jóel","Jl","Jóel"],["Joel","Joel","Joel"],["Joël","Jl","Joël"],["Joel","Jl","Joel"],["Ιωήλ","Jl","Ιωήλ"],["Jóel","Jl","Jóel"],["Gioele","Gl","Gioele"],["ヨエル書","Jl","ヨエル書"],["요엘","욜","요엘"],["Ioel","Ioel","Ioel"],["Joela","Jl","Joela"],["Joel","Jl","Joel"],["Ioel","Jl","Ioel"],["Иоиль","Иоил","Иоиль"],["Joel","Jl","Joel"],["யோவேல்","Jl","யோவேல்"],["โยเอล","Jl","โยเอล"],["Joel | Giôên","Jl","Joel","Giôên"]],[["Amos","Am","Amos"],["Amos","Am","Amos"],["Amosi","Am","Amosi"],["","",""],["عاموس","Am","عاموس"],["亞毛斯","Am","亞毛斯"],["","Am",""],["Ámos","Am","Ámos"],["Amos","Amos","Amos"],["Amos","Am","Amos"],["Amos","Am","Amos"],["Αμώς","Am","Αμώς"],["Ámos","Am","Ámos"],["Amos","Am","Amos"],["アモス書","Am","アモス書"],["아모스","암","아모스"],["Amos","Am","Amos"],["Amosa","Am","Amosa"],["Amós","Am","Amós"],["Amos","Am","Amos"],["Амос","Амос","Амос"],["Amós","Am","Amós"],["ஆமோஸ்","Am","ஆமோஸ்"],["อาโมส","Am","อาโมส"],["Amos","Am","Amos"]],[["Obadiah","Ob","Obadiah"],["Obádja","Ob","Obádja"],["Abdia","Ob","Abdia"],["","",""],["عوبديا","Ob","عوبديا"],["亞北底亞","Ob","亞北底亞"],["","Ob",""],["Abdijáš","Ob","Abdijáš"],["Obadias","Oba","Obadias"],["Abdias","Ob","Abdias"],["Obadja","Ob","Obadja"],["Αβδιού","Ob","Αβδιού"],["Abdiás","Ob","Abdiás"],["Abdia","Abd","Abdia"],["オバデヤ書","Ob","オバデヤ書"],["오바댜","옵","오바댜"],["Abdiæ | Abdiae | Abdia","Abd","Abdiæ","Abdiae","Abdia"],["Abdiasza","Ab","Abdiasza"],["Abdias","Ob","Abdias"],["Obadia","Ob","Obadia"],["Авдия","Авд","Авдия"],["Abdías","Abd","Abdías"],["ஒபதியா","Ob","ஒபதியா"],["โอบาดีห์","Ob","โอบาดีห์"],["Obadiah | Ovadyah","Ob","Obadiah","Ovadyah"]],[["Jonah","Jon","Jonah"],["Jona","Jon","Jona"],["Jona","Jon","Jona"],["","",""],["يونان","Jon","يونان"],["約納","Jon","約納"],["","Jon",""],["Jonáš","Jon","Jonáš"],["Jonas","Jon","Jonas"],["Jonas","Jon","Jonas"],["Jona","Jon","Jona"],["Ιωνάς","Jon","Ιωνάς"],["Jónás","Jon","Jónás"],["Giona","Gna","Giona"],["ヨナ書","Jon","ヨナ書"],["요나","욘","요나"],["Ionæ | Ionae | Jonæ | Jonae | Iona | Jona","Ion","Ionæ","Ionae","Jonæ","Jonae","Iona","Jona"],["Jonasza","Jon","Jonasza"],["Jonas","Jon","Jonas"],["Iona","Jon","Iona"],["Иона","Иона","Иона"],["Jonás","Jon","Jonás"],["யோனா","Jon","யோனா"],["โยนาห์","Jon","โยนาห์"],["Jonah | Yonah","Jon","Jonah","Yonah"]],[["Micah","Mi | Mic","Micah","Mi","Mic"],["Miga","Mi","Miga"],["Mikea","Mi | Mic","Mikea","Mi","Mic"],["","",""],["ميخا","Mi | Mic","ميخا","Mi","Mic"],["米該亞","Mi | Mic","米該亞","Mi","Mic"],["","Mi | Mic","","Mi","Mic"],["Micheáš","Mi | Mic","Micheáš","Mi","Mic"],["Mikas","Mik","Mikas"],["Michée","Mi | Mic","Michée","Mi","Mic"],["Micha","Mi | Mic","Micha","Mi","Mic"],["Μιχαίας","Mi | Mic","Μιχαίας","Mi","Mic"],["Mikeás","Mi | Mic","Mikeás","Mi","Mic"],["Michea","Mi","Michea"],["ミカ書","Mi | Mic","ミカ書","Mi","Mic"],["미가 | 미카","미","미가","미카"],["Michææ | Michaeae","Mich","Michææ","Michaeae"],["Micheasza","Mi","Micheasza"],["Miqueias","Mi | Mic","Miqueias","Mi","Mic"],["Mica","Mi | Mic","Mica","Mi","Mic"],["Михей","Мих","Михей"],["Miqueas","Mi | Miq","Miqueas","Mi","Miq"],["மீக்கா","Mi | Mic","மீக்கா","Mi","Mic"],["มีคาห์","Mi | Mic","มีคาห์","Mi","Mic"],["Micah | Mikhah","Mi | Mic","Micah","Mikhah","Mi","Mic"]],[["Nahum","Na | Nah","Nahum","Na","Nah"],["Nahum","Na","Nahum"],["Nahumi","Na | Nah","Nahumi","Na","Nah"],["","",""],["ناحوم","Na | Nah","ناحوم","Na","Nah"],["納鴻","Na | Nah","納鴻","Na","Nah"],["","Na | Nah","","Na","Nah"],["Nahum","Na | Nah","Nahum","Na","Nah"],["Nahum","Nah","Nahum"],["Nahoum","Na | Nah","Nahoum","Na","Nah"],["Nahum","Na | Nah","Nahum","Na","Nah"],["Ναούμ","Na | Nah","Ναούμ","Na","Nah"],["Náhum","Na | Nah","Náhum","Na","Nah"],["Naum","Na","Naum"],["ナホム書","Na | Nah","ナホム書","Na","Nah"],["나훔","나","나훔"],["Nahum","Nah","Nahum"],["Nahuma","Na","Nahuma"],["Naum","Na | Nah","Naum","Na","Nah"],["Naum","Na | Nah","Naum","Na","Nah"],["Наум","Наум","Наум"],["Nahúm","Na | Nah","Nahúm","Na","Nah"],["நாகூம்","Na | Nah","நாகூம்","Na","Nah"],["นาฮูม","Na | Nah","นาฮูม","Na","Nah"],["Nahum | Nachum","Na | Nah","Nahum","Nachum","Na","Nah"]],[["Habakkuk","Hab","Habakkuk"],["Hábakuk","Hk","Hábakuk"],["Habakuku","Hab","Habakuku"],["","",""],["حبقوق","Hab","حبقوق"],["哈巴谷","Hab","哈巴谷"],["","Hab",""],["Abakuk","Hab","Abakuk"],["Habakuk","Hab","Habakuk"],["Habaquq","Hab","Habaquq"],["Habakuk","Hab","Habakuk"],["Αββακούμ","Hab","Αββακούμ"],["Habakuk","Hab","Habakuk"],["Abacuc","Ab","Abacuc"],["ハバクク書","Hab","ハバクク書"],["하박국 | 하바쿡","합","하박국","하바쿡"],["Habacuc","Hab","Habacuc"],["Habakuka","Ha","Habakuka"],["Habacuc","Hab","Habacuc"],["Habacuc","Hab","Habacuc"],["Аввакум","Авв","Аввакум"],["Habacuc","Ha | Hab","Habacuc","Ha","Hab"],["அபக்கூக்கு","Hab","அபக்கூக்கு"],["ฮาบากุก","Hab","ฮาบากุก"],["Habakkuk | Habaquq","Hab","Habakkuk","Habaquq"]],[["Zephaniah","Zeph","Zephaniah"],["Sefánja","Zp","Sefánja"],["Sofonia","Zeph","Sofonia"],["","",""],["صفنيا","Zeph","صفنيا"],["索福尼亞","Zeph","索福尼亞"],["","Zeph",""],["Sofonjáš","Zeph","Sofonjáš"],["Zefanias","Zef","Zefanias"],["Sophonie","Zeph","Sophonie"],["Zefanja","Zeph","Zefanja"],["Σοφονίας","Zeph","Σοφονίας"],["Sofoniás","Zeph","Sofoniás"],["Sofonia","Sof","Sofonia"],["ゼパニヤ書","Zeph","ゼパニヤ書"],["스바냐 | 스바니야","습","스바냐","스바니야"],["Sophoniæ | Sophoniae | Sophonia","Soph","Sophoniæ","Sophoniae","Sophonia"],["Sofoniasza","So","Sofoniasza"],["Sofonias","Zeph","Sofonias"],["Tefania","Zeph","Tefania"],["Софония","Соф","Софония"],["Sofonías","Sof","Sofonías"],["செப்பனியா","Zeph","செப்பனியா"],["เศฟันยาห์","Zeph","เศฟันยาห์"],["Zephaniah | Tsefania","Zeph","Zephaniah","Tsefania"]],[["Haggai","Hag | Hg","Haggai","Hag","Hg"],["Haggai","Hg","Haggai"],["Hagai","Hag | Hg","Hagai","Hag","Hg"],["","",""],["حجى","Hag | Hg","حجى","Hag","Hg"],["哈蓋","Hag | Hg","哈蓋","Hag","Hg"],["","Hag | Hg","","Hag","Hg"],["Ageus","Hag | Hg","Ageus","Hag","Hg"],["Hagai","Hag","Hagai"],["Aggée","Hag | Hg","Aggée","Hag","Hg"],["Haggai","Hag | Hg","Haggai","Hag","Hg"],["Αγγαίος","Hag | Hg","Αγγαίος","Hag","Hg"],["Aggeus","Hag | Hg","Aggeus","Hag","Hg"],["Aggeo","Ag","Aggeo"],["ハガイ書","Hag | Hg","ハガイ書","Hag","Hg"],["학개 | 하까이","학","학개","하까이"],["Aggæi | Aggaei","Agg","Aggæi","Aggaei"],["Aggeusza","Ag","Aggeusza"],["Ageu","Hag | Hg","Ageu","Hag","Hg"],["Hagai","Hag | Hg","Hagai","Hag","Hg"],["Аггей","Агг","Аггей"],["Ageo","Ag","Ageo"],["ஆகாய்","Hag | Hg","ஆகாய்","Hag","Hg"],["ฮักกัย","Hag | Hg","ฮักกัย","Hag","Hg"],["Haggai","Hag | Hg","Haggai","Hag","Hg"]],[["Zechariah","Zech","Zechariah"],["Sagaría","Zc","Sagaría"],["Zakaria","Zech","Zakaria"],["","",""],["زكريا","Zech","زكريا"],["匝加利亞","Zech","匝加利亞"],["","Zech",""],["Zacharjáš","Zech","Zacharjáš"],["Zacarias","Zac","Zacarias"],["Zacharie","Zech","Zacharie"],["Sacharja","Zech","Sacharja"],["Ζαχαρίας","Zech","Ζαχαρίας"],["Zakariás","Zech","Zakariás"],["Zaccaria","Zc","Zaccaria"],["ゼカリヤ書","Zech","ゼカリヤ書"],["스가랴 | 즈카르야","슥","스가랴","즈카르야"],["Zachariæ | Zachariae","Zach","Zachariæ","Zachariae"],["Zachariasza","Za","Zachariasza"],["Zacarias","Zech","Zacarias"],["Zaharia","Zech","Zaharia"],["Захария","Зах","Захария"],["Zacarías","Za | Zac","Zacarías","Za","Zac"],["செக்கரியா","Zech","செக்கரியா"],["เศคาริยาห์","Zech","เศคาริยาห์"],["Zechariah | Zekharia","Zech","Zechariah","Zekharia"]],[["Malachi","Mal | Ml","Malachi","Mal","Ml"],["Maleági","Ml","Maleági"],["Malakia","Mal | Ml","Malakia","Mal","Ml"],["","",""],["ملاخي","Mal | Ml","ملاخي","Mal","Ml"],["瑪拉基亞","Mal | Ml","瑪拉基亞","Mal","Ml"],["","Mal | Ml","","Mal","Ml"],["Malachiáš","Mal | Ml","Malachiáš","Mal","Ml"],["Malakias","Mal","Malakias"],["Malachie","Mal | Ml","Malachie","Mal","Ml"],["Maleachi","Mal | Ml","Maleachi","Mal","Ml"],["Μαλαχίος","Mal | Ml","Μαλαχίος","Mal","Ml"],["Malakiás","Mal | Ml","Malakiás","Mal","Ml"],["Malachia","Ml","Malachia"],["マラキ書","Mal | Ml","マラキ書","Mal","Ml"],["말라기 | 말라키","말","말라기","말라키"],["Malachiæ | Malachiae","Mal","Malachiæ","Malachiae"],["Malachiasza","Ml","Malachiasza"],["Malaquias","Mal | Ml","Malaquias","Mal","Ml"],["Maleahi","Mal | Ml","Maleahi","Mal","Ml"],["Малахия","Мал","Малахия"],["Malaquías","Ml | Mal","Malaquías","Ml","Mal"],["மலாக்கி","Mal | Ml","மலாக்கி","Mal","Ml"],["มาลาคี","Mal | Ml","มาลาคี","Mal","Ml"],["Malachi | Malakhi","Mal | Ml","Malachi","Malakhi","Mal","Ml"]],[["Matthew","Matt | Mt","Matthew","Matt","Mt"],["Matthéüs","Mt","Matthéüs"],["Mateu","Matt | Mt","Mateu","Matt","Mt"],["","",""],["متى","Matt | Mt","متى","Matt","Mt"],["瑪竇福音","Matt | Mt","瑪竇福音","Matt","Mt"],["","Matt | Mt","","Matt","Mt"],["Matouše","Matt | Mt","Matouše","Matt","Mt"],["Mateo","Mt","Mateo"],["Matthieu","Matt | Mt","Matthieu","Matt","Mt"],["Matthäus","Matt | Mt","Matthäus","Matt","Mt"],["Ματθαίος","Matt | Mt","Ματθαίος","Matt","Mt"],["Máté","Matt | Mt","Máté","Matt","Mt"],["Matteo","Mt","Matteo"],["マタイによる福音書","Matt | Mt","マタイによる福音書","Matt","Mt"],["마태 | 마태오 복음","Matt | Mt","마태","마태오복음","Matt","Mt"],["Matthæum | Matthaeum | Matthaeus","Mt","Matthæum","Matthaeum","Matthaeus"],["Mateusza","Mt","Mateusza"],["Mateus","Matt | Mt","Mateus","Matt","Mt"],["Matei","Matt | Mt","Matei","Matt","Mt"],["Матфея","Matt | Mt","Матфея","Matt","Mt"],["Mateo","Mt","Mateo"],["மத்தேயு","Matt | Mt","மத்தேயு","Matt","Mt"],["มัทธิว","Matt | Mt","มัทธิว","Matt","Mt"],["Mátthêu | Mathiơ","Matt | Mt","Mátthêu","Mathiơ","Matt","Mt"]],[["Mark","Mk","Mark"],["Markus","Mr","Markus"],["Marku","Mk","Marku"],["","",""],["مرقس","Mk","مرقس"],["馬爾谷福音","Mk","馬爾谷福音"],["","Mk",""],["Marka","Mk","Marka"],["Marcos","Mc","Marcos"],["Marc","Mk","Marc"],["Markus","Mk","Markus"],["Μάρκος","Mk","Μάρκος"],["Márk","Mk","Márk"],["Marco","Mc","Marco"],["マルコによる福音書","Mk","マルコによる福音書"],["마가 | 마르코 복음","Mk","마가","마르코복음"],["Marcum | Marcus","Mc","Marcum","Marcus"],["Marka","Mk","Marka"],["Marcos","Mk","Marcos"],["Marcu","Mk","Marcu"],["Марка","Mk","Марка"],["Marcos","Mc","Marcos"],["மாற்கு","Mk","மாற்கு"],["มาระโก","Mk","มาระโก"],["Máccô | Mác","Mk","Máccô","Mác"]],[["Luke","Lk","Luke"],["Lukas","Lk","Lukas"],["Luka","Lk","Luka"],["","",""],["لوقا","Lk","لوقا"],["路加福音","Lk","路加福音"],["","Lk",""],["Lukáše","Lk","Lukáše"],["Lucas","Lu","Lucas"],["Luc","Lk","Luc"],["Lukas","Lk","Lukas"],["Λουκάς","Lk","Λουκάς"],["Lukács","Lk","Lukács"],["Luca","Lc","Luca"],["ルカによる福音書","Lk","ルカによる福音書"],["누가 | 루카 복음","Lk","누가","루카복음"],["Lucam | Lucas","Lc","Lucam","Lucas"],["Łukasza","Łk","Łukasza"],["Lucas","Lk","Lucas"],["Luca","Lk","Luca"],["Луки","Lk","Луки"],["Lucas","Lc","Lucas"],["லூக்கா","Lk","லூக்கா"],["ลูกา","Lk","ลูกา"],["Luca","Lk","Luca"]],[["John","Jn","John"],["Johannes","Jh","Johannes"],["Gjoni","Jn","Gjoni"],["","",""],["يوحنا","Jn","يوحنا"],["若望福音","Jn","若望福音"],["","Jn",""],["Jana","Jn","Jana"],["Juan","Jn","Juan"],["Jean","Jn","Jean"],["Johannes","Jn","Johannes"],["Ιωάννης","Jn","Ιωάννης"],["János","Jn","János"],["Giovanni","Gv","Giovanni"],["ヨハネによる福音書","Jn","ヨハネによる福音書"],["요한 복음","Jn","요한복음"],["Ioannem | Ioannes | Joannes | Johannes | Iohannes","Ioh","Ioannem","Ioannes","Joannes","Johannes","Iohannes"],["Jana","J","Jana"],["João","Jn","João"],["Ioan","Jn","Ioan"],["Иоанна","Jn","Иоанна"],["Juan","Jn","Juan"],["யோவான்","Jn","யோவான்"],["ยอห์น","Jn","ยอห์น"],["Gioan | Giăng","Jn","Gioan","Giăng"]],[["Acts | Acts of the Apostles","Ac","Acts","Actsoftheapostles"],["Handelinge | Die handelinge van die apostels","Ac","Handelinge","Diehandelingevandieapostels"],["Veprat | Veprat e Apostujve","Ac","Veprat","Veprateapostujve"],["","",""],["اعمال","Ac","اعمال"],["宗徒大事錄","Ac","宗徒大事錄"],["","Ac",""],["Skutky apoštolů","Ac","Skutkyapoštolů"],["Gawa | Mga Gawa","Gw","Gawa","Mgagawa"],["Actes","Ac","Actes"],["Apostelgeschichte","Ac","Apostelgeschichte"],["Πράξεις | Πράξεις των Αποστόλων","Ac","Πράξεις","Πράξειςτωναποστόλων"],["Apostolok","Ac","Apostolok"],["Atti | Atti degli Apostoli","At","Atti","Attidegliapostoli"],["使徒行伝","Ac","使徒行伝"],["사도행전","Ac","사도행전"],["Actus Apostolorum","Ac","Actusapostolorum"],["Dzieje | Dzieje Apostolskie","Dz","Dzieje","Dziejeapostolskie"],["Actos","Ac","Actos"],["Faptele | Faptele Apostolilor","Ac","Faptele","Fapteleapostolilor"],["Деяния","Ac","Деяния"],["Hechos | Hechos de los Apóstoles","He | Hch | Hech","Hechos","Hechosdelosapóstoles","He","Hch","Hech"],["திருத்தூதர் பணிகள்","Ac","திருத்தூதர்பணிகள்"],["กิจการของอัครทูต | กิจการอัครสาวก","Ac","กิจการของอัครทูต","กิจการอัครสาวก"],["Công vụ các Sứ đồ | Công vụ Tông đồ","Ac","Côngvụcácsứđồ","Côngvụtôngđồ"]],[["Romans","Rm | Rom","Romans","Rm","Rom"],["Romeine","Rm","Romeine"],["Romakëve","Rm | Rom","Romakëve","Rm","Rom"],["","",""],["رومية","Rm | Rom","رومية","Rm","Rom"],["羅馬書","Rm | Rom","羅馬書","Rm","Rom"],["","Rm | Rom","","Rm","Rom"],["Římanům","Rm | Rom","Římanům","Rm","Rom"],["Taga-Roma | Mga Taga-Roma","Ro","Taga-roma","Mgataga-roma"],["Romains","Rm | Rom","Romains","Rm","Rom"],["Römer","Rm | Rom","Römer","Rm","Rom"],["Ρωμαίους","Rm | Rom","Ρωμαίους","Rm","Rom"],["Rómaiakhoz","Rm | Rom","Rómaiakhoz","Rm","Rom"],["Romani","Rm","Romani"],["ローマ人への手紙","Rm | Rom","ローマ人への手紙","Rm","Rom"],["로마서","Rm | Rom","로마서","Rm","Rom"],["Romanos","Rom","Romanos"],["Rzymian","Rz","Rzymian"],["Romanos","Rm | Rom","Romanos","Rm","Rom"],["Romani","Rm | Rom","Romani","Rm","Rom"],["Римлянам","Rm | Rom","Римлянам","Rm","Rom"],["Romanos","Rm | Rom","Romanos","Rm","Rom"],["உரோமையர்","Rm | Rom","உரோமையர்","Rm","Rom"],["โรม","Rm | Rom","โรม","Rm","Rom"],["Rôma","Rm | Rom","Rôma","Rm","Rom"]],[["1 Corinthians","1Cor","1Corinthians"],["1 Korintiërs","1Cr","1Korintiërs"],["1Korintasve","1Cor","1Korintasve"],["","",""],["1كورنثوس","1Cor","1كورنثوس"],["格林多前書","1Cor","格林多前書"],["","1Cor",""],["1Korintským","1Cor","1Korintským"],["1 Taga-Corinto | 1 Mga Taga-Corinto","1Cor","1Taga-corinto","1Mgataga-corinto"],["1Corinthiens","1Cor","1Corinthiens"],["1Korinther","1Cor","1Korinther"],["Α Κορινθίους","1Cor","Ακορινθίους"],["1Korintusi","1Cor","1Korintusi"],["1Corinzi","1Cor","1Corinzi"],["コリント人への第一の手紙","1Cor","コリント人への第一の手紙"],["고린도1서 | 코린토1서","1Cor","고린도1서","코린토1서"],["I Corinthios","I Cor","Icorinthios"],["1Koryntian","1Kor","1Koryntian"],["1 Coríntios","1Cor","1Coríntios"],["1Corinteni","1Cor","1Corinteni"],["1Коринфянам","1Cor","1Коринфянам"],["1Corintios","1Co | 1Cor","1Corintios","1Co","1Cor"],["1 கொரிந்தியர்","1Cor","1கொரிந்தியர்"],["1 โครินธ์ | โครินธ์ฉบับที่หึ่ง","1Cor","1โครินธ์","โครินธ์ฉบับที่หึ่ง"],["1 Côrintô","1Cor","1Côrintô"]],[["2 Corinthians","2Cor","2Corinthians"],["2 Korintiërs","2Cr","2Korintiërs"],["2Koristasve","2Cor","2Koristasve"],["","",""],["2كورنثوس","2Cor","2كورنثوس"],["格林多後書","2Cor","格林多後書"],["","2Cor",""],["2Korintským","2Cor","2Korintským"],["2 Taga-Corinto | 2 Mga Taga-Corinto","2Cor","2Taga-corinto","2Mgataga-corinto"],["2Corinthiens","2Cor","2Corinthiens"],["2Korinther","2Cor","2Korinther"],["Β Κορινθίους","2Cor","Βκορινθίους"],["2Korintusi","2Cor","2Korintusi"],["2Corinzi","2Cor","2Corinzi"],["コリント人への第二の手紙","2Cor","コリント人への第二の手紙"],["고린도2서 | 코린토2서","2Cor","고린도2서","코린토2서"],["II Corinthios","II Cor","Iicorinthios"],["2Koryntian","2Kor","2Koryntian"],["2 Coríntios","2Cor","2Coríntios"],["2Corinteni","2Cor","2Corinteni"],["2Коринфянам","2Cor","2Коринфянам"],["2Corintios","2Co | 2Cor","2Corintios","2Co","2Cor"],["2 கொரிந்தியர்","2Cor","2கொரிந்தியர்"],["2 โครินธ์ | โครินธ์ฉบับที่สอง","2Cor","2โครินธ์","โครินธ์ฉบับที่สอง"],["2 Côrintô","2Cor","2Côrintô"]],[["Galatians","Gal","Galatians"],["Galasiërs","Gl","Galasiërs"],["Galatasve","Gal","Galatasve"],["","",""],["غلاطية","Gal","غلاطية"],["迦拉達書","Gal","迦拉達書"],["","Gal",""],["Galatským","Gal","Galatským"],["Taga-Galacia | Mga Taga-Galacia","Ga","Taga-galacia","Mgataga-galacia"],["Galates","Gal","Galates"],["Galater","Gal","Galater"],["Γαλάτας","Gal","Γαλάτας"],["Galatákhoz","Gal","Galatákhoz"],["Galati","Gal","Galati"],["ガラテヤ人への手紙","Gal","ガラテヤ人への手紙"],["갈라디아서","Gal","갈라디아서"],["Galatas","Gal","Galatas"],["Galatów","Ga","Galatów"],["Gálatas","Gal","Gálatas"],["Galateni","Gal","Galateni"],["Галатам","Gal","Галатам"],["Gálatas","Ga | Gál","Gálatas","Ga","Gál"],["கலாத்தியர்","Gal","கலாத்தியர்"],["กาลาเทีย","Gal","กาลาเทีย"],["Galát","Gal","Galát"]],[["Ephesians","Eph","Ephesians"],["Efésiërs","Ep","Efésiërs"],["Efesianëve","Eph","Efesianëve"],["","",""],["افسس","Eph","افسس"],["厄弗所書","Eph","厄弗所書"],["","Eph",""],["Efezským","Eph","Efezským"],["Taga-Efeso | Mga Taga-Efeso","Ef","Taga-efeso","Mgataga-efeso"],["Éphésiens","Eph","Éphésiens"],["Epheser","Eph","Epheser"],["Εφεσίους","Eph","Εφεσίους"],["Efézusiakhoz","Eph","Efézusiakhoz"],["Efesini","Ef","Efesini"],["エペソ人への手紙","Eph","エペソ人への手紙"],["에베소서 | 에페소서","Eph","에베소서","에페소서"],["Ephesios","Eph","Ephesios"],["Efezjan","Ef","Efezjan"],["Efésios","Eph","Efésios"],["Efeseni","Eph","Efeseni"],["Ефесянам","Eph","Ефесянам"],["Efesios","Ef","Efesios"],["எபேசியர்","Eph","எபேசியர்"],["เอเฟซัส","Eph","เอเฟซัส"],["Êphêsô","Eph","Êphêsô"]],[["Philippians","Phil","Philippians"],["Filippense","Ph","Filippense"],["Filipianëve","Phil","Filipianëve"],["","",""],["فيلبي","Phil","فيلبي"],["斐理伯書","Phil","斐理伯書"],["","Phil",""],["Filipským","Phil","Filipským"],["Taga-Filipos | Mga Taga-Filipos","Fil","Taga-filipos","Mgataga-filipos"],["Philippiens","Phil","Philippiens"],["Philipper","Phil","Philipper"],["Φιλιππησίους","Phil","Φιλιππησίους"],["Filippiekhez","Phil","Filippiekhez"],["Filippesi","Fil","Filippesi"],["ピリピ人への手紙","Phil","ピリピ人への手紙"],["빌립보서 | 필리피서","Phil","빌립보서","필리피서"],["Philippenses","Phil","Philippenses"],["Filipian","Flp","Filipian"],["Filipenses","Phil","Filipenses"],["Filipeni","Phil","Filipeni"],["Филиппийцам","Phil","Филиппийцам"],["Filipenses","Flp","Filipenses"],["பிலிப்பியர்","Phil","பிலிப்பியர்"],["ฟีลิปปี","Phil","ฟีลิปปี"],["Philípphê","Phil","Philípphê"]],[["Colossians","Col","Colossians"],["Kolossense","Cl","Kolossense"],["Kolosianëve","Col","Kolosianëve"],["","",""],["كولوسي","Col","كولوسي"],["哥羅森書","Col","哥羅森書"],["","Col",""],["Koloským","Col","Koloským"],["Taga-Colosas | Mga Taga-Colosas","Co","Taga-colosas","Mgataga-colosas"],["Colossiens","Col","Colossiens"],["Kolosser","Col","Kolosser"],["Κολοσσαείς","Col","Κολοσσαείς"],["Kolosséiakhoz","Col","Kolosséiakhoz"],["Colossesi","Col","Colossesi"],["コロサイ人への手紙","Col","コロサイ人への手紙"],["골로새서 | 콜로새서","Col","골로새서","콜로새서"],["Colossenses","Col","Colossenses"],["Kolosan","Kol","Kolosan"],["Colossenses","Col","Colossenses"],["Coloseni","Col","Coloseni"],["Колоссянам","Col","Колоссянам"],["Colosenses","Col","Colosenses"],["கொலோசையர்","Col","கொலோசையர்"],["โคโลสี","Col","โคโลสี"],["Thư Côlôxê","Col","Thưcôlôxê"]],[["1Thessalonians","1Th | 1Thess","1Thessalonians","1Th","1Thess"],["1 Tessalonicense","1Th","1Tessalonicense"],["1Thesalonikasve","1Th | 1Thess","1Thesalonikasve","1Th","1Thess"],["","",""],["1تسالونيكي","1Th | 1Thess","1تسالونيكي","1Th","1Thess"],["得撒洛尼前書","1Th | 1Thess","得撒洛尼前書","1Th","1Thess"],["","1Th | 1Thess","","1Th","1Thess"],["1Soluňským | 1Tesalonickým","1Th | 1Thess","1Soluňským","1Tesalonickým","1Th","1Thess"],["1 Taga-Tesalonica | 1 Mga Taga-Tesalonica","1Tes","1Taga-tesalonica","1Mgataga-tesalonica"],["1Thessaloniciens","1Th | 1Thess","1Thessaloniciens","1Th","1Thess"],["1Thessalonicher","1Th | 1Thess","1Thessalonicher","1Th","1Thess"],["Α Θεσσαλονικείς","1Th | 1Thess","Αθεσσαλονικείς","1Th","1Thess"],["1Tesszalonika","1Th | 1Thess","1Tesszalonika","1Th","1Thess"],["1Tessalonicesi","1Ts","1Tessalonicesi"],["テサロニケ人への第一の手紙","1Th | 1Thess","テサロニケ人への第一の手紙","1Th","1Thess"],["데살로니가1서 | 테살로니카1서","1Th | 1Thess","데살로니가1서","테살로니카1서","1Th","1Thess"],["I Thessalonicenses","I Thess","Ithessalonicenses"],["1Tesaloniczan","1Tes","1Tesaloniczan"],["Filémon","1Th | 1Thess","Filémon","1Th","1Thess"],["1Tesaloniceni","1Th | 1Thess","1Tesaloniceni","1Th","1Thess"],["1Фессалоникийцам","1Th | 1Thess","1Фессалоникийцам","1Th","1Thess"],["1Tesalonicenses","1Ts | 1Tes","1Tesalonicenses","1Ts","1Tes"],["1 தெசலோனிக்கர்","1Th | 1Thess","1தெசலோனிக்கர்","1Th","1Thess"],["1 เธสะโลนิกา | เธสะโลนิกาฉบับที่หึ่ง","1Th | 1Thess","1เธสะโลนิกา","เธสะโลนิกาฉบับที่หึ่ง","1Th","1Thess"],["1 Thêxalônica","1Th | 1Thess","1Thêxalônica","1Th","1Thess"]],[["2Thessalonians","2Th | 2Thess","2Thessalonians","2Th","2Thess"],["2 Tessalonicense","2Th","2Tessalonicense"],["2Thesalonikasve","2Th | 2Thess","2Thesalonikasve","2Th","2Thess"],["","",""],["2تسالونيكي","2Th | 2Thess","2تسالونيكي","2Th","2Thess"],["得撒洛尼後書","2Th | 2Thess","得撒洛尼後書","2Th","2Thess"],["","2Th | 2Thess","","2Th","2Thess"],["2Soluňským | 2Tesalonickým","2Th | 2Thess","2Soluňským","2Tesalonickým","2Th","2Thess"],["2 Taga-Tesalonica | 2 Mga Taga-Tesalonica","2Tes","2Taga-tesalonica","2Mgataga-tesalonica"],["2Thessaloniciens","2Th | 2Thess","2Thessaloniciens","2Th","2Thess"],["2Thessalonicher","2Th | 2Thess","2Thessalonicher","2Th","2Thess"],["Β Θεσσαλονικείς","2Th | 2Thess","Βθεσσαλονικείς","2Th","2Thess"],["2Tesszalonika","2Th | 2Thess","2Tesszalonika","2Th","2Thess"],["2Tessalonicesi","2Ts","2Tessalonicesi"],["テサロニケ人への第二の手紙","2Th | 2Thess","テサロニケ人への第二の手紙","2Th","2Thess"],["데살로니가2서 | 테살로니카2서","2Th | 2Thess","데살로니가2서","테살로니카2서","2Th","2Thess"],["II Thessalonicenses","II Thess","Iithessalonicenses"],["2Tesaloniczan","2Tes","2Tesaloniczan"],["1 Tessalonicenses","2Th | 2Thess","1Tessalonicenses","2Th","2Thess"],["2Tesaloniceni","2Th | 2Thess","2Tesaloniceni","2Th","2Thess"],["2Фессалоникийцам","2Th | 2Thess","2Фессалоникийцам","2Th","2Thess"],["2Tesalonicenses","2Ts | 2Tes","2Tesalonicenses","2Ts","2Tes"],["2 தெசலோனிக்கர்","2Th | 2Thess","2தெசலோனிக்கர்","2Th","2Thess"],["2 เธสะโลนิกา | เธสะโลนิกาฉบับที่สอง","2Th | 2Thess","2เธสะโลนิกา","เธสะโลนิกาฉบับที่สอง","2Th","2Thess"],["2 Thêxalônica","2Th | 2Thess","2Thêxalônica","2Th","2Thess"]],[["1Timothy","1Tim | 1Tm","1Timothy","1Tim","1Tm"],["1 Timótheüs","1Tm","1Timótheüs"],["1Timoteut","1Tim | 1Tm","1Timoteut","1Tim","1Tm"],["","",""],["1تيموثاوس","1Tim | 1Tm","1تيموثاوس","1Tim","1Tm"],["弟茂德前書","1Tim | 1Tm","弟茂德前書","1Tim","1Tm"],["","1Tim | 1Tm","","1Tim","1Tm"],["1Timoteovi","1Tim | 1Tm","1Timoteovi","1Tim","1Tm"],["1 Timoteo","1Tim","1Timoteo"],["1Timothée","1Tim | 1Tm","1Timothée","1Tim","1Tm"],["1Timotheus","1Tim | 1Tm","1Timotheus","1Tim","1Tm"],["Α Τιμόθεον","1Tim | 1Tm","Ατιμόθεον","1Tim","1Tm"],["1Timóteushoz","1Tim | 1Tm","1Timóteushoz","1Tim","1Tm"],["1Timoteo","1Tm","1Timoteo"],["テモテヘの第一の手紙","1Tim | 1Tm","テモテヘの第一の手紙","1Tim","1Tm"],["디모데1서 | 티모테오1서","1Tim | 1Tm","디모데1서","티모테오1서","1Tim","1Tm"],["I Timotheum","I Tim","Itimotheum"],["1Tymoteusza","1Tm","1Tymoteusza"],["2 Tessalonicenses","1Tim | 1Tm","2Tessalonicenses","1Tim","1Tm"],["1Timotei","1Tim | 1Tm","1Timotei","1Tim","1Tm"],["1Тимофею","1Tim | 1Tm","1Тимофею","1Tim","1Tm"],["1Timoteo","1Tm | 1Tim","1Timoteo","1Tm","1Tim"],["1 திமொத்தேயு","1Tim | 1Tm","1திமொத்தேயு","1Tim","1Tm"],["1 ทิโมธี | ทิโมธีฉบับที่หึ่ง","1Tim | 1Tm","1ทิโมธี","ทิโมธีฉบับที่หึ่ง","1Tim","1Tm"],["1 Timôthê","1Tim | 1Tm","1Timôthê","1Tim","1Tm"]],[["2Timothy","2Tim | 2Tm","2Timothy","2Tim","2Tm"],["2 Timótheüs","2Tm","2Timótheüs"],["2Timoteut","2Tim | 2Tm","2Timoteut","2Tim","2Tm"],["","",""],["2تيموثاوس","2Tim | 2Tm","2تيموثاوس","2Tim","2Tm"],["弟茂德後書","2Tim | 2Tm","弟茂德後書","2Tim","2Tm"],["","2Tim | 2Tm","","2Tim","2Tm"],["2Timoteovi","2Tim | 2Tm","2Timoteovi","2Tim","2Tm"],["2 Timoteo","2Tim","2Timoteo"],["2Timothée","2Tim | 2Tm","2Timothée","2Tim","2Tm"],["2Timotheus","2Tim | 2Tm","2Timotheus","2Tim","2Tm"],["Β Τιμόθεον","2Tim | 2Tm","Βτιμόθεον","2Tim","2Tm"],["2Timóteushoz","2Tim | 2Tm","2Timóteushoz","2Tim","2Tm"],["2Timoteo","2Tm","2Timoteo"],["テモテヘの第二の手紙","2Tim | 2Tm","テモテヘの第二の手紙","2Tim","2Tm"],["디모데2서 | 티모테오2서","2Tim | 2Tm","디모데2서","티모테오2서","2Tim","2Tm"],["II Timotheum","II Tim","Iitimotheum"],["2Tymoteusza","2Tm","2Tymoteusza"],["1 Timóteo","2Tim | 2Tm","1Timóteo","2Tim","2Tm"],["2Timotei","2Tim | 2Tm","2Timotei","2Tim","2Tm"],["2Тимофею","2Tim | 2Tm","2Тимофею","2Tim","2Tm"],["2Timoteo","2Tm | 2Tim","2Timoteo","2Tm","2Tim"],["2 திமொத்தேயு","2Tim | 2Tm","2திமொத்தேயு","2Tim","2Tm"],["2 ทิโมธี | ทิโมธีฉบับที่สอง","2Tim | 2Tm","2ทิโมธี","ทิโมธีฉบับที่สอง","2Tim","2Tm"],["2 Timôthê","2Tim | 2Tm","2Timôthê","2Tim","2Tm"]],[["Titus","Tt","Titus"],["Titus","Tt","Titus"],["Titi","Tt","Titi"],["","",""],["تيطس","Tt","تيطس"],["弟鐸書","Tt","弟鐸書"],["","Tt",""],["Titovi","Tt","Titovi"],["Tito","Tito","Tito"],["Tite","Tt","Tite"],["Titus","Tt","Titus"],["Τίτον","Tt","Τίτον"],["Titushoz","Tt","Titushoz"],["Tito","Tt","Tito"],["テトスヘの手紙","Tt","テトスヘの手紙"],["디도서 | 티토서","Tt","디도서","티토서"],["Titum","Tt","Titum"],["Tytusa","Tt","Tytusa"],["2 Timóteo","Tt","2Timóteo"],["Tit","Tt","Tit"],["Титу","Tt","Титу"],["Tito","Tt | Tit","Tito","Tt","Tit"],["தீத்து","Tt","தீத்து"],["ทิตัส","Tt","ทิตัส"],["Titô","Tt","Titô"]],[["Philemon","Phlm","Philemon"],["Filemon","Pl","Filemon"],["Filemonit","Phlm","Filemonit"],["","",""],["فليمون","Phlm","فليمون"],["費肋孟書","Phlm","費肋孟書"],["","Phlm",""],["Filemonovi","Phlm","Filemonovi"],["Filemon","Filem","Filemon"],["Philémon","Phlm","Philémon"],["Philemon","Phlm","Philemon"],["Φιλήμονα","Phlm","Φιλήμονα"],["Filemonhoz","Phlm","Filemonhoz"],["Filemone","Fm","Filemone"],["ピレモンヘの手紙","Phlm","ピレモンヘの手紙"],["빌레몬서 | 필레몬서","Phlm","빌레몬서","필레몬서"],["Philemonem","Phlm","Philemonem"],["Filemona","Flm","Filemona"],["Tito","Phlm","Tito"],["Filimon","Phlm","Filimon"],["К Филимону","Phlm","Кфилимону"],["Filemón","Flm","Filemón"],["பிலமோன்","Phlm","பிலமோன்"],["ฟีเลโมน","Phlm","ฟีเลโมน"],["Philêmon","Phlm","Philêmon"]],[["Hebrews","Heb","Hebrews"],["Hebreërs","Hb","Hebreërs"],["Hebrenjve","Heb","Hebrenjve"],["","",""],["عبرانيين","Heb","عبرانيين"],["希伯來書","Heb","希伯來書"],["","Heb",""],["Židům","Heb","Židům"],["Hebreo | Mga Hebreo","Heb","Hebreo","Mgahebreo"],["Hébreux","Heb","Hébreux"],["Hebräer","Heb","Hebräer"],["Εβραίους","Heb","Εβραίους"],["Zsidókhoz","Heb","Zsidókhoz"],["Ebrei","Eb","Ebrei"],["ヘブル人への手紙","Heb","ヘブル人への手紙"],["히브리서","Heb","히브리서"],["Hebræos |  Hebraeos","Heb","Hebræos","Hebraeos"],["Hebrajczyków","Hbr","Hebrajczyków"],["Hebreus","Heb","Hebreus"],["Evrei","Heb","Evrei"],["Евреям","Heb","Евреям"],["Hebreos","Hb | Heb","Hebreos","Hb","Heb"],["எபிரேயர்","Heb","எபிரேயர்"],["ฮีบรู","Heb","ฮีบรู"],["Do Thái","Heb","Dothái"]],[["James","Jm | Jas","James","Jm","Jas"],["Jakobus","Jm","Jakobus"],["Jakobit","Jm | Jas","Jakobit","Jm","Jas"],["","",""],["يعقوب","Jm | Jas","يعقوب","Jm","Jas"],["雅各伯書","Jm | Jas","雅各伯書","Jm","Jas"],["","Jm | Jas","","Jm","Jas"],["Jakubův","Jm | Jas","Jakubův","Jm","Jas"],["Santiago","San","Santiago"],["Jacques","Jm | Jas","Jacques","Jm","Jas"],["Jakobus","Jm | Jas","Jakobus","Jm","Jas"],["Ιάκωβος","Jm | Jas","Ιάκωβος","Jm","Jas"],["Jakab","Jm | Jas","Jakab","Jm","Jas"],["Giacomo","Gc","Giacomo"],["ヤコブの手紙","Jm | Jas","ヤコブの手紙","Jm","Jas"],["야고보서","Jm | Jas","야고보서","Jm","Jas"],["Iacobi","Iac","Iacobi"],["Jakuba","Jk","Jakuba"],["Tiago","Jm | Jas","Tiago","Jm","Jas"],["Iacob","Jm | Jas","Iacob","Jm","Jas"],["Иакова","Jm | Jas","Иакова","Jm","Jas"],["Santiago","St","Santiago"],["யாக்கோபு","Jm | Jas","யாக்கோபு","Jm","Jas"],["ยากอบ","Jm | Jas","ยากอบ","Jm","Jas"],["Giacôbê","Jm | Jas","Giacôbê","Jm","Jas"]],[["1 Peter","1Pt | 1Pet","1Peter","1Pt","1Pet"],["1 Petrus","1Pt","1Petrus"],["1Pjetrit","1Pt | 1Pet","1Pjetrit","1Pt","1Pet"],["","",""],["1بطرس","1Pt | 1Pet","1بطرس","1Pt","1Pet"],["伯多祿前書","1Pt | 1Pet","伯多祿前書","1Pt","1Pet"],["","1Pt | 1Pet","","1Pt","1Pet"],["1Petrův","1Pt | 1Pet","1Petrův","1Pt","1Pet"],["1 Pedro","1Ped","1Pedro"],["1Pierre","1Pt | 1Pet","1Pierre","1Pt","1Pet"],["1Petrus","1Pt | 1Pet","1Petrus","1Pt","1Pet"],["Α Πέτρου","1Pt | 1Pet","Απέτρου","1Pt","1Pet"],["1Péter","1Pt | 1Pet","1Péter","1Pt","1Pet"],["1Pietro","1Pt","1Pietro"],["ペテロの第一の手紙","1Pt | 1Pet","ペテロの第一の手紙","1Pt","1Pet"],["베드로1서","1Pt | 1Pet","베드로1서","1Pt","1Pet"],["I Petri","I Pet","Ipetri"],["1Piotra","1P","1Piotra"],["1 Pedro","1Pt | 1Pet","1Pedro","1Pt","1Pet"],["1Petru","1Pt | 1Pet","1Petru","1Pt","1Pet"],["1Петра","1Pt | 1Pet","1Петра","1Pt","1Pet"],["1Pedro","1P | 1Pe","1Pedro","1P","1Pe"],["1 பேதுரு","1Pt | 1Pet","1பேதுரு","1Pt","1Pet"],["1 เปโตร | เปโตรฉบับที่หึ่ง","1Pt | 1Pet","1เปโตร","เปโตรฉบับที่หึ่ง","1Pt","1Pet"],["1 Phêrô","1Pt | 1Pet","1Phêrô","1Pt","1Pet"]],[["2 Peter","2Pt | 2Pet","2Peter","2Pt","2Pet"],["2 Petrus","2Pt","2Petrus"],["2Pjetrit","2Pt | 2Pet","2Pjetrit","2Pt","2Pet"],["","",""],["2بطرس","2Pt | 2Pet","2بطرس","2Pt","2Pet"],["伯多祿後書","2Pt | 2Pet","伯多祿後書","2Pt","2Pet"],["","2Pt | 2Pet","","2Pt","2Pet"],["2Petrův","2Pt | 2Pet","2Petrův","2Pt","2Pet"],["2 Pedro","2Ped","2Pedro"],["2Pierre","2Pt | 2Pet","2Pierre","2Pt","2Pet"],["2Petrus","2Pt | 2Pet","2Petrus","2Pt","2Pet"],["Β Πέτρου","2Pt | 2Pet","Βπέτρου","2Pt","2Pet"],["2Péter","2Pt | 2Pet","2Péter","2Pt","2Pet"],["2Pietro","2Pt","2Pietro"],["ペテロの第二の手紙","2Pt | 2Pet","ペテロの第二の手紙","2Pt","2Pet"],["베드로2서","2Pt | 2Pet","베드로2서","2Pt","2Pet"],["II Petri","II Pet","Iipetri"],["2Piotra","2P","2Piotra"],["2 Pedro","2Pt | 2Pet","2Pedro","2Pt","2Pet"],["2Petru","2Pt | 2Pet","2Petru","2Pt","2Pet"],["2Петра","2Pt | 2Pet","2Петра","2Pt","2Pet"],["2Pedro","2P | 2Pe","2Pedro","2P","2Pe"],["2 பேதுரு","2Pt | 2Pet","2பேதுரு","2Pt","2Pet"],["2 เปโตร | เปโตรฉบับที่สอง","2Pt | 2Pet","2เปโตร","เปโตรฉบับที่สอง","2Pt","2Pet"],["2 Phêrô","2Pt | 2Pet","2Phêrô","2Pt","2Pet"]],[["1 John","1Jn","1John"],["1 Johannes","1Jh","1Johannes"],["1Gjonit","1Jn","1Gjonit"],["","",""],["1يوحنا","1Jn","1يوحنا"],["若望一書","1Jn","若望一書"],["","1Jn",""],["1Janův","1Jn","1Janův"],["1 Juan","1Jn","1Juan"],["1Jean","1Jn","1Jean"],["1Johannes","1Jn","1Johannes"],["Α Ιωάννου","1Jn","Αιωάννου"],["1János","1Jn","1János"],["1Giovanni","1Gv","1Giovanni"],["ヨハネの第一の手紙","1Jn","ヨハネの第一の手紙"],["요한1서","1Jn","요한1서"],["I Ioannis | I Iohannis | I Joannis | I Johannis","I Ioh","Iioannis","Iiohannis","Ijoannis","Ijohannis"],["1Jana","1J","1Jana"],["Judas","1Jn","Judas"],["1Ioan","1Jn","1Ioan"],["1Иоанна","1Jn","1Иоанна"],["1Juan","1Jn","1Juan"],["1 யோவான்","1Jn","1யோவான்"],["1 ยอห์น | ยอห์นฉบับที่หึ่ง","1Jn","1ยอห์น","ยอห์นฉบับที่หึ่ง"],["1 Gioan","1Jn","1Gioan"]],[["2 John","2Jn","2John"],["2 Johannes","2Jh","2Johannes"],["2Gjonit","2Jn","2Gjonit"],["","",""],["2يوحنا","2Jn","2يوحنا"],["若望二書","2Jn","若望二書"],["","2Jn",""],["2Janův","2Jn","2Janův"],["2 Juan","2Jn","2Juan"],["2Jean","2Jn","2Jean"],["2Johannes","2Jn","2Johannes"],["Β Ιωάννου","2Jn","Βιωάννου"],["2János","2Jn","2János"],["2Giovanni","2Gv","2Giovanni"],["ヨハネの第二の手紙","2Jn","ヨハネの第二の手紙"],["요한2서","2Jn","요한2서"],["II Ioannis | II Iohannis | II Joannis | II Johannis","II Ioh","Iiioannis","Iiiohannis","Iijoannis","Iijohannis"],["2Jana","2J","2Jana"],["1 João","2Jn","1João"],["2Ioan","2Jn","2Ioan"],["2Иоанна","2Jn","2Иоанна"],["2Juan","2Jn","2Juan"],["2 யோவான்","2Jn","2யோவான்"],["2 ยอห์น | ยอห์นฉบับที่สอง","2Jn","2ยอห์น","ยอห์นฉบับที่สอง"],["2 Gioan","2Jn","2Gioan"]],[["3 John","3Jn","3John"],["3 Johannes","3Jh","3Johannes"],["3Gjonit","3Jn","3Gjonit"],["","",""],["3يوحنا","3Jn","3يوحنا"],["若望三書","3Jn","若望三書"],["","3Jn",""],["3Janův","3Jn","3Janův"],["3 Juan","3Jn","3Juan"],["3Jean","3Jn","3Jean"],["3Johannes","3Jn","3Johannes"],["Γ Ιωάννου","3Jn","Γιωάννου"],["3János","3Jn","3János"],["3Giovanni","3Gv","3Giovanni"],["ヨハネの第三の手紙","3Jn","ヨハネの第三の手紙"],["요한3서","3Jn","요한3서"],["III Ioannis | III Iohannis | III Joannis | III Johannis","III Ioh","Iiiioannis","Iiiiohannis","Iiijoannis","Iiijohannis"],["3Jana","3J","3Jana"],["2 João","3Jn","2João"],["3Ioan","3Jn","3Ioan"],["3Иоанна","3Jn","3Иоанна"],["3Juan","3Jn","3Juan"],["3 யோவான்","3Jn","3யோவான்"],["3 ยอห์น | ยอห์นฉบับที่สาม","3Jn","3ยอห์น","ยอห์นฉบับที่สาม"],["3 Gioan","3Jn","3Gioan"]],[["Jude","Jud | Jd","Jude","Jud","Jd"],["Judas","Jd","Judas"],["Juda","Jud | Jd","Juda","Jud","Jd"],["","",""],["يهوذا","Jud | Jd","يهوذا","Jud","Jd"],["猶達書","Jud | Jd","猶達書","Jud","Jd"],["","Jud | Jd","","Jud","Jd"],["Judův","Jud | Jd","Judův","Jud","Jd"],["Judas","Ju","Judas"],["Jude","Jud | Jd","Jude","Jud","Jd"],["Judas","Jud | Jd","Judas","Jud","Jd"],["Ιούδας","Jud | Jd","Ιούδας","Jud","Jd"],["Júdás","Jud | Jd","Júdás","Jud","Jd"],["Giuda","Gd","Giuda"],["ユダの手紙","Jud | Jd","ユダの手紙","Jud","Jd"],["유다서","Jud | Jd","유다서","Jud","Jd"],["Iudæ | Iudae | Judæ | Judae","Iud","Iudæ","Iudae","Judæ","Judae"],["Judy","Jud","Judy"],["3 João","Jud | Jd","3João","Jud","Jd"],["Iuda","Jud | Jd","Iuda","Jud","Jd"],["Иуда","Jud | Jd","Иуда","Jud","Jd"],["Judas","Jd | Jud","Judas","Jd","Jud"],["யூதா","Jud | Jd","யூதா","Jud","Jd"],["ยูดา","Jud | Jd","ยูดา","Jud","Jd"],["Giuđa","Jud | Jd","Giuđa","Jud","Jd"]],[["Revelation | Apocalypse","Rev | Apoc","Revelation","Apocalypse","Rev","Apoc"],["Openbaring | Die openbaring","Rv","Openbaring","Dieopenbaring"],["Zbulesa","Rev | Apoc","Zbulesa","Rev","Apoc"],["","",""],["رؤيا","Rev | Apoc","رؤيا","Rev","Apoc"],["若望默示錄","Rev | Apoc","若望默示錄","Rev","Apoc"],["","Rev | Apoc","","Rev","Apoc"],["Zjevení | Apokalypsa","Rev | Apoc","Zjevení","Apokalypsa","Rev","Apoc"],["Pahayag","Pah","Pahayag"],["Apocalypse","Rev | Apoc","Apocalypse","Rev","Apoc"],["Offenbarung","Rev | Apoc","Offenbarung","Rev","Apoc"],["Αποκάλυψη","Rev | Apoc","Αποκάλυψη","Rev","Apoc"],["Jelenések","Rev | Apoc","Jelenések","Rev","Apoc"],["Apocalisse","Ap","Apocalisse"],["ヨハネの黙示録","Rev | Apoc","ヨハネの黙示録","Rev","Apoc"],["요한계시록 | 요한묵시록","Rev | Apoc","요한계시록","요한묵시록","Rev","Apoc"],["Apocalypsis","Apoc","Apocalypsis"],["Apokalipsa","Ap","Apokalipsa"],["Apocalipse","Rev | Apoc","Apocalipse","Rev","Apoc"],["Apocalipsa","Rev | Apoc","Apocalipsa","Rev","Apoc"],["Откровение","Rev | Apoc","Откровение","Rev","Apoc"],["Apocalipsis","Ap","Apocalipsis"],["திருவெளிப்பாடு","Rev | Apoc","திருவெளிப்பாடு","Rev","Apoc"],["วิวรณ์","Rev | Apoc","วิวรณ์","Rev","Apoc"],["Khải Huyền","Rev | Apoc","Khảihuyền","Rev","Apoc"]]],"errors":[],"info":{"ENDPOINT_VERSION":"3.0"},"languages":["ENGLISH","AFRIKAANS","ALBANIAN","AMHARIC","ARABIC","CHINESE","CROATIAN","CZECH","FILIPINO","FRENCH","GERMAN","GREEK","HUNGARIAN","ITALIAN","JAPANESE","KOREAN","LATIN","POLISH","PORTUGUESE","ROMANIAN","RUSSIAN","SPANISH","TAMIL","THAI","VIETNAMESE"]}
+          },
+          "MetadataVersionIndex": {
+              "type": "object",
+              "properties": {
+                  "indexes": {
+                      "type": "object",
+                      "description": "An object the *keys* of which are the *acronyms of the Bible versions as requested with the `versions` parameter*, and the corresponding *values* of which are objects with the index information associated with that Bible version.",
+                      "additionalProperties": {
+                          "$ref": "#/components/schemas/MetadataVersionIndexForVersion"
+                      }
+                  },
+                  "errors": {
+                      "type": "array",
+                      "description": "An array of any error messages that may have been generated indicating a badly formed `query` parameter, a bad value for the `version` parameter, or an API server error",
+                      "items": {
+                          "type": "string"
+                      }
+                  },
+                  "info": {
+                      "type": "object",
+                      "description": "An object containing metadata about the API endpoint",
+                      "properties": {
+                          "ENDPOINT_VERSION": {
+                              "type": "string"
+                          }
+                      }
+                  }
+              },
+              "xml": {
+                  "name": "BibleGetMetadata"
+              },
+              "example": {"results":[],"errors":[],"info":{"ENDPOINT_VERSION":"3.0"},"indexes":{"NABRE":{"abbreviations":["Gn","Ex","Lv","Nm","Dt","Jos","Jgs","Ru","1Sm","2Sm","1Kgs","2Kgs","1Chr","2Chr","Ezr","Neh","Tb","Jdt","Est","1Mc","2Mc","Jb","Ps","Prv","Eccl","Sg","Wis","Sir","Is","Jer","Lam","Bar","Ez","Dn","Hos","Jl","Am","Ob","Jon","Mi","Na","Hb","Zep","Hg","Zec","Mal","Mt","Mk","Lk","Jn","Acts","Rom","1Cor","2Cor","Gal","Eph","Phil","Col","1Thes","2Thes","1Tm","2Tm","Ti","Phlm","Heb","Jas","1Pt","2Pt","1Jn","2Jn","3Jn","Jude","Rev"],"biblebooks":["Genesis","Exodus","Leviticus","Numbers","Deuteronomy","Joshua","Judges","Ruth","1Samuel","2Samuel","1Kings","2Kings","1Chronicles","2Chronicles","Ezra","Nehemiah","Tobit","Judith","Esther","1Maccabees","2Maccabees","Job","Psalms","Proverbs","Ecclesiastes","Song of Songs","Wisdom","Sirach","Isaiah","Jeremiah","Lamentations","Baruch","Ezekiel","Daniel","Hosea","Joel","Amos","Obadiah","Jonah","Micah","Nahum","Habakkuk","Zephaniah","Haggai","Zechariah","Malachi","Matthew","Mark","Luke","John","Acts of the Apostles","Romans","1Corinthians","2Corinthians","Galatians","Ephesians","Philippians","Colossians","1Thessalonians","2Thessalonians","1Timothy","2Timothy","Titus","Philemon","Hebrews","James","1Peter","2Peter","1John","2John","3John","Jude","Revelation"],"chapter_limit":[50,40,27,36,34,24,21,4,31,24,22,25,29,36,10,13,14,16,20,16,15,42,150,31,12,8,19,51,66,52,5,6,48,14,14,4,9,1,4,7,3,3,3,2,14,3,28,16,24,21,28,16,16,13,6,6,4,4,5,3,6,4,3,1,13,5,5,3,5,1,1,1,22],"verse_limit":[[31,25,24,26,32,22,24,22,29,32,32,20,18,24,21,16,27,33,38,18,34,24,20,67,34,35,46,22,35,43,54,33,20,31,29,43,36,30,23,23,57,38,34,34,28,34,31,22,33,26],[22,25,22,31,23,30,29,28,35,29,10,51,22,31,27,36,16,27,25,26,37,30,33,18,40,37,21,43,46,38,18,35,23,35,35,38,29,31,43,38],[17,16,17,35,26,23,38,36,24,20,47,8,59,57,33,34,16,30,37,27,24,33,44,23,55,46,34],[54,34,51,49,31,27,89,26,23,36,35,16,33,45,41,35,28,32,22,29,35,41,30,25,18,65,23,31,39,17,54,42,56,29,34,13],[46,37,29,49,33,25,26,20,29,22,32,31,19,29,23,22,20,22,21,20,23,29,26,22,19,19,26,69,28,20,30,52,29,12],[18,24,17,24,15,27,26,35,27,43,23,24,33,15,63,10,18,28,51,9,45,34,16,33],[36,23,31,24,31,40,25,35,57,18,40,15,25,20,20,31,13,31,30,48,25],[22,23,18,22],[28,36,21,22,12,21,17,22,27,27,15,25,23,52,35,23,58,30,24,42,16,23,28,23,44,25,12,25,11,31,13],[27,32,39,12,25,23,29,18,13,19,27,31,39,33,37,23,29,32,44,26,22,51,39,25],[53,46,28,20,32,38,51,66,28,29,43,33,34,31,34,34,24,46,21,43,29,54],[18,25,27,44,27,33,20,29,37,36,20,22,25,29,38,20,41,37,37,21,26,20,37,20,30],[54,55,24,43,41,66,40,40,44,14,47,41,14,17,29,43,27,17,19,8,30,19,32,31,31,32,34,21,30],[18,17,17,22,14,42,22,18,31,19,23,16,23,14,19,14,19,34,11,37,20,12,21,27,28,23,9,27,36,27,21,33,25,33,27,23],[11,70,13,24,17,22,28,36,15,44],[11,20,38,17,19,19,72,18,37,40,36,47,31],[22,14,17,21,1,18,17,21,6,13,18,22,18,15],[16,28,10,15,24,21,32,36,14,23,23,20,20,19,14,25],[22,23,15,17,14,14,10,17,32,3,22,23,15,17,14,14,10,17,32,3],[64,70,60,61,68,63,50,32,73,89,74,53,53,49,41,24],[36,32,40,50,27,31,42,36,29,38,38,46,26,46,39],[22,13,26,21,27,30,21,22,10,22,20,25,28,22,35,22,16,21,29,29,34,30,17,25,6,14,23,28,25,31,40,22,33,37,16,33,24,41,30,32,26,17],[6,11,9,9,13,11,18,10,21,18,7,9,6,7,5,11,15,51,15,10,14,32,6,10,22,12,14,9,11,13,25,11,22,23,28,13,40,23,14,18,14,12,5,27,18,12,10,15,21,23,21,11,7,9,24,14,12,12,18,14,9,13,12,11,14,20,8,36,37,6,24,20,28,23,11,13,21,72,13,20,17,8,19,13,14,17,7,19,53,17,16,16,5,23,11,13,12,9,9,5,8,29,22,35,45,48,43,14,31,7,10,10,9,8,18,19,2,29,176,7,8,9,4,8,5,6,5,6,8,8,3,18,3,3,21,26,9,8,24,14,10,8,12,15,21,10,20,14,9,6],[33,22,35,27,23,35,27,36,18,32,31,28,25,35,33,33,28,24,29,30,31,29,35,34,28,28,27,28,27,33,31],[18,26,22,17,19,12,29,17,18,20,10,14],[17,17,11,16,16,12,14,14],[16,24,19,20,23,25,30,21,18,21,12,27,19,31,19,29,21,25,22],[30,18,31,31,15,37,36,19,18,31,34,18,26,27,20,30,32,33,30,31,28,27,27,33,26,29,30,26,28,25,31,24,33,31,26,31,31,34,35,30,22,25,33,23,26,20,25,25,16,29,30],[31,22,26,6,30,13,25,23,20,34,16,6,22,32,9,14,14,7,25,6,17,25,18,23,12,21,13,29,24,33,9,20,24,17,10,22,38,22,8,31,29,25,28,28,25,13,15,22,26,11,23,15,12,17,13,12,21,14,21,22,11,12,19,11,25,24],[19,37,25,31,31,30,34,23,25,25,23,17,27,22,21,21,27,23,15,18,14,30,40,10,38,24,22,17,32,24,40,44,26,22,19,32,21,28,18,16,18,22,13,30,5,28,7,47,39,46,64,34],[22,22,66,22,22],[22,35,38,37,9,72],[28,10,27,17,17,14,27,18,11,22,25,28,23,23,8,63,24,32,14,44,37,31,49,27,17,21,36,26,21,26,18,32,33,31,15,38,28,23,29,49,26,20,27,31,25,24,23,35],[21,49,100,34,30,29,28,27,27,1,45,13,64,42],[9,25,5,19,15,11,16,14,17,15,11,15,15,10],[20,27,5,21],[15,16,15,13,27,14,17,14,15],[21],[16,11,10,11],[16,13,12,14,14,16,20],[14,14,19],[17,20,19],[18,15,20],[15,23],[17,17,10,14,11,15,14,23,17,12,17,14,9,21],[14,17,24],[25,23,17,25,48,34,29,34,38,42,30,50,58,36,39,28,27,35,30,34,46,46,39,51,46,75,66,20],[45,28,35,41,43,56,37,38,50,52,33,44,37,72,47,20],[80,52,38,44,39,49,50,56,62,42,54,59,35,35,32,31,37,43,48,47,38,71,56,53],[51,25,36,54,47,71,52,59,41,42,57,50,38,31,27,33,26,40,42,31,25],[26,47,26,37,42,15,60,40,43,49,30,25,52,28,41,40,34,28,40,38,40,30,35,27,27,32,44,31],[32,29,31,25,21,23,25,39,33,21,36,21,14,23,33,27],[31,16,23,21,13,20,40,13,27,33,34,31,13,40,58,24],[24,17,18,18,21,18,16,24,15,18,33,21,13],[24,21,29,31,26,18],[23,22,21,32,33,24],[30,30,21,23],[29,23,25,18],[10,20,13,18,28],[12,17,18],[20,15,16,16,25,21],[18,26,17,22],[16,15,15],[25],[14,18,19,16,14,20,28,13,28,39,40,29,25],[27,26,18,17,20],[25,25,22,19,14],[21,22,18],[10,29,24,21,21],[13],[15],[25],[20,29,22,11,14,17,17,13,21,11,19,18,18,20,8,21,18,24,21,15,27,21]],"book_num":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73]}}}
+          },
+          "MetadataBibleBooksResult": {
+              "type": "array",
+              "description": "Each element of the `results` array will is an array whose implicit numbered index corresponds with the *LANGUAGES* supported by the main endoint, as can be found in the `languages` key of the returned data.",
+              "items": {
+                  "$ref": "#/components/schemas/MetadataBibleBooksResultForLang"
+              }
+          },
+          "MetadataBibleBooksResultForLang": {
+              "type": "array",
+              "description": "An array with a variable number of elements. The first two elements will always be present: 1. a pipe separated list of the possible Full names of the Bible book in the given language (if there are multiple possible forms that is; the pipe will be not be present if there is not a list of values) 2. a pipe separated list of the possible abbreviated forms of the Bible book in the given language (if there are multiple possible forms that is; the pipe will be not be present if there is not a list of values) 3. Any other elements will not be pipe separated lists but single strings of the possible alternate forms whether full or abbreviated ??? [note to myself: double check this, what was the reasoning behind this kind of structuring of the data?]",
+              "items": {
+                  "type": "string"
+              }
+          },
+          "MetadataVersionIndexForVersion": {
+              "type": "object",
+              "description": "",
+              "properties": {
+                  "abbreviations": {
+                      "type": "array",
+                      "description": "An array containing the abbreviations of the books of the Bible as found in the published edition of this version of the Bible. These may not necessarily always be used as is for making requests to the main API endpoint because there is some possibility that they may conflict with other abbreviations used by other versions of the Bible in other languages for a different book of the Bible. These are only useful for displaying the exact abbreviations for that version of the Bible. For verification of the validity of a request made to the main API endpoint, the abbreviations produced from the request `query=biblebooks` should be used.",
+                      "items": {
+                          "type": "string"
+                      }
+                  },
+                  "biblebooks": {
+                      "type": "array",
+                      "description": "An array containing the full names of the books of the Bible as found in the published edition of this version of the Bible. The implicit numbered index of this array will not necessarily correspond with that of the Canon of the Scriptures as recognized by the Roman Catholic Church and as produced from the request `query=biblebooks`, because some evangelical versions for example may not have all of the books of the Bible as per the Canon recognized by the Roman Catholic Church.",
+                      "items": {
+                          "type": "string"
+                      }
+                  },
+                  "chapter_limit": {
+                      "type": "array",
+                      "description": "An array of number values which indicate the last possible chapter for each of the books listed in the above mentioned `biblebooks` array (or in the above mentioned `abbreviations` array). Again, the implicit numerical index of these values will not necessarily correspond with that of the Canon of Scriptures as recognized by the Roman Catholic Church, if the version of the Bible being quoted from does not have all of the books recognized by this same Canon. Each of these values is the actual last chapter of each of the books of the Bible in this version of the Bible, so it is not a zero based index number but it is the actual number of the last chapter of the book",
+                      "items": {
+                          "type": "integer"
+                      }
+                  },
+                  "verse_limit": {
+                      "type": "array",
+                      "description": "An array in which the implicit numerical index corresponds with the books listed in the above mentioned `biblebooks` array (or in the above mentioned `abbreviations` array). Each value of the array is another array which again contains numerical values; the total number of values found in each nested array corresponds with the number of chapters for each of these same books. So if the book of Genesis has 50 chapters (as we found out from the `chapter_limit` key), there will be 50 values in the first nested array within the `verse_limit` array. Each one of these 50 values indicates the verse limit (as in the last possible verse) for each of the 50 chapters in the book of Genesis. The same goes for each of the nested arrays contained herein. Again, the numbers in the nested arrays indicate the actual number of the last verse, it is not a zero based index.",
+                      "items": {
+                          "type": "array",
+                          "description": "An array of numerical values indicating the last possible verse in the corresponding chapter of the corresponding book of the Bible in the given Bible version. The total number of values in this array corresponds with the number of chapters in the corresponding book of the Bible. If we are dealing with the book of Genesis which has 50 chapters (as we found out from the `chapter_limit` key), there will be 50 values in this array. Each one of these 50 values indicates the verse limit (as in the last possible verse) for each of the 50 chapters in the book of Genesis. Again, the numbers in this array indicate the actual number of the last verse, it is not a zero based index.",
+                          "items": {
+                              "type": "integer"
+                          }
+                      }
+                  },
+                  "book_num":{
+                      "type": "array",
+                      "description": "",
+                      "items": {
+                          "type": "array",
+                          "description": "An array containing the number of each book as it would be in the Canon of the Scriptures as recognized by the Roman Catholic Church. These numbers are not based on a zero based index. `1` = *Genesis*, `2` = *Exodus*, etc. This can be very helpful in trying to glue all of the metadata information together, between valid book names that can be used with their Roman Catholic Canon based index, and actual book names in a single version of the Bible where the number of elements might not be the same as those in the Roman Catholic Canon.",
+                          "items": {
+                              "type": "integer"
+                          }
+                      }
+                  }
+              }
+          },
+          "KeywordSearchResponseJSON": {
+              "type": "object",
+              "properties": {
+                  "results": {
+                      "type": "array",
+                      "description": "Array of objects each of which represents a Bible verse with all associated information",
+                      "items": {
+                          "type": "object",
+                          "properties": {
+                              "testament": {
+                                  "type": "integer",
+                                  "enum": [
+                                      1,
+                                      2
+                                  ],
+                                  "description": "`1` = *Old Testament*, `2` = *New Testament*",
+                                  "xml": {
+                                      "attribute": true
+                                  }
+                              },
+                              "section": {
+                                  "type": "integer",
+                                  "enum": [
+                                      1,
+                                      2,
+                                      3,
+                                      4,
+                                      5,
+                                      6,
+                                      7,
+                                      8,
+                                      9
+                                  ],
+                                  "description": "`1` = *Pentateuch*, `2` = *Historical Books*, `3` = *Wisdom Books*, `4` = *Prophets*, `5` = *Gospels*, `6` = *Acts of the Apostles*, `7` = *Letters of Saint Paul*, `8` = *Catholic Letters*, `9` = *Apocalypse*",
+                                  "xml": {
+                                      "attribute": true
+                                  }
+                              },
+                              "book": {
+                                  "type": "string",
+                                  "description": "Name of the book of the Bible in the language of the Bible version being quoted from",
+                                  "xml": {
+                                      "attribute": true
+                                  }
+                              },
+                              "bookabbrev": {
+                                  "type": "string",
+                                  "description": "Abbreviated form of the book of the Bible in the language of the Bible version being quoted from",
+                                  "xml": {
+                                      "attribute": true
+                                  }
+                              },
+                              "booknum": {
+                                  "type": "integer",
+                                  "description": "0 based index of the Book of the Bible in the Bible version being quoted from (not all versions have the same books in the same order, especially when considering differences between Catholic and evangelical versions). The value is returned as a number value ready to be used against index information for the Bible version being quoted from. The corresponding name of the Book of the Bible as used in the printed edition of the current Bible version can be retrieved using the `metadata.php` API endpoint, as can index information about the number of chapters in the book and the number of verses in each chapter.",
+                                  "xml": {
+                                      "attribute": true
+                                  }
+                              },
+                              "univbooknum": {
+                                  "type": "string",
+                                  "description": "A number identifying the Book of the Bible according to the universally recognized Catholic version of the Canon of the Sacred Scriptures (*i.e. universally recognized by the Roman Catholic Church*). This is not a 0 based index, but rather `1` = *Genesis*, `2` = *Exodus*, etc. Therefore it is returned as a string, but can be treated as a number.",
+                                  "enum": [
+                                      "1",
+                                      "2",
+                                      "3",
+                                      "4",
+                                      "5",
+                                      "6",
+                                      "7",
+                                      "8",
+                                      "9",
+                                      "10",
+                                      "11",
+                                      "12",
+                                      "13",
+                                      "14",
+                                      "15",
+                                      "16",
+                                      "17",
+                                      "18",
+                                      "19",
+                                      "20",
+                                      "21",
+                                      "22",
+                                      "23",
+                                      "24",
+                                      "25",
+                                      "26",
+                                      "27",
+                                      "28",
+                                      "29",
+                                      "30",
+                                      "31",
+                                      "32",
+                                      "33",
+                                      "34",
+                                      "35",
+                                      "36",
+                                      "37",
+                                      "38",
+                                      "39",
+                                      "40",
+                                      "41",
+                                      "42",
+                                      "43",
+                                      "44",
+                                      "45",
+                                      "46",
+                                      "47",
+                                      "48",
+                                      "49",
+                                      "50",
+                                      "51",
+                                      "52",
+                                      "53",
+                                      "54",
+                                      "55",
+                                      "56",
+                                      "57",
+                                      "58",
+                                      "59",
+                                      "60",
+                                      "61",
+                                      "62",
+                                      "63",
+                                      "64",
+                                      "65",
+                                      "66",
+                                      "67",
+                                      "68",
+                                      "69",
+                                      "70",
+                                      "71",
+                                      "72",
+                                      "73"
+                                  ],
+                                  "xml": {
+                                      "attribute": true
+                                  }
+                              },
+                              "chapter": {
+                                  "type": "integer",
+                                  "description": "Chapter of the book of the Bible in the Bible version that the verse is being quoted from",
+                                  "xml": {
+                                      "attribute": true
+                                  }
+                              },
+                              "versedescr": {
+                                  "type": "string",
+                                  "description": "Not currently used, comes back as a `null` value. Could possible be used in the future for scholarly notes associated with a Bible verse",
+                                  "nullable": true,
+                                  "xml": {
+                                      "attribute": true
+                                  }
+                              },
+                              "verse": {
+                                  "type": "string",
+                                  "description": "Verse Number of the verse being quoted. *N.B. this is returned as a string because it will not always necessarily be a number value, there are verses that have letters in them. The value must be treated as a string and not as a number.*",
+                                  "xml": {
+                                      "attribute": true
+                                  }
+                              },
+                              "verseequiv": {
+                                  "type": "integer",
+                                  "description": "I'm not actually sure if this is currently being used or not, I believe the idea was to have a number value for those verses that have a letter in the verse number... Will mostly return a `null` value.",
+                                  "nullable": true,
+                                  "xml": {
+                                      "attribute": true
+                                  }
+                              },
+                              "text": {
+                                  "type": "string",
+                                  "description": "Contains the actual text of the verse being quoted. May contain `newline` characters that may need to be dealt with. The **NABRE** version will contain ***it's own formatting tags that need to be dealt with***, whether that means producing the proper formatting associated with these tags, or removing them to have a basic formatting. The legal requirements for usage of the NABRE version require the proper formatting to be used where possible. Please [contact the project author](mailto:admin@bibleget.io) for information on how to deal with these tags and their formatting.",
+                                  "xml": {
+                                      "attribute": true
+                                  }
+                              },
+                              "version": {
+                                  "type": "string",
+                                  "description": "the acronym of the Bible version being quoted from. For data associated with any given Bible version, for example index information, the `metadata.php` API endpoint can be used",
+                                  "xml": {
+                                      "attribute": true
+                                  }
+                              },
+                              "title1": {
+                                  "type": "string",
+                                  "description": "not currently used. The original idea (which may yet be implemented) was for this to contain any first-level title text preceding the given verse in the version of the Bible being quoted from.",
+                                  "xml": {
+                                      "attribute": true
+                                  }
+                              },
+                              "title2": {
+                                  "type": "string",
+                                  "description": "not currently used. The original idea (which may yet be implemented) was for this to contain any second-level title text preceding the given verse in the version of the Bible being quoted from.",
+                                  "xml": {
+                                      "attribute": true
+                                  }
+                              },
+                              "title3": {
+                                  "type": "string",
+                                  "description": "not currently used. The original idea (which may yet be implemented) was for this to contain any third-level title text preceding the given verse in the version of the Bible being quoted from.",
+                                  "xml": {
+                                      "attribute": true
+                                  }
+                              },
+                              "originalquery": {
+                                  "type": "string",
+                                  "description": "The reference to the single verse in this result (*{Book}{Chapter}*:*{Verse}*).",
+                                  "xml": {
+                                      "attribute": true
+                                  }
+                              }
+                          }
+                      },
+                      "xml": {
+                          "wrapped": true,
+                          "name": "results"
+                      }
+                  },
+                  "errors": {
+                      "type": "array",
+                      "description": "An array of any error messages that may have been generated indicating a badly formed `query` parameter, a bad value for the `version` parameter, or an API server error",
+                      "items": {
+                          "type": "string"
+                      }
+                  },
+                  "info": {
+                      "type": "object",
+                      "description": "An object containing metadata about the API endpoint",
+                      "properties": {
+                          "ENDPOINT_VERSION": {
+                              "type": "string",
+                              "description": "The current version of the API endpoint. This may be useful information because the data produced by the endpoint may change over time, it is useful to know which data is associated with which version of the endpoint. For example, if an application caches data returned by the endpoint, but there has been a change to the structure of the data in a new version of the API, the application would know how to deal with emptying the cache and requesting new data from the updated endpoint."
+                          },
+                          "keyword": {
+                              "type": "string",
+                              "description": "The Bible version in which the search by keyword was performed, as indicated in the `version` parameter in the request"
+                          },
+                          "version": {
+                              "type": "string",
+                              "description": "The keyword used to perform the search as indicated by the `keyword` parameter in the request"
+                          }
+                      }
+                  }
+              },
+              "example": {"results":[{"testament":"1","section":"2","book":"1Maccabees","chapter":"9","versedescr":null,"verse":"7","verseequiv":null,"verseorigin":null,"text":"When Judas saw that his army was melting away just as the battle was imminent, he was brokenhearted, because he had no time to gather them together. ","title1":"","title2":"","title3":"","version":"NABRE","bookabbrev":"1Mc","booknum":19,"univbooknum":"20","originalquery":"1Mc9:7"},{"testament":"1","section":"3","book":"Psalms","chapter":"34","versedescr":null,"verse":"19","verseequiv":null,"verseorigin":null,"text":"<po>The L<sm>ORD<\/sm> is close to the brokenhearted,<\/po>\n<poi>saves those whose spirit is crushed.<\/poi>","title1":"","title2":"","title3":"","version":"NABRE","bookabbrev":"Ps","booknum":22,"univbooknum":"23","originalquery":"Ps34:19"},{"testament":"1","section":"3","book":"Psalms","chapter":"109","versedescr":null,"verse":"16","verseequiv":null,"verseorigin":null,"text":"<po>For he did not remember to show mercy,<\/po>\n<poi>but hounded the wretched poor<\/poi>\n<poi>and brought death to the brokenhearted.<\/poi>","title1":"","title2":"","title3":"","version":"NABRE","bookabbrev":"Ps","booknum":22,"univbooknum":"23","originalquery":"Ps109:16"},{"testament":"1","section":"3","book":"Psalms","chapter":"147","versedescr":null,"verse":"3","verseequiv":null,"verseorigin":null,"text":"<po>Healing the brokenhearted,<\/po>\n<poi>and binding up their wounds.<\/poi>","title1":"","title2":"","title3":"","version":"NABRE","bookabbrev":"Ps","booknum":22,"univbooknum":"23","originalquery":"Ps147:3"},{"testament":"1","section":"4","book":"Isaiah","chapter":"61","versedescr":null,"verse":"1","verseequiv":null,"verseorigin":null,"text":"<pof> The spirit of the Lord G<sm>OD<\/sm> is upon me,<\/pof>\n<poi>because the L<sm>ORD<\/sm> has anointed me;<\/poi>\n<po>He has sent me to bring good news to the afflicted,<\/po>\n<poi>to bind up the brokenhearted,<\/poi>\n<po>To proclaim liberty to the captives,<\/po>\n<poi>release to the prisoners,<\/poi>","title1":"","title2":"","title3":"","version":"NABRE","bookabbrev":"Is","booknum":28,"univbooknum":"29","originalquery":"Is61:1"}],"errors":[],"info":{"ENDPOINT_VERSION":"3.0","keyword":"brokenhearted","version":"NABRE"}}
+          },
+          "KeywordSearchResponseXML": {
+              "type": "object",
+              "properties": {
+                  "results": {
+                      "type": "array",
+                      "description": "Array of objects each of which represents a Bible verse in which the searched keyword was found, with all associated information",
+                      "items": {
+                          "$ref": "#/components/schemas/BibleQuoteResult"
+                      },
+                      "xml": {
+                          "name": "results",
+                          "wrapped": true
+                      }
+                  },
+                  "errors": {
+                      "type": "array",
+                      "description": "An array of any error messages that may have been generated indicating a badly formed `query` parameter, a bad value for the `version` parameter, or an API server error",
+                      "items": {
+                          "type": "string"
+                      }
+                  },
+                  "info": {
+                      "type": "object",
+                      "description": "An object containing metadata about the API endpoint",
+                      "properties": {
+                          "ENDPOINT_VERSION": {
+                              "type": "string",
+                              "description": "The current version of the API endpoint. This may be useful information because the data produced by the endpoint may change over time, it is useful to know which data is associated with which version of the endpoint. For example, if an application caches data returned by the endpoint, but there has been a change to the structure of the data in a new version of the API, the application would know how to deal with emptying the cache and requesting new data from the updated endpoint.",
+                              "xml": {
+                                "attribute": true
+                              },
+                              "example": "3.0"
+                          },
+                          "version": {
+                              "type": "string",
+                              "description": "The Bible version in which the search by keyword was performed, as indicated in the `version` parameter in the request",
+                              "example": "NABRE"
+                          },
+                          "keyword": {
+                              "type": "string",
+                              "description": "The keyword used to perform the search as indicated by the `keyword` parameter in the request",
+                              "example": "brokenhearted"
+                          }
+                      }
+                  }
+              },
+              "xml": {
+                  "name": "BibleQuote"
+              }
+          },
+          "MetadataPOST": {
+              "type": "object",
+              "properties": {
+                  "query": {
+                      "type": "string",
+                      "description": "Specifies the subset of metadata to retrieve. **`biblebooks`**: retrieve the list of valid **book names** and **abbreviations** in various languages that are currently supported / recognized by the main BibleGet API endpoint. **`bibleversions`**: retrieve the list of **Bible versions** that are currently supported by the main BibleGet API endpoint. **`versionindex`**: retrieve the **indices of chapters and verses** for any of the Bible versions currently supported by the BibleGet engine (this value requires the usage of a second parameter `versions`).",
+                      "enum": [
+                          "biblebooks",
+                          "bibleversions",
+                          "versionindex"
+                      ],
+                      "example": "bibleversions"
+                  },
+                  "versions": {
+                      "type": "array",
+                      "description": "Bible version or versions from which to retrieve the Bible quote. A list of valid versions can be retrieved from the `metadata.php` API using `query=bibleversions`",
+                      "items": {
+                          "type": "string"
+                      },
+                      "example": [
+                          "NABRE",
+                          "NVBSE"
+                      ],
+                      "default": [
+                          "CEI2008"
+                      ]
+                  },
+                  "return": {
+                      "type": "string",
+                      "description": "Type of data that should be returned in the response",
+                      "enum": [
+                          "json",
+                          "xml",
+                          "html"
+                      ],
+                      "example": "json",
+                      "default": "json"
+                  }
+              },
+              "required": [
+                  "query"
+              ]
+          },
+          "KeywordSearchPOST": {
+              "type": "object",
+              "properties": {
+                  "query": {
+                      "type": "string",
+                      "description": "Specifies the kind of search to perform. As of v2.8 of the search API only a value of `keywordsearch` is available.",
+                      "enum": ["keywordsearch"],
+                      "example": "keywordsearch"
+                  },
+                  "keyword": {
+                      "type": "string",
+                      "description": "*(required when `query=keywordsearch`)* indicates the keyword that will be searched in the text of the Bible verses",
+                      "example": "creation"
+                  },
+                  "version": {
+                      "type": "string",
+                      "description": "The acronym of the Bible version within which to perform the search by keyword. Can only be a single value, not a comma delimited list of values.",
+                      "example": "NVBSE"
+                  },
+                  "exactmatch": {
+                      "type": "boolean",
+                      "description": "since the default behaviour for a keyword search is to find any word of 4 or more letters which matches or contains the keyword, this option will try to find only exact matches and will also allow to search for words of even only 3 letters (parts of speech excluded)",
+                      "example": "true"
+                  },
+                  "return": {
+                      "type": "string",
+                      "description": "Type of data that should be returned in the response",
+                      "enum": [
+                          "json",
+                          "xml",
+                          "html"
+                      ],
+                      "example": "json",
+                      "default": "json"
+                  }
+              },
+              "required": [
+                  "query",
+                  "version"
+              ]
+            
+          },
+          "MainAPIHtmlResponse": {
+            "type": "string",
+            "example": "<html><head></head><body><div class=\"results bibleQuote\"><p class=\"version bibleVersion\">NABRE</p><p class=\"book bookChapter\">1John&nbsp;4</p><p class=\"verses versesParagraph\"><span class=\"sup verseNum\">7</span><span class=\"text verseText\"> Beloved, let us love one another, because love is of God; everyone who loves is begotten by God and knows God. </span><span class=\"sup verseNum\">8</span><span class=\"text verseText\">Whoever is without love does not know God, for God is love. </span></p><input type=\"hidden\" class=\"originalQueries\" value=\"1John4,7-8\"><input type=\"hidden\" class=\"bookAbbrev\" value=\"1Jn\"><input type=\"hidden\" class=\"bookNum\" value=\"68\"><input type=\"hidden\" class=\"univBookNum\" value=\"69\"></div><div class=\"errors bibleQuote\"></div><div class=\"info bibleQuote\"><input type=\"hidden\" name=\"ENDPOINT_VERSION\" value=\"3.0\" class=\"BibleGetInfo\"><input type=\"hidden\" name=\"detectedNotation\" value=\"ENGLISH\" class=\"BibleGetInfo\"><input type=\"hidden\" name=\"bibleVersionsInfo\" value=\"{&quot;NABRE&quot;:&quot;New American Bible - Revised Edition|2011|en|1|CATHOLIC|United States Conference of Catholic Bishops|&quot;}\" class=\"BibleGetInfo\"></div></body></html>"
+          },
+          "MetadataBibleVersionsHTML": {
+            "type": "string",
+            "example": "<html><head></head><body><div class=\"results\" id=\"results\"><table id=\"BibleVersionsTbl\" class=\"BibleVersionsTbl\"><thead><tr><th>ABBREVIATION</th><th>FULLNAME</th><th>YEAR</th><th>LANGUAGE</th><th>COPYRIGHT</th><th>COPYRIGHT_HOLDER</th><th>IMPRIMATUR</th><th>CANON</th></tr></thead><tbody><tr id=\"ValidVersionRow1\" class=\"ValidVersionRow\"><td>CEI2008</td><td>Conferenza Episcopale Italiana</td><td>2008</td><td>it</td><td>1</td><td>Fondazione di Religione “Santi Francesco d’Assisi e Caterina da Siena”</td><td>1</td><td>CATHOLIC</td></tr><tr id=\"ValidVersionRow2\" class=\"ValidVersionRow\"><td>DRB</td><td>Douay–Rheims Challoner Revision</td><td>1752</td><td>en</td><td>0</td><td></td><td>1</td><td>CATHOLIC</td></tr><tr id=\"ValidVersionRow3\" class=\"ValidVersionRow\"><td>LUZZI</td><td>Riveduta - Luzzi</td><td>1924</td><td>it</td><td>0</td><td></td><td>0</td><td>PROTESTANT</td></tr><tr id=\"ValidVersionRow4\" class=\"ValidVersionRow\"><td>NABRE</td><td>New American Bible - Revised Edition</td><td>2011</td><td>en</td><td>1</td><td>United States Conference of Catholic Bishops</td><td>1</td><td>CATHOLIC</td></tr><tr id=\"ValidVersionRow5\" class=\"ValidVersionRow\"><td>NVBSE</td><td>Nova Vulgata - Bibliorum Sacrorum Editio</td><td>1979</td><td>la</td><td>0</td><td></td><td>1</td><td>CATHOLIC</td></tr><tr id=\"ValidVersionRow6\" class=\"ValidVersionRow\"><td>VGCL</td><td>Vulgata Clementina</td><td>1592</td><td>la</td><td>0</td><td></td><td>1</td><td>CATHOLIC</td></tr><tr id=\"ValidVersionRow7\" class=\"ValidVersionRow\"><td>BLPD</td><td>Libro del Pueblo de Dios</td><td>2015</td><td>es</td><td>1</td><td>Fundación Palabra de Vida y Editorial Verbo Divino</td><td>1</td><td>CATHOLIC</td></tr></tbody></table></div><div class=\"errors\" id=\"errors\"></div><input type=\"hidden\" value=\"3.0\" name=\"ENDPOINT_VERSION\"></body></html>"
+          },
+          "MetadataBibleBooksHTML": {
+            "type": "string",
+            "example": "<html><head></head><body><div class=\"results\" id=\"results\"><table id=\"BibleBooksTbl\" class=\"BibleBooksTbl\"><thead><tr><td>BOOK INDEX</td><td>LANGUAGE</td><td>VALUE</td></tr></thead><tbody><tr><td rowspan=\"25\">Book 0</td><td>ENGLISH</td><td>[\"Genesis\",\"Gen\",\"Genesis\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Génesis\",\"Gn\",\"Génesis\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Zanafilla\",\"Gen\",\"Zanafilla\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"تكوين\",\"Gen\",\"تكوين\"]</td></tr><tr><td>CHINESE</td><td>[\"創世紀\",\"Gen\",\"創世紀\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Gen\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Genesis\",\"Gen\",\"Genesis\"]</td></tr><tr><td>FILIPINO</td><td>[\"Genesis\",\"Gen\",\"Genesis\"]</td></tr><tr><td>FRENCH</td><td>[\"Genèse\",\"Gen\",\"Genèse\"]</td></tr><tr><td>GERMAN</td><td>[\"Genesis | 1Mose\",\"Gen\",\"Genesis\",\"1Mose\"]</td></tr><tr><td>GREEK</td><td>[\"Γένεση\",\"Gen\",\"Γένεση\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"1Mózes\",\"Gen\",\"1Mózes\"]</td></tr><tr><td>ITALIAN</td><td>[\"Genesi\",\"Gen | Gn | Ge\",\"Genesi\",\"Gen\",\"Gn\",\"Ge\"]</td></tr><tr><td>JAPANESE</td><td>[\"創世記\",\"Gen\",\"創世記\"]</td></tr><tr><td>KOREAN</td><td>[\"창세기\",\"창세 | 창\",\"창세기\",\"창세\",\"창\"]</td></tr><tr><td>LATIN</td><td>[\"Genesis\",\"Gen\",\"Genesis\"]</td></tr><tr><td>POLISH</td><td>[\"Rodzaju\",\"Rdz\",\"Rodzaju\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Génesis\",\"Gen\",\"Génesis\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Geneza\",\"Gen\",\"Geneza\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Бытие\",\"Быт\",\"Бытие\"]</td></tr><tr><td>SPANISH</td><td>[\"Génesis\",\"Gen | Gén | Gn\",\"Génesis\",\"Gen\",\"Gén\",\"Gn\"]</td></tr><tr><td>TAMIL</td><td>[\"தொடக்க நூல்\",\"Gen\",\"தொடக்கநூல்\"]</td></tr><tr><td>THAI</td><td>[\"ปฐมกาล\",\"Gen\",\"ปฐมกาล\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Sáng Thế\",\"Gen\",\"Sángthế\"]</td></tr><tr><td rowspan=\"25\">Book 1</td><td>ENGLISH</td><td>[\"Exodus\",\"Ex\",\"Exodus\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Exodus\",\"Ex\",\"Exodus\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Eksodi\",\"Ex\",\"Eksodi\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"خروج\",\"Ex\",\"خروج\"]</td></tr><tr><td>CHINESE</td><td>[\"出谷紀\",\"Ex\",\"出谷紀\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Ex\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Exodus\",\"Ex\",\"Exodus\"]</td></tr><tr><td>FILIPINO</td><td>[\"Exodo\",\"Exo\",\"Exodo\"]</td></tr><tr><td>FRENCH</td><td>[\"Exode\",\"Ex\",\"Exode\"]</td></tr><tr><td>GERMAN</td><td>[\"Exodus | 2Mose\",\"Ex\",\"Exodus\",\"2Mose\"]</td></tr><tr><td>GREEK</td><td>[\"Έξοδος\",\"Ex\",\"Έξοδος\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"2Mózes\",\"Ex\",\"2Mózes\"]</td></tr><tr><td>ITALIAN</td><td>[\"Esodo\",\"Es\",\"Esodo\"]</td></tr><tr><td>JAPANESE</td><td>[\"出エジプト記\",\"Ex\",\"出エジプト記\"]</td></tr><tr><td>KOREAN</td><td>[\"출애굽기 | 탈출기\",\"탈출 | 출\",\"출애굽기\",\"탈출기\",\"탈출\",\"출\"]</td></tr><tr><td>LATIN</td><td>[\"Exodus\",\"Ex\",\"Exodus\"]</td></tr><tr><td>POLISH</td><td>[\"Wyjścia\",\"Wj\",\"Wyjścia\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Êxodo\",\"Ex\",\"Êxodo\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Exod\",\"Ex\",\"Exod\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Исход\",\"Исх\",\"Исход\"]</td></tr><tr><td>SPANISH</td><td>[\"Éxodo\",\"Ex | Éx\",\"Éxodo\",\"Ex\",\"Éx\"]</td></tr><tr><td>TAMIL</td><td>[\"விடுதலைப் பயணம்\",\"Ex\",\"விடுதலைப்பயணம்\"]</td></tr><tr><td>THAI</td><td>[\"อพยพ\",\"Ex\",\"อพยพ\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Xuất Hành\",\"Ex\",\"Xuấthành\"]</td></tr><tr><td rowspan=\"25\">Book 2</td><td>ENGLISH</td><td>[\"Leviticus\",\"Lev | Lv\",\"Leviticus\",\"Lev\",\"Lv\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Levitikus\",\"Lv\",\"Levitikus\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Levitiku\",\"Lev | Lv\",\"Levitiku\",\"Lev\",\"Lv\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"لاويين\",\"Lev | Lv\",\"لاويين\",\"Lev\",\"Lv\"]</td></tr><tr><td>CHINESE</td><td>[\"肋未紀\",\"Lev | Lv\",\"肋未紀\",\"Lev\",\"Lv\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Lev | Lv\",\"\",\"Lev\",\"Lv\"]</td></tr><tr><td>CZECH</td><td>[\"Levitikus\",\"Lev | Lv\",\"Levitikus\",\"Lev\",\"Lv\"]</td></tr><tr><td>FILIPINO</td><td>[\"Levitico\",\"Lev\",\"Levitico\"]</td></tr><tr><td>FRENCH</td><td>[\"Lévitique\",\"Lev | Lv\",\"Lévitique\",\"Lev\",\"Lv\"]</td></tr><tr><td>GERMAN</td><td>[\"Levitikus | 3Mose\",\"Lev | Lv\",\"Levitikus\",\"3Mose\",\"Lev\",\"Lv\"]</td></tr><tr><td>GREEK</td><td>[\"Λευιτικό\",\"Lev | Lv\",\"Λευιτικό\",\"Lev\",\"Lv\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"3Mózes\",\"Lev | Lv\",\"3Mózes\",\"Lev\",\"Lv\"]</td></tr><tr><td>ITALIAN</td><td>[\"Levitico\",\"Lv\",\"Levitico\"]</td></tr><tr><td>JAPANESE</td><td>[\"レビ記\",\"Lev | Lv\",\"レビ記\",\"Lev\",\"Lv\"]</td></tr><tr><td>KOREAN</td><td>[\"레위기\",\"레위 | 레\",\"레위기\",\"레위\",\"레\"]</td></tr><tr><td>LATIN</td><td>[\"Leviticus\",\"Lev | Lv\",\"Leviticus\",\"Lev\",\"Lv\"]</td></tr><tr><td>POLISH</td><td>[\"Kapłańska\",\"Kpł\",\"Kapłańska\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Levítico\",\"Lev | Lv\",\"Levítico\",\"Lev\",\"Lv\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Levitic\",\"Lev | Lv\",\"Levitic\",\"Lev\",\"Lv\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Левит\",\"Лев\",\"Левит\"]</td></tr><tr><td>SPANISH</td><td>[\"Levítico\",\"Lv | Lev\",\"Levítico\",\"Lv\",\"Lev\"]</td></tr><tr><td>TAMIL</td><td>[\"லேவியர்\",\"Lev | Lv\",\"லேவியர்\",\"Lev\",\"Lv\"]</td></tr><tr><td>THAI</td><td>[\"เลวีนิติ\",\"Lev | Lv\",\"เลวีนิติ\",\"Lev\",\"Lv\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Lêvi\",\"Lev | Lv\",\"Lêvi\",\"Lev\",\"Lv\"]</td></tr><tr><td rowspan=\"25\">Book 3</td><td>ENGLISH</td><td>[\"Numbers\",\"Num | Nm\",\"Numbers\",\"Num\",\"Nm\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Númeri\",\"Nm\",\"Númeri\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Numrat\",\"Num | Nm\",\"Numrat\",\"Num\",\"Nm\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"عدد\",\"Num | Nm\",\"عدد\",\"Num\",\"Nm\"]</td></tr><tr><td>CHINESE</td><td>[\"戶籍紀\",\"Num | Nm\",\"戶籍紀\",\"Num\",\"Nm\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Num | Nm\",\"\",\"Num\",\"Nm\"]</td></tr><tr><td>CZECH</td><td>[\"Numeri\",\"Num | Nm\",\"Numeri\",\"Num\",\"Nm\"]</td></tr><tr><td>FILIPINO</td><td>[\"Bilang | Mga Bilang\",\"Bil\",\"Bilang\",\"Mgabilang\"]</td></tr><tr><td>FRENCH</td><td>[\"Nombres\",\"Num | Nm\",\"Nombres\",\"Num\",\"Nm\"]</td></tr><tr><td>GERMAN</td><td>[\"Numeri | 4Mose\",\"Num | Nm\",\"Numeri\",\"4Mose\",\"Num\",\"Nm\"]</td></tr><tr><td>GREEK</td><td>[\"Αριθμοί\",\"Num | Nm\",\"Αριθμοί\",\"Num\",\"Nm\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"4Mózes\",\"Num | Nm\",\"4Mózes\",\"Num\",\"Nm\"]</td></tr><tr><td>ITALIAN</td><td>[\"Numeri\",\"Nm\",\"Numeri\"]</td></tr><tr><td>JAPANESE</td><td>[\"民数記\",\"Num | Nm\",\"民数記\",\"Num\",\"Nm\"]</td></tr><tr><td>KOREAN</td><td>[\"민수기\",\"민수 | 민\",\"민수기\",\"민수\",\"민\"]</td></tr><tr><td>LATIN</td><td>[\"Numeri\",\"Num | Nm\",\"Numeri\",\"Num\",\"Nm\"]</td></tr><tr><td>POLISH</td><td>[\"Liczb\",\"Lb\",\"Liczb\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Números\",\"Num | Nm\",\"Números\",\"Num\",\"Nm\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Numeri\",\"Num | Nm\",\"Numeri\",\"Num\",\"Nm\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Числа\",\"Чис\",\"Числа\"]</td></tr><tr><td>SPANISH</td><td>[\"Números\",\"Nm | Núm\",\"Números\",\"Nm\",\"Núm\"]</td></tr><tr><td>TAMIL</td><td>[\"எண்ணிக்கை\",\"Num | Nm\",\"எண்ணிக்கை\",\"Num\",\"Nm\"]</td></tr><tr><td>THAI</td><td>[\"กันดารวิถี\",\"Num | Nm\",\"กันดารวิถี\",\"Num\",\"Nm\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Dân Số\",\"Num | Nm\",\"Dânsố\",\"Num\",\"Nm\"]</td></tr><tr><td rowspan=\"25\">Book 4</td><td>ENGLISH</td><td>[\"Deuteronomy\",\"Deut | Dt\",\"Deuteronomy\",\"Deut\",\"Dt\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Deuteronómium\",\"Dt\",\"Deuteronómium\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Përtërirë | Ligji i Përtërirë\",\"Deut | Dt\",\"Përtërirë\",\"Ligjiipërtërirë\",\"Deut\",\"Dt\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"تثنية\",\"Deut | Dt\",\"تثنية\",\"Deut\",\"Dt\"]</td></tr><tr><td>CHINESE</td><td>[\"申命紀\",\"Deut | Dt\",\"申命紀\",\"Deut\",\"Dt\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Deut | Dt\",\"\",\"Deut\",\"Dt\"]</td></tr><tr><td>CZECH</td><td>[\"Deuteronomium\",\"Deut | Dt\",\"Deuteronomium\",\"Deut\",\"Dt\"]</td></tr><tr><td>FILIPINO</td><td>[\"Deuteronomio\",\"Deut\",\"Deuteronomio\"]</td></tr><tr><td>FRENCH</td><td>[\"Deutéronome\",\"Deut | Dt\",\"Deutéronome\",\"Deut\",\"Dt\"]</td></tr><tr><td>GERMAN</td><td>[\"Deuteronomium | 5Mose\",\"Deut | Dt\",\"Deuteronomium\",\"5Mose\",\"Deut\",\"Dt\"]</td></tr><tr><td>GREEK</td><td>[\"Δευτερονόμιο\",\"Deut | Dt\",\"Δευτερονόμιο\",\"Deut\",\"Dt\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"5Mózes\",\"Deut | Dt\",\"5Mózes\",\"Deut\",\"Dt\"]</td></tr><tr><td>ITALIAN</td><td>[\"Deuteronomio\",\"Dt\",\"Deuteronomio\"]</td></tr><tr><td>JAPANESE</td><td>[\"申命記\",\"Deut | Dt\",\"申命記\",\"Deut\",\"Dt\"]</td></tr><tr><td>KOREAN</td><td>[\"신명기\",\"신명 | 신\",\"신명기\",\"신명\",\"신\"]</td></tr><tr><td>LATIN</td><td>[\"Deuteronomii\",\"Deut | Dt\",\"Deuteronomii\",\"Deut\",\"Dt\"]</td></tr><tr><td>POLISH</td><td>[\"Powtórzonego | Powtórzonego Prawa\",\"Pwt\",\"Powtórzonego\",\"Powtórzonegoprawa\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Deuteronómio\",\"Deut | Dt\",\"Deuteronómio\",\"Deut\",\"Dt\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Deuteronom\",\"Deut | Dt\",\"Deuteronom\",\"Deut\",\"Dt\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Второзаконие\",\"Втор\",\"Второзаконие\"]</td></tr><tr><td>SPANISH</td><td>[\"Deuteronomio\",\"Dt\",\"Deuteronomio\"]</td></tr><tr><td>TAMIL</td><td>[\"இணைச் சட்டம்\",\"Deut | Dt\",\"இணைச்சட்டம்\",\"Deut\",\"Dt\"]</td></tr><tr><td>THAI</td><td>[\"เฉลยธรรมบัญญัติ\",\"Deut | Dt\",\"เฉลยธรรมบัญญัติ\",\"Deut\",\"Dt\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Đệ Nhị Luật\",\"Deut | Dt\",\"Đệnhịluật\",\"Deut\",\"Dt\"]</td></tr><tr><td rowspan=\"25\">Book 5</td><td>ENGLISH</td><td>[\"Joshua\",\"Josh\",\"Joshua\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Josua\",\"Js\",\"Josua\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Jozueu\",\"Josh\",\"Jozueu\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"يشوع\",\"Josh\",\"يشوع\"]</td></tr><tr><td>CHINESE</td><td>[\"若蘇厄書\",\"Josh\",\"若蘇厄書\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Josh\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Jozue\",\"Josh\",\"Jozue\"]</td></tr><tr><td>FILIPINO</td><td>[\"Josue\",\"Jos\",\"Josue\"]</td></tr><tr><td>FRENCH</td><td>[\"Josué\",\"Josh\",\"Josué\"]</td></tr><tr><td>GERMAN</td><td>[\"Josua\",\"Josh\",\"Josua\"]</td></tr><tr><td>GREEK</td><td>[\"Ιησού του Ναυή\",\"Josh\",\"Ιησούτουναυή\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Józsué\",\"Josh\",\"Józsué\"]</td></tr><tr><td>ITALIAN</td><td>[\"Giosue\",\"Gs\",\"Giosue\"]</td></tr><tr><td>JAPANESE</td><td>[\"ヨシュア記\",\"Josh\",\"ヨシュア記\"]</td></tr><tr><td>KOREAN</td><td>[\"여호수아\",\"수\",\"여호수아\"]</td></tr><tr><td>LATIN</td><td>[\"Iosue\",\"Ios | Jos\",\"Iosue\",\"Ios\",\"Jos\"]</td></tr><tr><td>POLISH</td><td>[\"Jozuego\",\"Joz\",\"Jozuego\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Josué\",\"Josh\",\"Josué\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Iosua\",\"Josh\",\"Iosua\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Иисус Навин\",\"Нав\",\"Иисуснавин\"]</td></tr><tr><td>SPANISH</td><td>[\"Josué\",\"Jos\",\"Josué\"]</td></tr><tr><td>TAMIL</td><td>[\"யோசுவா\",\"Josh\",\"யோசுவா\"]</td></tr><tr><td>THAI</td><td>[\"โยชูวา\",\"Josh\",\"โยชูวา\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Giôsuê\",\"Josh\",\"Giôsuê\"]</td></tr><tr><td rowspan=\"25\">Book 6</td><td>ENGLISH</td><td>[\"Judges\",\"Jdg | Jgs\",\"Judges\",\"Jdg\",\"Jgs\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Rigters\",\"Jg\",\"Rigters\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Gjyqtarët\",\"Jdg | Jgs\",\"Gjyqtarët\",\"Jdg\",\"Jgs\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"قضاة\",\"Jdg | Jgs\",\"قضاة\",\"Jdg\",\"Jgs\"]</td></tr><tr><td>CHINESE</td><td>[\"民長紀\",\"Jdg | Jgs\",\"民長紀\",\"Jdg\",\"Jgs\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Jdg | Jgs\",\"\",\"Jdg\",\"Jgs\"]</td></tr><tr><td>CZECH</td><td>[\"Soudců\",\"Jdg | Jgs\",\"Soudců\",\"Jdg\",\"Jgs\"]</td></tr><tr><td>FILIPINO</td><td>[\"Hukom | Mga Hukom\",\"Huk\",\"Hukom\",\"Mgahukom\"]</td></tr><tr><td>FRENCH</td><td>[\"Juges\",\"Jdg | Jgs\",\"Juges\",\"Jdg\",\"Jgs\"]</td></tr><tr><td>GERMAN</td><td>[\"Richter\",\"Jdg | Jgs\",\"Richter\",\"Jdg\",\"Jgs\"]</td></tr><tr><td>GREEK</td><td>[\"Κριτές\",\"Jdg | Jgs\",\"Κριτές\",\"Jdg\",\"Jgs\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Birák\",\"Jdg | Jgs\",\"Birák\",\"Jdg\",\"Jgs\"]</td></tr><tr><td>ITALIAN</td><td>[\"Giudici\",\"Gdc\",\"Giudici\"]</td></tr><tr><td>JAPANESE</td><td>[\"士師記\",\"Jdg | Jgs\",\"士師記\",\"Jdg\",\"Jgs\"]</td></tr><tr><td>KOREAN</td><td>[\"사사기 | 판관기\",\"삿\",\"사사기\",\"판관기\"]</td></tr><tr><td>LATIN</td><td>[\"Iudicum\",\"Iudc | Judc\",\"Iudicum\",\"Iudc\",\"Judc\"]</td></tr><tr><td>POLISH</td><td>[\"Sędziów\",\"Sdz\",\"Sędziów\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Juízes\",\"Jdg | Jgs\",\"Juízes\",\"Jdg\",\"Jgs\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Judecatori\",\"Jdg | Jgs\",\"Judecatori\",\"Jdg\",\"Jgs\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Книга Судей\",\"Суд\",\"Книгасудей\"]</td></tr><tr><td>SPANISH</td><td>[\"Jueces\",\"Jc | Jue\",\"Jueces\",\"Jc\",\"Jue\"]</td></tr><tr><td>TAMIL</td><td>[\"நீதித் தலைவர்கள்\",\"Jdg | Jgs\",\"நீதித்தலைவர்கள்\",\"Jdg\",\"Jgs\"]</td></tr><tr><td>THAI</td><td>[\"ผู้วินิจฉัย\",\"Jdg | Jgs\",\"ผู้วินิจฉัย\",\"Jdg\",\"Jgs\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Thủ Lãnh\",\"Jdg | Jgs\",\"Thủlãnh\",\"Jdg\",\"Jgs\"]</td></tr><tr><td rowspan=\"25\">Book 7</td><td>ENGLISH</td><td>[\"Ruth\",\"Ru\",\"Ruth\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Rut\",\"Rt\",\"Rut\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Ruthi\",\"Ru\",\"Ruthi\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"راعوث\",\"Ru\",\"راعوث\"]</td></tr><tr><td>CHINESE</td><td>[\"盧德紀\",\"Ru\",\"盧德紀\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Ru\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Rút\",\"Ru\",\"Rút\"]</td></tr><tr><td>FILIPINO</td><td>[\"Ruth\",\"Ruth\",\"Ruth\"]</td></tr><tr><td>FRENCH</td><td>[\"Ruth\",\"Ru\",\"Ruth\"]</td></tr><tr><td>GERMAN</td><td>[\"Rut\",\"Ru\",\"Rut\"]</td></tr><tr><td>GREEK</td><td>[\"Ρουθ\",\"Ru\",\"Ρουθ\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Ruth\",\"Ru\",\"Ruth\"]</td></tr><tr><td>ITALIAN</td><td>[\"Rut\",\"Rt\",\"Rut\"]</td></tr><tr><td>JAPANESE</td><td>[\"ルツ記\",\"Ru\",\"ルツ記\"]</td></tr><tr><td>KOREAN</td><td>[\"룻기\",\"룻\",\"룻기\"]</td></tr><tr><td>LATIN</td><td>[\"Ruth\",\"Ru\",\"Ruth\"]</td></tr><tr><td>POLISH</td><td>[\"Rut\",\"Rt\",\"Rut\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Rute\",\"Ru\",\"Rute\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Rut\",\"Ru\",\"Rut\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Руфь\",\"Руф\",\"Руфь\"]</td></tr><tr><td>SPANISH</td><td>[\"Rut\",\"Rt\",\"Rut\"]</td></tr><tr><td>TAMIL</td><td>[\"ரூத்து\",\"Ru\",\"ரூத்து\"]</td></tr><tr><td>THAI</td><td>[\"นางรูธ\",\"Ru\",\"นางรูธ\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Rút\",\"Ru\",\"Rút\"]</td></tr><tr><td rowspan=\"25\">Book 8</td><td>ENGLISH</td><td>[\"1 Samuel\",\"1Sam\",\"1Samuel\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"1 Samuel\",\"1Sm\",\"1Samuel\"]</td></tr><tr><td>ALBANIAN</td><td>[\"1Samuelit\",\"1Sam\",\"1Samuelit\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"1صموئيل\",\"1Sam\",\"1صموئيل\"]</td></tr><tr><td>CHINESE</td><td>[\"撒慕爾紀上\",\"1Sam\",\"撒慕爾紀上\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"1Sam\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"1Samuelova\",\"1Sam\",\"1Samuelova\"]</td></tr><tr><td>FILIPINO</td><td>[\"1 Samuel\",\"1Sam\",\"1Samuel\"]</td></tr><tr><td>FRENCH</td><td>[\"1Samuel\",\"1Sam\",\"1Samuel\"]</td></tr><tr><td>GERMAN</td><td>[\"1Samuel\",\"1Sam\",\"1Samuel\"]</td></tr><tr><td>GREEK</td><td>[\"Α Σαμουήλ\",\"1Sam\",\"Ασαμουήλ\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"1Sámuel\",\"1Sam\",\"1Sámuel\"]</td></tr><tr><td>ITALIAN</td><td>[\"1Samuele\",\"1Sam\",\"1Samuele\"]</td></tr><tr><td>JAPANESE</td><td>[\"サムエル記上\",\"1Sam\",\"サムエル記上\"]</td></tr><tr><td>KOREAN</td><td>[\"사무엘 상\",\"삼상\",\"사무엘상\"]</td></tr><tr><td>LATIN</td><td>[\"I Samuelis\",\"I Sam\",\"Isamuelis\"]</td></tr><tr><td>POLISH</td><td>[\"1Samuela\",\"1Sm\",\"1Samuela\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"1 Samuel\",\"1Sam\",\"1Samuel\"]</td></tr><tr><td>ROMANIAN</td><td>[\"1Samuel\",\"1Sam\",\"1Samuel\"]</td></tr><tr><td>RUSSIAN</td><td>[\"1Царств\",\"1Цар\",\"1Царств\"]</td></tr><tr><td>SPANISH</td><td>[\"1Samuel\",\"1Sa | 1Sam\",\"1Samuel\",\"1Sa\",\"1Sam\"]</td></tr><tr><td>TAMIL</td><td>[\"1 சாமுவேல்\",\"1Sam\",\"1சாமுவேல்\"]</td></tr><tr><td>THAI</td><td>[\"1 ซามูเอล | ซามูเอลฉบับที่หึ่ง\",\"1Sam\",\"1ซามูเอล\",\"ซามูเอลฉบับที่หึ่ง\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"1Samuen\",\"1Sam\",\"1Samuen\"]</td></tr><tr><td rowspan=\"25\">Book 9</td><td>ENGLISH</td><td>[\"2 Samuel\",\"2Sam\",\"2Samuel\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"2 Samuel\",\"2Sm\",\"2Samuel\"]</td></tr><tr><td>ALBANIAN</td><td>[\"2Samuelit\",\"2Sam\",\"2Samuelit\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"2صموئيل\",\"2Sam\",\"2صموئيل\"]</td></tr><tr><td>CHINESE</td><td>[\"撒慕爾記下\",\"2Sam\",\"撒慕爾記下\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"2Sam\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"2Samuelova\",\"2Sam\",\"2Samuelova\"]</td></tr><tr><td>FILIPINO</td><td>[\"2 Samuel\",\"2Sam\",\"2Samuel\"]</td></tr><tr><td>FRENCH</td><td>[\"2Samuel\",\"2Sam\",\"2Samuel\"]</td></tr><tr><td>GERMAN</td><td>[\"2Samuel\",\"2Sam\",\"2Samuel\"]</td></tr><tr><td>GREEK</td><td>[\"Β Σαμουήλ\",\"2Sam\",\"Βσαμουήλ\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"2Sámuel\",\"2Sam\",\"2Sámuel\"]</td></tr><tr><td>ITALIAN</td><td>[\"2Samuele\",\"2Sam\",\"2Samuele\"]</td></tr><tr><td>JAPANESE</td><td>[\"サムエル記下\",\"2Sam\",\"サムエル記下\"]</td></tr><tr><td>KOREAN</td><td>[\"사무엘 하\",\"삼하\",\"사무엘하\"]</td></tr><tr><td>LATIN</td><td>[\"II Samuelis\",\"II Sam\",\"Iisamuelis\"]</td></tr><tr><td>POLISH</td><td>[\"2Samuela\",\"2Sm\",\"2Samuela\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"2 Samuel\",\"2Sam\",\"2Samuel\"]</td></tr><tr><td>ROMANIAN</td><td>[\"2Samuel\",\"2Sam\",\"2Samuel\"]</td></tr><tr><td>RUSSIAN</td><td>[\"2Царств\",\"2Цар\",\"2Царств\"]</td></tr><tr><td>SPANISH</td><td>[\"2Samuel\",\"2Sa | 2Sam\",\"2Samuel\",\"2Sa\",\"2Sam\"]</td></tr><tr><td>TAMIL</td><td>[\"2 சாமுவேல்\",\"2Sam\",\"2சாமுவேல்\"]</td></tr><tr><td>THAI</td><td>[\"2 ซามูเอล | ซามูเอลฉบับที่สอง\",\"2Sam\",\"2ซามูเอล\",\"ซามูเอลฉบับที่สอง\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"2Samuen\",\"2Sam\",\"2Samuen\"]</td></tr><tr><td rowspan=\"25\">Book 10</td><td>ENGLISH</td><td>[\"1 Kings\",\"1Kgs\",\"1Kings\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"1 Konings\",\"1Kn\",\"1Konings\"]</td></tr><tr><td>ALBANIAN</td><td>[\"1Mbretërve\",\"1Kgs\",\"1Mbretërve\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"1ملوك\",\"1Kgs\",\"1ملوك\"]</td></tr><tr><td>CHINESE</td><td>[\"列王紀上\",\"1Kgs\",\"列王紀上\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"1Kgs\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"1Královská\",\"1Kgs\",\"1Královská\"]</td></tr><tr><td>FILIPINO</td><td>[\"1 Hari | 1 Mga Hari\",\"1Ha\",\"1Hari\",\"1Mgahari\"]</td></tr><tr><td>FRENCH</td><td>[\"1Rois\",\"1Kgs\",\"1Rois\"]</td></tr><tr><td>GERMAN</td><td>[\"1Könige\",\"1Kgs\",\"1Könige\"]</td></tr><tr><td>GREEK</td><td>[\"Α Βασιλέων\",\"1Kgs\",\"Αβασιλέων\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"1Királyok\",\"1Kgs\",\"1Királyok\"]</td></tr><tr><td>ITALIAN</td><td>[\"1Re\",\"1Re\",\"1Re\"]</td></tr><tr><td>JAPANESE</td><td>[\"列王紀上\",\"1Kgs\",\"列王紀上\"]</td></tr><tr><td>KOREAN</td><td>[\"열왕기 상\",\"왕상\",\"열왕기상\"]</td></tr><tr><td>LATIN</td><td>[\"I Regum\",\"I Reg\",\"Iregum\"]</td></tr><tr><td>POLISH</td><td>[\"1Królewska\",\"1Krl\",\"1Królewska\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"1 Reis\",\"1Kgs\",\"1Reis\"]</td></tr><tr><td>ROMANIAN</td><td>[\"1Imparati\",\"1Kgs\",\"1Imparati\"]</td></tr><tr><td>RUSSIAN</td><td>[\"3Царств\",\"3Цар\",\"3Царств\"]</td></tr><tr><td>SPANISH</td><td>[\"1Reyes\",\"1Re\",\"1Reyes\"]</td></tr><tr><td>TAMIL</td><td>[\"1 அரசர்கள்\",\"1Kgs\",\"1அரசர்கள்\"]</td></tr><tr><td>THAI</td><td>[\"1 พงศ์กษัตริย์ | พงศ์กษัตริย์ฉบับที่หึ่ง\",\"1Kgs\",\"1พงศ์กษัตริย์\",\"พงศ์กษัตริย์ฉบับที่หึ่ง\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"1 Các Vua\",\"1Kgs\",\"1Cácvua\"]</td></tr><tr><td rowspan=\"25\">Book 11</td><td>ENGLISH</td><td>[\"2 Kings\",\"2Kgs\",\"2Kings\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"2 Konings\",\"2Kn\",\"2Konings\"]</td></tr><tr><td>ALBANIAN</td><td>[\"2Mbretërve\",\"2Kgs\",\"2Mbretërve\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"2ملوك\",\"2Kgs\",\"2ملوك\"]</td></tr><tr><td>CHINESE</td><td>[\"列王紀下\",\"2Kgs\",\"列王紀下\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"2Kgs\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"2Královská\",\"2Kgs\",\"2Královská\"]</td></tr><tr><td>FILIPINO</td><td>[\"2 Hari | 2 Mga Hari\",\"2Ha\",\"2Hari\",\"2Mgahari\"]</td></tr><tr><td>FRENCH</td><td>[\"2Rois\",\"2Kgs\",\"2Rois\"]</td></tr><tr><td>GERMAN</td><td>[\"2Könige\",\"2Kgs\",\"2Könige\"]</td></tr><tr><td>GREEK</td><td>[\"Β Βασιλέων\",\"2Kgs\",\"Ββασιλέων\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"2Királyok\",\"2Kgs\",\"2Királyok\"]</td></tr><tr><td>ITALIAN</td><td>[\"2Re\",\"2Re\",\"2Re\"]</td></tr><tr><td>JAPANESE</td><td>[\"列王紀下\",\"2Kgs\",\"列王紀下\"]</td></tr><tr><td>KOREAN</td><td>[\"열왕기 하\",\"왕하\",\"열왕기하\"]</td></tr><tr><td>LATIN</td><td>[\"II Regum\",\"II Reg\",\"Iiregum\"]</td></tr><tr><td>POLISH</td><td>[\"2Królewska\",\"2Krl\",\"2Królewska\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"2 Reis\",\"2Kgs\",\"2Reis\"]</td></tr><tr><td>ROMANIAN</td><td>[\"2Imparati\",\"2Kgs\",\"2Imparati\"]</td></tr><tr><td>RUSSIAN</td><td>[\"4Царств\",\"4Цар\",\"4Царств\"]</td></tr><tr><td>SPANISH</td><td>[\"2Reyes\",\"2Re\",\"2Reyes\"]</td></tr><tr><td>TAMIL</td><td>[\"2 அரசர்கள்\",\"2Kgs\",\"2அரசர்கள்\"]</td></tr><tr><td>THAI</td><td>[\"2 พงศ์กษัตริย์ | พงศ์กษัตริย์ฉบับที่สอง\",\"2Kgs\",\"2พงศ์กษัตริย์\",\"พงศ์กษัตริย์ฉบับที่สอง\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"2 Các Vua\",\"2Kgs\",\"2Cácvua\"]</td></tr><tr><td rowspan=\"25\">Book 12</td><td>ENGLISH</td><td>[\"1 Chronicles\",\"1Chron | 1Chr\",\"1Chronicles\",\"1Chron\",\"1Chr\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"1 Kronieke\",\"1Ch\",\"1Kronieke\"]</td></tr><tr><td>ALBANIAN</td><td>[\"1Kronikave\",\"1Chron | 1Chr\",\"1Kronikave\",\"1Chron\",\"1Chr\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"1اخبار\",\"1Chron | 1Chr\",\"1اخبار\",\"1Chron\",\"1Chr\"]</td></tr><tr><td>CHINESE</td><td>[\"編年紀上\",\"1Chron | 1Chr\",\"編年紀上\",\"1Chron\",\"1Chr\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"1Chron | 1Chr\",\"\",\"1Chron\",\"1Chr\"]</td></tr><tr><td>CZECH</td><td>[\"1Paralipomenon\",\"1Chron | 1Chr\",\"1Paralipomenon\",\"1Chron\",\"1Chr\"]</td></tr><tr><td>FILIPINO</td><td>[\"1 Cronica | 1 Mga Cronica\",\"1Cro\",\"1Cronica\",\"1Mgacronica\"]</td></tr><tr><td>FRENCH</td><td>[\"1Chroniques\",\"1Chron | 1Chr\",\"1Chroniques\",\"1Chron\",\"1Chr\"]</td></tr><tr><td>GERMAN</td><td>[\"1Chronik\",\"1Chron | 1Chr\",\"1Chronik\",\"1Chron\",\"1Chr\"]</td></tr><tr><td>GREEK</td><td>[\"Α Χρονικών\",\"1Chron | 1Chr\",\"Αχρονικών\",\"1Chron\",\"1Chr\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"1Krónika\",\"1Chron | 1Chr\",\"1Krónika\",\"1Chron\",\"1Chr\"]</td></tr><tr><td>ITALIAN</td><td>[\"1Cronache\",\"1Cr\",\"1Cronache\"]</td></tr><tr><td>JAPANESE</td><td>[\"歴代志上\",\"1Chron | 1Chr\",\"歴代志上\",\"1Chron\",\"1Chr\"]</td></tr><tr><td>KOREAN</td><td>[\"역대상 | 역대기 상\",\"대상\",\"역대상\",\"역대기상\"]</td></tr><tr><td>LATIN</td><td>[\"I Paralipomenon\",\"I Paral\",\"Iparalipomenon\"]</td></tr><tr><td>POLISH</td><td>[\"1Kronik\",\"1Krn\",\"1Kronik\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"1 Crónicas\",\"1Chron | 1Chr\",\"1Crónicas\",\"1Chron\",\"1Chr\"]</td></tr><tr><td>ROMANIAN</td><td>[\"1Cronici\",\"1Chron | 1Chr\",\"1Cronici\",\"1Chron\",\"1Chr\"]</td></tr><tr><td>RUSSIAN</td><td>[\"1Паралипоменон\",\"1Пар\",\"1Паралипоменон\"]</td></tr><tr><td>SPANISH</td><td>[\"1Crónicas\",\"1Cro | 1Crón\",\"1Crónicas\",\"1Cro\",\"1Crón\"]</td></tr><tr><td>TAMIL</td><td>[\"1 குறிப்பேடு\",\"1Chron | 1Chr\",\"1குறிப்பேடு\",\"1Chron\",\"1Chr\"]</td></tr><tr><td>THAI</td><td>[\"1 พงศาวดาร | พงศาวดารฉบับที่หึ่ง\",\"1Chron | 1Chr\",\"1พงศาวดาร\",\"พงศาวดารฉบับที่หึ่ง\",\"1Chron\",\"1Chr\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"1 Sử Biên Niên\",\"1Chron | 1Chr\",\"1Sửbiênniên\",\"1Chron\",\"1Chr\"]</td></tr><tr><td rowspan=\"25\">Book 13</td><td>ENGLISH</td><td>[\"2 Chronicles\",\"2Chron | 2Chr\",\"2Chronicles\",\"2Chron\",\"2Chr\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"2 Kronieke\",\"2Ch\",\"2Kronieke\"]</td></tr><tr><td>ALBANIAN</td><td>[\"2Kronikave\",\"2Chron | 2Chr\",\"2Kronikave\",\"2Chron\",\"2Chr\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"2اخبار\",\"2Chron | 2Chr\",\"2اخبار\",\"2Chron\",\"2Chr\"]</td></tr><tr><td>CHINESE</td><td>[\"編年記下\",\"2Chron | 2Chr\",\"編年記下\",\"2Chron\",\"2Chr\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"2Chron | 2Chr\",\"\",\"2Chron\",\"2Chr\"]</td></tr><tr><td>CZECH</td><td>[\"2Paralipomenon\",\"2Chron | 2Chr\",\"2Paralipomenon\",\"2Chron\",\"2Chr\"]</td></tr><tr><td>FILIPINO</td><td>[\"2 Cronica | 2 Mga Cronica\",\"2Cro\",\"2Cronica\",\"2Mgacronica\"]</td></tr><tr><td>FRENCH</td><td>[\"2Chroniques\",\"2Chron | 2Chr\",\"2Chroniques\",\"2Chron\",\"2Chr\"]</td></tr><tr><td>GERMAN</td><td>[\"2Chronik\",\"2Chron | 2Chr\",\"2Chronik\",\"2Chron\",\"2Chr\"]</td></tr><tr><td>GREEK</td><td>[\"Β Χρονικών\",\"2Chron | 2Chr\",\"Βχρονικών\",\"2Chron\",\"2Chr\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"2Krónika\",\"2Chron | 2Chr\",\"2Krónika\",\"2Chron\",\"2Chr\"]</td></tr><tr><td>ITALIAN</td><td>[\"2Cronache\",\"2Cr\",\"2Cronache\"]</td></tr><tr><td>JAPANESE</td><td>[\"歴代志下\",\"2Chron | 2Chr\",\"歴代志下\",\"2Chron\",\"2Chr\"]</td></tr><tr><td>KOREAN</td><td>[\"역대하 | 역대기 하\",\"대하\",\"역대하\",\"역대기하\"]</td></tr><tr><td>LATIN</td><td>[\"II Paralipomenon\",\"II Paral\",\"Iiparalipomenon\"]</td></tr><tr><td>POLISH</td><td>[\"2Kronik\",\"2Krn\",\"2Kronik\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"2 Crónicas\",\"2Chron | 2Chr\",\"2Crónicas\",\"2Chron\",\"2Chr\"]</td></tr><tr><td>ROMANIAN</td><td>[\"2Cronici\",\"2Chron | 2Chr\",\"2Cronici\",\"2Chron\",\"2Chr\"]</td></tr><tr><td>RUSSIAN</td><td>[\"2Паралипоменон\",\"2Пар\",\"2Паралипоменон\"]</td></tr><tr><td>SPANISH</td><td>[\"2Crónicas\",\"2Cro | 2Crón\",\"2Crónicas\",\"2Cro\",\"2Crón\"]</td></tr><tr><td>TAMIL</td><td>[\"2 குறிப்பேடு\",\"2Chron | 2Chr\",\"2குறிப்பேடு\",\"2Chron\",\"2Chr\"]</td></tr><tr><td>THAI</td><td>[\"2 พงศาวดาร | พงศาวดารฉบับที่สอง\",\"2Chron | 2Chr\",\"2พงศาวดาร\",\"พงศาวดารฉบับที่สอง\",\"2Chron\",\"2Chr\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"2 Sử Biên Niên\",\"2Chron | 2Chr\",\"2Sửbiênniên\",\"2Chron\",\"2Chr\"]</td></tr><tr><td rowspan=\"25\">Book 14</td><td>ENGLISH</td><td>[\"Ezra\",\"Ezr\",\"Ezra\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Esra\",\"Ezr\",\"Esra\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Esdra\",\"Ezr\",\"Esdra\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"عزرا\",\"Ezr\",\"عزرا\"]</td></tr><tr><td>CHINESE</td><td>[\"厄斯德拉上\",\"Ezr\",\"厄斯德拉上\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Ezr\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Ezdráš\",\"Ezr\",\"Ezdráš\"]</td></tr><tr><td>FILIPINO</td><td>[\"Ezra\",\"Ezr\",\"Ezra\"]</td></tr><tr><td>FRENCH</td><td>[\"Esdras\",\"Ezr\",\"Esdras\"]</td></tr><tr><td>GERMAN</td><td>[\"Esra\",\"Ezr\",\"Esra\"]</td></tr><tr><td>GREEK</td><td>[\"Έσδρας\",\"Ezr\",\"Έσδρας\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Ezsdrás\",\"Ezr\",\"Ezsdrás\"]</td></tr><tr><td>ITALIAN</td><td>[\"Esdra\",\"Esd\",\"Esdra\"]</td></tr><tr><td>JAPANESE</td><td>[\"エズラ記\",\"Ezr\",\"エズラ記\"]</td></tr><tr><td>KOREAN</td><td>[\"에스라 | 에즈라\",\"스\",\"에스라\",\"에즈라\"]</td></tr><tr><td>LATIN</td><td>[\"Esdræ | Esdrae\",\"Esd\",\"Esdræ\",\"Esdrae\"]</td></tr><tr><td>POLISH</td><td>[\"Ezdrasza\",\"Ezd\",\"Ezdrasza\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Esdras\",\"Ezr\",\"Esdras\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Ezra\",\"Ezr\",\"Ezra\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Ездра\",\"Езд\",\"Ездра\"]</td></tr><tr><td>SPANISH</td><td>[\"Esdras\",\"Esd\",\"Esdras\"]</td></tr><tr><td>TAMIL</td><td>[\"எஸ்ரா\",\"Ezr\",\"எஸ்ரா\"]</td></tr><tr><td>THAI</td><td>[\"เอสรา\",\"Ezr\",\"เอสรา\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Étra\",\"Ezr\",\"Étra\"]</td></tr><tr><td rowspan=\"25\">Book 15</td><td>ENGLISH</td><td>[\"Nehemiah\",\"Neh\",\"Nehemiah\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Nehemia\",\"Nh\",\"Nehemia\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Nehemía\",\"Neh\",\"Nehemía\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"نحميا\",\"Neh\",\"نحميا\"]</td></tr><tr><td>CHINESE</td><td>[\"厄斯德拉下\",\"Neh\",\"厄斯德拉下\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Neh\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Nehemjáš\",\"Neh\",\"Nehemjáš\"]</td></tr><tr><td>FILIPINO</td><td>[\"Nehemias\",\"Neh\",\"Nehemias\"]</td></tr><tr><td>FRENCH</td><td>[\"Néhémie\",\"Neh\",\"Néhémie\"]</td></tr><tr><td>GERMAN</td><td>[\"Nehemia\",\"Neh\",\"Nehemia\"]</td></tr><tr><td>GREEK</td><td>[\"Νεεμίας\",\"Neh\",\"Νεεμίας\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Nehemiás\",\"Neh\",\"Nehemiás\"]</td></tr><tr><td>ITALIAN</td><td>[\"Neemia\",\"Ne\",\"Neemia\"]</td></tr><tr><td>JAPANESE</td><td>[\"ネヘミヤ記\",\"Neh\",\"ネヘミヤ記\"]</td></tr><tr><td>KOREAN</td><td>[\"느헤미야\",\"느\",\"느헤미야\"]</td></tr><tr><td>LATIN</td><td>[\"Nehemiæ | Nehemiae\",\"Neh\",\"Nehemiæ\",\"Nehemiae\"]</td></tr><tr><td>POLISH</td><td>[\"Nehemiasza\",\"Ne\",\"Nehemiasza\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Neemias\",\"Neh\",\"Neemias\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Neemia\",\"Neh\",\"Neemia\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Неемия\",\"Неем\",\"Неемия\"]</td></tr><tr><td>SPANISH</td><td>[\"Nehemías\",\"Ne | Neh\",\"Nehemías\",\"Ne\",\"Neh\"]</td></tr><tr><td>TAMIL</td><td>[\"நெகேமியா\",\"Neh\",\"நெகேமியா\"]</td></tr><tr><td>THAI</td><td>[\"เนหะมีย์\",\"Neh\",\"เนหะมีย์\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Nơkhemia\",\"Neh\",\"Nơkhemia\"]</td></tr><tr><td rowspan=\"25\">Book 16</td><td>ENGLISH</td><td>[\"Tobit | Tobias\",\"Tob\",\"Tobit\",\"Tobias\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Tobias\",\"\",\"Tobias\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Tobit\",\"Tob\",\"Tobit\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"طوبيا\",\"Tob\",\"طوبيا\"]</td></tr><tr><td>CHINESE</td><td>[\"多俾亞傳\",\"Tob\",\"多俾亞傳\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Tob\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Tobiáš\",\"Tob\",\"Tobiáš\"]</td></tr><tr><td>FILIPINO</td><td>[\"Tobit\",\"Tob\",\"Tobit\"]</td></tr><tr><td>FRENCH</td><td>[\"Tobie\",\"Tob\",\"Tobie\"]</td></tr><tr><td>GERMAN</td><td>[\"Tobit | Tobias\",\"Tob\",\"Tobit\",\"Tobias\"]</td></tr><tr><td>GREEK</td><td>[\"Τωβίτ\",\"Tob\",\"Τωβίτ\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Tóbiás\",\"Tob\",\"Tóbiás\"]</td></tr><tr><td>ITALIAN</td><td>[\"Tobia\",\"Tb\",\"Tobia\"]</td></tr><tr><td>JAPANESE</td><td>[\"トビト記\",\"Tob\",\"トビト記\"]</td></tr><tr><td>KOREAN</td><td>[\"토비트\",\"Tob\",\"토비트\"]</td></tr><tr><td>LATIN</td><td>[\"Thobis\",\"Tob\",\"Thobis\"]</td></tr><tr><td>POLISH</td><td>[\"Tobiasza\",\"Tb\",\"Tobiasza\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Tobias\",\"Tob\",\"Tobias\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Tobit\",\"Tob\",\"Tobit\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Тови́та\",\"Тов\",\"Тови́та\"]</td></tr><tr><td>SPANISH</td><td>[\"Tobías\",\"Tb | Tob\",\"Tobías\",\"Tb\",\"Tob\"]</td></tr><tr><td>TAMIL</td><td>[\"தோபித்து\",\"Tob\",\"தோபித்து\"]</td></tr><tr><td>THAI</td><td>[\"โทบิต\",\"Tob\",\"โทบิต\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Tobit\",\"Tob\",\"Tobit\"]</td></tr><tr><td rowspan=\"25\">Book 17</td><td>ENGLISH</td><td>[\"Judith\",\"Jdt\",\"Judith\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Judith\",\"\",\"Judith\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Judith\",\"Jdt\",\"Judith\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"يهوديت\",\"Jdt\",\"يهوديت\"]</td></tr><tr><td>CHINESE</td><td>[\"友弟德傳\",\"Jdt\",\"友弟德傳\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Jdt\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Júdit\",\"Jdt\",\"Júdit\"]</td></tr><tr><td>FILIPINO</td><td>[\"Judith\",\"Jdt\",\"Judith\"]</td></tr><tr><td>FRENCH</td><td>[\"Judith\",\"Jdt\",\"Judith\"]</td></tr><tr><td>GERMAN</td><td>[\"Judit\",\"Jdt\",\"Judit\"]</td></tr><tr><td>GREEK</td><td>[\"Ιουδίθ\",\"Jdt\",\"Ιουδίθ\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Judit\",\"Jdt\",\"Judit\"]</td></tr><tr><td>ITALIAN</td><td>[\"Giuditta\",\"Gdt\",\"Giuditta\"]</td></tr><tr><td>JAPANESE</td><td>[\"ユディト記\",\"Jdt\",\"ユディト記\"]</td></tr><tr><td>KOREAN</td><td>[\"유딧\",\"Jdt\",\"유딧\"]</td></tr><tr><td>LATIN</td><td>[\"Iudith | Judith\",\"Idt\",\"Iudith\",\"Judith\"]</td></tr><tr><td>POLISH</td><td>[\"Judyty\",\"Jdt\",\"Judyty\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Judite\",\"Jdt\",\"Judite\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Iudita\",\"Jdt\",\"Iudita\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Юдифи | Иудифи\",\"Иудифь\",\"Юдифи\",\"Иудифи\"]</td></tr><tr><td>SPANISH</td><td>[\"Judit\",\"Jdt\",\"Judit\"]</td></tr><tr><td>TAMIL</td><td>[\"யூதித்து\",\"Jdt\",\"யூதித்து\"]</td></tr><tr><td>THAI</td><td>[\"ยูดิธ\",\"Jdt\",\"ยูดิธ\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Judith\",\"Jdt\",\"Judith\"]</td></tr><tr><td rowspan=\"25\">Book 18</td><td>ENGLISH</td><td>[\"Esther\",\"Est\",\"Esther\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Ester\",\"Es\",\"Ester\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Ester\",\"Est\",\"Ester\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"استير\",\"Est\",\"استير\"]</td></tr><tr><td>CHINESE</td><td>[\"艾斯德爾傳\",\"Est\",\"艾斯德爾傳\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Est\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Ester\",\"Est\",\"Ester\"]</td></tr><tr><td>FILIPINO</td><td>[\"Ester\",\"Est\",\"Ester\"]</td></tr><tr><td>FRENCH</td><td>[\"Esther\",\"Est\",\"Esther\"]</td></tr><tr><td>GERMAN</td><td>[\"Ester\",\"Est\",\"Ester\"]</td></tr><tr><td>GREEK</td><td>[\"Εσθήρ\",\"Est\",\"Εσθήρ\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Eszter\",\"Est\",\"Eszter\"]</td></tr><tr><td>ITALIAN</td><td>[\"Ester\",\"Est\",\"Ester\"]</td></tr><tr><td>JAPANESE</td><td>[\"エステル記\",\"Est\",\"エステル記\"]</td></tr><tr><td>KOREAN</td><td>[\"에스더 | 에스테르(에)\",\"에\",\"에스더\",\"에스테르(에)\"]</td></tr><tr><td>LATIN</td><td>[\"Esther\",\"Est\",\"Esther\"]</td></tr><tr><td>POLISH</td><td>[\"Estery\",\"Est\",\"Estery\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Ester\",\"Est\",\"Ester\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Estera\",\"Est\",\"Estera\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Есфирь\",\"Есф\",\"Есфирь\"]</td></tr><tr><td>SPANISH</td><td>[\"Ester\",\"Est\",\"Ester\"]</td></tr><tr><td>TAMIL</td><td>[\"எஸ்தர்\",\"Est\",\"எஸ்தர்\"]</td></tr><tr><td>THAI</td><td>[\"เอสเธอร์\",\"Est\",\"เอสเธอร์\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Étte\",\"Est\",\"Étte\"]</td></tr><tr><td rowspan=\"25\">Book 19</td><td>ENGLISH</td><td>[\"1 Maccabees\",\"1Macc | 1Mc\",\"1Maccabees\",\"1Macc\",\"1Mc\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"1 Makkabeërs\",\"\",\"1Makkabeërs\"]</td></tr><tr><td>ALBANIAN</td><td>[\"1 Maccabees\",\"1Macc | 1Mc\",\"1Maccabees\",\"1Macc\",\"1Mc\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"المكابيين1\",\"1Macc | 1Mc\",\"المكابيين1\",\"1Macc\",\"1Mc\"]</td></tr><tr><td>CHINESE</td><td>[\"瑪加伯上\",\"1Macc | 1Mc\",\"瑪加伯上\",\"1Macc\",\"1Mc\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"1Macc | 1Mc\",\"\",\"1Macc\",\"1Mc\"]</td></tr><tr><td>CZECH</td><td>[\"1Makabejská\",\"1Macc | 1Mc\",\"1Makabejská\",\"1Macc\",\"1Mc\"]</td></tr><tr><td>FILIPINO</td><td>[\"1 Macabeo\",\"1Mcb\",\"1Macabeo\"]</td></tr><tr><td>FRENCH</td><td>[\"1 Maccabées\",\"1Macc | 1Mc\",\"1Maccabées\",\"1Macc\",\"1Mc\"]</td></tr><tr><td>GERMAN</td><td>[\"1Makkabäer\",\"1Macc | 1Mc\",\"1Makkabäer\",\"1Macc\",\"1Mc\"]</td></tr><tr><td>GREEK</td><td>[\"A Μακκαβαίοι\",\"1Macc | 1Mc\",\"Aμακκαβαίοι\",\"1Macc\",\"1Mc\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"1 Makkabeusok\",\"1Macc | 1Mc\",\"1Makkabeusok\",\"1Macc\",\"1Mc\"]</td></tr><tr><td>ITALIAN</td><td>[\"1Maccabei\",\"1Mac\",\"1Maccabei\"]</td></tr><tr><td>JAPANESE</td><td>[\"マカバイ記1\",\"1Macc | 1Mc\",\"マカバイ記1\",\"1Macc\",\"1Mc\"]</td></tr><tr><td>KOREAN</td><td>[\"마카베오상\",\"1Macc | 1Mc\",\"마카베오상\",\"1Macc\",\"1Mc\"]</td></tr><tr><td>LATIN</td><td>[\"I Maccabæorum | I Maccabaeorum\",\"I Macc\",\"Imaccabæorum\",\"Imaccabaeorum\"]</td></tr><tr><td>POLISH</td><td>[\"1Machabejska\",\"1Mch\",\"1Machabejska\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"1 Macabeus\",\"1Macc | 1Mc\",\"1Macabeus\",\"1Macc\",\"1Mc\"]</td></tr><tr><td>ROMANIAN</td><td>[\"1Macabei\",\"1Macc | 1Mc\",\"1Macabei\",\"1Macc\",\"1Mc\"]</td></tr><tr><td>RUSSIAN</td><td>[\"1Маккавейские\",\"1Macc | 1Mc\",\"1Маккавейские\",\"1Macc\",\"1Mc\"]</td></tr><tr><td>SPANISH</td><td>[\"1Macabeos\",\"1Mac\",\"1Macabeos\"]</td></tr><tr><td>TAMIL</td><td>[\"1 மக்கபேயர்\",\"1Macc | 1Mc\",\"1மக்கபேயர்\",\"1Macc\",\"1Mc\"]</td></tr><tr><td>THAI</td><td>[\"1 มัคคาบี | มัคคาบีฉบับที่หึ่ง\",\"1Macc | 1Mc\",\"1มัคคาบี\",\"มัคคาบีฉบับที่หึ่ง\",\"1Macc\",\"1Mc\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"1 Maccabee\",\"1Macc | 1Mc\",\"1Maccabee\",\"1Macc\",\"1Mc\"]</td></tr><tr><td rowspan=\"25\">Book 20</td><td>ENGLISH</td><td>[\"2 Maccabees\",\"2Macc | 2Mc\",\"2Maccabees\",\"2Macc\",\"2Mc\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"2 Makkabeërs\",\"\",\"2Makkabeërs\"]</td></tr><tr><td>ALBANIAN</td><td>[\"2 Maccabees\",\"2Macc | 2Mc\",\"2Maccabees\",\"2Macc\",\"2Mc\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"المكابيين2\",\"2Macc | 2Mc\",\"المكابيين2\",\"2Macc\",\"2Mc\"]</td></tr><tr><td>CHINESE</td><td>[\"瑪加伯下\",\"2Macc | 2Mc\",\"瑪加伯下\",\"2Macc\",\"2Mc\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"2Macc | 2Mc\",\"\",\"2Macc\",\"2Mc\"]</td></tr><tr><td>CZECH</td><td>[\"2Makabejská\",\"2Macc | 2Mc\",\"2Makabejská\",\"2Macc\",\"2Mc\"]</td></tr><tr><td>FILIPINO</td><td>[\"2 Macabeo\",\"2Mcb\",\"2Macabeo\"]</td></tr><tr><td>FRENCH</td><td>[\"2 Maccabées\",\"2Macc | 2Mc\",\"2Maccabées\",\"2Macc\",\"2Mc\"]</td></tr><tr><td>GERMAN</td><td>[\"2Makkabäer\",\"2Macc | 2Mc\",\"2Makkabäer\",\"2Macc\",\"2Mc\"]</td></tr><tr><td>GREEK</td><td>[\"B Μακκαβαίοι\",\"2Macc | 2Mc\",\"Bμακκαβαίοι\",\"2Macc\",\"2Mc\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"2 Makkabeusok\",\"2Macc | 2Mc\",\"2Makkabeusok\",\"2Macc\",\"2Mc\"]</td></tr><tr><td>ITALIAN</td><td>[\"2Maccabei\",\"2Mac\",\"2Maccabei\"]</td></tr><tr><td>JAPANESE</td><td>[\"マカバイ記2\",\"2Macc | 2Mc\",\"マカバイ記2\",\"2Macc\",\"2Mc\"]</td></tr><tr><td>KOREAN</td><td>[\"마카베오하\",\"2Macc | 2Mc\",\"마카베오하\",\"2Macc\",\"2Mc\"]</td></tr><tr><td>LATIN</td><td>[\"II Maccabæorum | II Maccabaeorum\",\"II Macc\",\"Iimaccabæorum\",\"Iimaccabaeorum\"]</td></tr><tr><td>POLISH</td><td>[\"2Machabejska\",\"2Mch\",\"2Machabejska\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"2 Macabeus\",\"2Macc | 2Mc\",\"2Macabeus\",\"2Macc\",\"2Mc\"]</td></tr><tr><td>ROMANIAN</td><td>[\"2Macabei\",\"2Macc | 2Mc\",\"2Macabei\",\"2Macc\",\"2Mc\"]</td></tr><tr><td>RUSSIAN</td><td>[\"2Маккавейские\",\"2Macc | 2Mc\",\"2Маккавейские\",\"2Macc\",\"2Mc\"]</td></tr><tr><td>SPANISH</td><td>[\"2Macabeos\",\"2Mac\",\"2Macabeos\"]</td></tr><tr><td>TAMIL</td><td>[\"2 மக்கபேயர்\",\"2Macc | 2Mc\",\"2மக்கபேயர்\",\"2Macc\",\"2Mc\"]</td></tr><tr><td>THAI</td><td>[\"2 มัคคาบี | มัคคาบีฉบับที่สอง\",\"2Macc | 2Mc\",\"2มัคคาบี\",\"มัคคาบีฉบับที่สอง\",\"2Macc\",\"2Mc\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"2 Maccabee\",\"2Macc | 2Mc\",\"2Maccabee\",\"2Macc\",\"2Mc\"]</td></tr><tr><td rowspan=\"25\">Book 21</td><td>ENGLISH</td><td>[\"Job\",\"Jb\",\"Job\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Job\",\"Jb\",\"Job\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Jobi\",\"Jb\",\"Jobi\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"ايوب\",\"Jb\",\"ايوب\"]</td></tr><tr><td>CHINESE</td><td>[\"約伯傳\",\"Jb\",\"約伯傳\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Jb\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Jób\",\"Jb\",\"Jób\"]</td></tr><tr><td>FILIPINO</td><td>[\"Job\",\"Job\",\"Job\"]</td></tr><tr><td>FRENCH</td><td>[\"Job\",\"Jb\",\"Job\"]</td></tr><tr><td>GERMAN</td><td>[\"Ijob | Hiob\",\"Jb\",\"Ijob\",\"Hiob\"]</td></tr><tr><td>GREEK</td><td>[\"Ιώβ\",\"Jb\",\"Ιώβ\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Jób\",\"Jb\",\"Jób\"]</td></tr><tr><td>ITALIAN</td><td>[\"Giobbe\",\"Gb\",\"Giobbe\"]</td></tr><tr><td>JAPANESE</td><td>[\"ヨブ記\",\"Jb\",\"ヨブ記\"]</td></tr><tr><td>KOREAN</td><td>[\"욥기\",\"욥\",\"욥기\"]</td></tr><tr><td>LATIN</td><td>[\"Iob | Job\",\"Iob\",\"Iob\",\"Job\"]</td></tr><tr><td>POLISH</td><td>[\"Hioba\",\"Hi\",\"Hioba\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Job\",\"Jb\",\"Job\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Iov\",\"Jb\",\"Iov\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Иов | Иова\",\"Иов\",\"Иов\",\"Иова\"]</td></tr><tr><td>SPANISH</td><td>[\"Job\",\"Jb\",\"Job\"]</td></tr><tr><td>TAMIL</td><td>[\"யோபு\",\"Jb\",\"யோபு\"]</td></tr><tr><td>THAI</td><td>[\"โยบ\",\"Jb\",\"โยบ\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Gióp\",\"Jb\",\"Gióp\"]</td></tr><tr><td rowspan=\"25\">Book 22</td><td>ENGLISH</td><td>[\"Psalms | Psalm\",\"Ps\",\"Psalms\",\"Psalm\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Psalms | Psalm\",\"Ps\",\"Psalms\",\"Psalm\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Psalmet\",\"Ps\",\"Psalmet\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"مزامير\",\"Ps\",\"مزامير\"]</td></tr><tr><td>CHINESE</td><td>[\"聖詠集\",\"Ps\",\"聖詠集\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Ps\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Žalmy | Žalm\",\"Ps\",\"Žalmy\",\"Žalm\"]</td></tr><tr><td>FILIPINO</td><td>[\"Awit | Mga Awit\",\"Awit\",\"Awit\",\"Mgaawit\"]</td></tr><tr><td>FRENCH</td><td>[\"Psaumes | Psaume\",\"Ps\",\"Psaumes\",\"Psaume\"]</td></tr><tr><td>GERMAN</td><td>[\"Psalter\",\"Ps\",\"Psalter\"]</td></tr><tr><td>GREEK</td><td>[\"Ψαλμοί | Ψαλμός\",\"Ps\",\"Ψαλμοί\",\"Ψαλμός\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Zsoltárok | Zsoltár\",\"Ps\",\"Zsoltárok\",\"Zsoltár\"]</td></tr><tr><td>ITALIAN</td><td>[\"Salmi | Salmo\",\"Sal\",\"Salmi\",\"Salmo\"]</td></tr><tr><td>JAPANESE</td><td>[\"詩篇\",\"Ps\",\"詩篇\"]</td></tr><tr><td>KOREAN</td><td>[\"시편\",\"시\",\"시편\"]</td></tr><tr><td>LATIN</td><td>[\"Psalmorum\",\"Psal\",\"Psalmorum\"]</td></tr><tr><td>POLISH</td><td>[\"Psalmów\",\"Ps\",\"Psalmów\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Salmos | Salmo\",\"Ps\",\"Salmos\",\"Salmo\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Psalmi\",\"Ps\",\"Psalmi\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Псалтирь\",\"Пс | Псал\",\"Псалтирь\",\"Пс\",\"Псал\"]</td></tr><tr><td>SPANISH</td><td>[\"Salmos | Salmo\",\"Sal\",\"Salmos\",\"Salmo\"]</td></tr><tr><td>TAMIL</td><td>[\"திருப்பாடல்கள்\",\"Ps\",\"திருப்பாடல்கள்\"]</td></tr><tr><td>THAI</td><td>[\"สดุดี | เพลงสดุดี\",\"Ps\",\"สดุดี\",\"เพลงสดุดี\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Thánh Vịnh | Thi Thiên\",\"Ps\",\"Thánhvịnh\",\"Thithiên\"]</td></tr><tr><td rowspan=\"25\">Book 23</td><td>ENGLISH</td><td>[\"Proverbs\",\"Prov | Pr\",\"Proverbs\",\"Prov\",\"Pr\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Spreuke | Spreuke van Salomo\",\"Pr\",\"Spreuke\",\"Spreukevansalomo\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Fjalët e urta\",\"Prov | Pr\",\"Fjalëteurta\",\"Prov\",\"Pr\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"امثال\",\"Prov | Pr\",\"امثال\",\"Prov\",\"Pr\"]</td></tr><tr><td>CHINESE</td><td>[\"箴言\",\"Prov | Pr\",\"箴言\",\"Prov\",\"Pr\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Prov | Pr\",\"\",\"Prov\",\"Pr\"]</td></tr><tr><td>CZECH</td><td>[\"Přísloví\",\"Prov | Pr\",\"Přísloví\",\"Prov\",\"Pr\"]</td></tr><tr><td>FILIPINO</td><td>[\"Kawikaan | Mga Kawikaan\",\"Kaw\",\"Kawikaan\",\"Mgakawikaan\"]</td></tr><tr><td>FRENCH</td><td>[\"Proverbes\",\"Prov | Pr\",\"Proverbes\",\"Prov\",\"Pr\"]</td></tr><tr><td>GERMAN</td><td>[\"Sprichwörter | Sprüche\",\"Prov | Pr\",\"Sprichwörter\",\"Sprüche\",\"Prov\",\"Pr\"]</td></tr><tr><td>GREEK</td><td>[\"Παροιμίες\",\"Prov | Pr\",\"Παροιμίες\",\"Prov\",\"Pr\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Példabeszédek\",\"Prov | Pr\",\"Példabeszédek\",\"Prov\",\"Pr\"]</td></tr><tr><td>ITALIAN</td><td>[\"Proverbi\",\"Pr\",\"Proverbi\"]</td></tr><tr><td>JAPANESE</td><td>[\"箴言\",\"Prov | Pr\",\"箴言\",\"Prov\",\"Pr\"]</td></tr><tr><td>KOREAN</td><td>[\"잠언\",\"잠\",\"잠언\"]</td></tr><tr><td>LATIN</td><td>[\"Proverbiorum\",\"Prov\",\"Proverbiorum\"]</td></tr><tr><td>POLISH</td><td>[\"Przysłów\",\"Prz\",\"Przysłów\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Provérbios\",\"Prov | Pr\",\"Provérbios\",\"Prov\",\"Pr\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Proverbe\",\"Prov | Pr\",\"Proverbe\",\"Prov\",\"Pr\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Притчи\",\"Прит\",\"Притчи\"]</td></tr><tr><td>SPANISH</td><td>[\"Proverbios\",\"Pr | Prov\",\"Proverbios\",\"Pr\",\"Prov\"]</td></tr><tr><td>TAMIL</td><td>[\"நீதிமொழிகள்\",\"Prov | Pr\",\"நீதிமொழிகள்\",\"Prov\",\"Pr\"]</td></tr><tr><td>THAI</td><td>[\"สุภาษิต\",\"Prov | Pr\",\"สุภาษิต\",\"Prov\",\"Pr\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Châm Ngôn\",\"Prov | Pr\",\"Châmngôn\",\"Prov\",\"Pr\"]</td></tr><tr><td rowspan=\"25\">Book 24</td><td>ENGLISH</td><td>[\"Ecclesiastes | Qoelet\",\"Eccl | Qo\",\"Ecclesiastes\",\"Qoelet\",\"Eccl\",\"Qo\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Prediker\",\"Ec\",\"Prediker\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Predikuesi\",\"Eccl | Qo\",\"Predikuesi\",\"Eccl\",\"Qo\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"جامعة\",\"Eccl | Qo\",\"جامعة\",\"Eccl\",\"Qo\"]</td></tr><tr><td>CHINESE</td><td>[\"訓道篇\",\"Eccl | Qo\",\"訓道篇\",\"Eccl\",\"Qo\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Eccl | Qo\",\"\",\"Eccl\",\"Qo\"]</td></tr><tr><td>CZECH</td><td>[\"Kazatel\",\"Eccl | Qo\",\"Kazatel\",\"Eccl\",\"Qo\"]</td></tr><tr><td>FILIPINO</td><td>[\"Mangangaral | Ang Mangangaral\",\"Manga\",\"Mangangaral\",\"Angmangangaral\"]</td></tr><tr><td>FRENCH</td><td>[\"Ecclésiaste\",\"Eccl | Qo\",\"Ecclésiaste\",\"Eccl\",\"Qo\"]</td></tr><tr><td>GERMAN</td><td>[\"Ecclesiastes\",\"Eccl | Qo\",\"Ecclesiastes\",\"Eccl\",\"Qo\"]</td></tr><tr><td>GREEK</td><td>[\"Εκκλησιαστής\",\"Eccl | Qo\",\"Εκκλησιαστής\",\"Eccl\",\"Qo\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Prédikátor\",\"Eccl | Qo\",\"Prédikátor\",\"Eccl\",\"Qo\"]</td></tr><tr><td>ITALIAN</td><td>[\"Qoelet | Ecclesiaste\",\"Qo\",\"Qoelet\",\"Ecclesiaste\"]</td></tr><tr><td>JAPANESE</td><td>[\"伝道の書\",\"Eccl | Qo\",\"伝道の書\",\"Eccl\",\"Qo\"]</td></tr><tr><td>KOREAN</td><td>[\"전도서 | 코헬렛\",\"전\",\"전도서\",\"코헬렛\"]</td></tr><tr><td>LATIN</td><td>[\"Ecclesiastes\",\"Eccl\",\"Ecclesiastes\"]</td></tr><tr><td>POLISH</td><td>[\"Koheleta\",\"Koh\",\"Koheleta\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Coelet\",\"Eccl | Qo\",\"Coelet\",\"Eccl\",\"Qo\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Ecclesiast\",\"Eccl | Qo\",\"Ecclesiast\",\"Eccl\",\"Qo\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Екклесиаст | Екклесиаста\",\"Екк\",\"Екклесиаст\",\"Екклесиаста\"]</td></tr><tr><td>SPANISH</td><td>[\"Eclesiastés | Qohélet | Qoélet | Cohélet\",\"Qo | Ec | Ecl\",\"Eclesiastés\",\"Qohélet\",\"Qoélet\",\"Cohélet\",\"Qo\",\"Ec\",\"Ecl\"]</td></tr><tr><td>TAMIL</td><td>[\"சபை உரையாளர்\",\"Eccl | Qo\",\"சபைஉரையாளர்\",\"Eccl\",\"Qo\"]</td></tr><tr><td>THAI</td><td>[\"ปัญญาจารย์\",\"Eccl | Qo\",\"ปัญญาจารย์\",\"Eccl\",\"Qo\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Truyền đạo\",\"Eccl | Qo\",\"Truyềnđạo\",\"Eccl\",\"Qo\"]</td></tr><tr><td rowspan=\"25\">Book 25</td><td>ENGLISH</td><td>[\"Song of Songs | Song | Canticle | Canticle of Canticles | Song of Solomon\",\"Sg\",\"Songofsongs\",\"Song\",\"Canticle\",\"Canticleofcanticles\",\"Songofsolomon\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Hooglied | Hooglied van Salomo\",\"Sn\",\"Hooglied\",\"Hoogliedvansalomo\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Kantiku | Kantiku i Kantikëve\",\"Sg\",\"Kantiku\",\"Kantikuikantikëve\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"نشيدالانشاد\",\"Sg\",\"نشيدالانشاد\"]</td></tr><tr><td>CHINESE</td><td>[\"雅歌\",\"Sg\",\"雅歌\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Sg\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Píseň písní\",\"Sg\",\"Píseňpísní\"]</td></tr><tr><td>FILIPINO</td><td>[\"Awit ni Solomon | Ang Awit ni Solomon\",\"Aw ni S | Awnis\",\"Awitnisolomon\",\"Angawitnisolomon\",\"Awnis\",\"Awnis\"]</td></tr><tr><td>FRENCH</td><td>[\"Cantique | Cantique des Cantiques\",\"Sg\",\"Cantique\",\"Cantiquedescantiques\"]</td></tr><tr><td>GERMAN</td><td>[\"Hoheslied\",\"Sg\",\"Hoheslied\"]</td></tr><tr><td>GREEK</td><td>[\"Άσμα Ασμάτων\",\"Sg\",\"Άσμαασμάτων\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Énekek | Énekek Éneke\",\"Sg\",\"Énekek\",\"Énekekéneke\"]</td></tr><tr><td>ITALIAN</td><td>[\"Cantico | Cantico dei Cantici\",\"Ct\",\"Cantico\",\"Canticodeicantici\"]</td></tr><tr><td>JAPANESE</td><td>[\"雅歌\",\"Sg\",\"雅歌\"]</td></tr><tr><td>KOREAN</td><td>[\"아가\",\"아\",\"아가\"]</td></tr><tr><td>LATIN</td><td>[\"Canticum Canticorum | Canticum\",\"Cant\",\"Canticumcanticorum\",\"Canticum\"]</td></tr><tr><td>POLISH</td><td>[\"Pieśń nad Pieśniami\",\"Pnp\",\"Pieśńnadpieśniami\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Cântico\",\"Sg\",\"Cântico\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Cantarea | Cantarea Cantarilor\",\"Sg\",\"Cantarea\",\"Cantareacantarilor\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Песни Песней | Песнь песней Соломона\",\"Песн\",\"Песнипесней\",\"Песньпеснейсоломона\"]</td></tr><tr><td>SPANISH</td><td>[\"Cantares | Cantar de los Cantares\",\"Cant\",\"Cantares\",\"Cantardeloscantares\"]</td></tr><tr><td>TAMIL</td><td>[\"இனிமைமிகு பாடல்\",\"Sg\",\"இனிமைமிகுபாடல்\"]</td></tr><tr><td>THAI</td><td>[\"เพลงโซโลมอน | เพลงซาโลมอน\",\"Sg\",\"เพลงโซโลมอน\",\"เพลงซาโลมอน\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Diễm Ca | Nhã ca\",\"Sg\",\"Diễmca\",\"Nhãca\"]</td></tr><tr><td rowspan=\"25\">Book 26</td><td>ENGLISH</td><td>[\"Wisdom\",\"Ws | Wis\",\"Wisdom\",\"Ws\",\"Wis\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Wysheid\",\"\",\"Wysheid\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Wisdom\",\"Ws | Wis\",\"Wisdom\",\"Ws\",\"Wis\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"الحكمة\",\"Ws | Wis\",\"الحكمة\",\"Ws\",\"Wis\"]</td></tr><tr><td>CHINESE</td><td>[\"智慧篇\",\"Ws | Wis\",\"智慧篇\",\"Ws\",\"Wis\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Ws | Wis\",\"\",\"Ws\",\"Wis\"]</td></tr><tr><td>CZECH</td><td>[\"Moudrosti\",\"Ws | Wis\",\"Moudrosti\",\"Ws\",\"Wis\"]</td></tr><tr><td>FILIPINO</td><td>[\"Karunungan | Ang Karunungan | Ang Karunungan ni Solomon\",\"Kar\",\"Karunungan\",\"Angkarunungan\",\"Angkarunungannisolomon\"]</td></tr><tr><td>FRENCH</td><td>[\"Sagesse\",\"Ws | Wis\",\"Sagesse\",\"Ws\",\"Wis\"]</td></tr><tr><td>GERMAN</td><td>[\"Weisheit\",\"Ws | Wis\",\"Weisheit\",\"Ws\",\"Wis\"]</td></tr><tr><td>GREEK</td><td>[\"Σοφία\",\"Ws | Wis\",\"Σοφία\",\"Ws\",\"Wis\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Bölcsesség\",\"Ws | Wis\",\"Bölcsesség\",\"Ws\",\"Wis\"]</td></tr><tr><td>ITALIAN</td><td>[\"Sapienza\",\"Sap\",\"Sapienza\"]</td></tr><tr><td>JAPANESE</td><td>[\"知恵の書\",\"Ws | Wis\",\"知恵の書\",\"Ws\",\"Wis\"]</td></tr><tr><td>KOREAN</td><td>[\"지혜서\",\"Ws | Wis\",\"지혜서\",\"Ws\",\"Wis\"]</td></tr><tr><td>LATIN</td><td>[\"Sapientiæ | Sapientiae\",\"Sap\",\"Sapientiæ\",\"Sapientiae\"]</td></tr><tr><td>POLISH</td><td>[\"Mądrości\",\"Mdr\",\"Mądrości\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Sabedoria\",\"Ws | Wis\",\"Sabedoria\",\"Ws\",\"Wis\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Înţelepciunea\",\"Ws | Wis\",\"Înţelepciunea\",\"Ws\",\"Wis\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Премудрость | Премудрость Соломона\",\"Ws | Wis\",\"Премудрость\",\"Премудростьсоломона\",\"Ws\",\"Wis\"]</td></tr><tr><td>SPANISH</td><td>[\"Sabiduría\",\"Sb | Sab\",\"Sabiduría\",\"Sb\",\"Sab\"]</td></tr><tr><td>TAMIL</td><td>[\"சாலமோனின் ஞானம்\",\"Ws | Wis\",\"சாலமோனின்ஞானம்\",\"Ws\",\"Wis\"]</td></tr><tr><td>THAI</td><td>[\"ปรีชาญาณ\",\"Ws | Wis\",\"ปรีชาญาณ\",\"Ws\",\"Wis\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Khôn Ngoan\",\"Ws | Wis\",\"Khônngoan\",\"Ws\",\"Wis\"]</td></tr><tr><td rowspan=\"25\">Book 27</td><td>ENGLISH</td><td>[\"Ecclesiasticus | Sirach\",\"Sir\",\"Ecclesiasticus\",\"Sirach\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Sirag\",\"\",\"Sirag\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Sirach\",\"Sir\",\"Sirach\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"يشوع بن سيراخ\",\"Sir\",\"يشوعبنسيراخ\"]</td></tr><tr><td>CHINESE</td><td>[\"德訓篇\",\"Sir\",\"德訓篇\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Sir\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Sírachovcova\",\"Sir\",\"Sírachovcova\"]</td></tr><tr><td>FILIPINO</td><td>[\"Ecclesiastico\",\"Ecc\",\"Ecclesiastico\"]</td></tr><tr><td>FRENCH</td><td>[\"Siracide\",\"Sir\",\"Siracide\"]</td></tr><tr><td>GERMAN</td><td>[\"Sirach\",\"Sir\",\"Sirach\"]</td></tr><tr><td>GREEK</td><td>[\"Σειράχ\",\"Sir\",\"Σειράχ\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Sirák fia\",\"Sir\",\"Sirákfia\"]</td></tr><tr><td>ITALIAN</td><td>[\"Siracide\",\"Sir\",\"Siracide\"]</td></tr><tr><td>JAPANESE</td><td>[\"シラ書\",\"Sir\",\"シラ書\"]</td></tr><tr><td>KOREAN</td><td>[\"집회서\",\"Sir\",\"집회서\"]</td></tr><tr><td>LATIN</td><td>[\"Ecclesiasticus\",\"Ecc\",\"Ecclesiasticus\"]</td></tr><tr><td>POLISH</td><td>[\"Syracha\",\"Syr\",\"Syracha\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Eclesiástico\",\"Sir\",\"Eclesiástico\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Sirah\",\"Sir\",\"Sirah\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Иисуса | Премудрости Иисуса\",\"Sir\",\"Иисуса\",\"Премудростииисуса\"]</td></tr><tr><td>SPANISH</td><td>[\"Sirácides | Eclesiástico\",\"Si | Sir | Ecli\",\"Sirácides\",\"Eclesiástico\",\"Si\",\"Sir\",\"Ecli\"]</td></tr><tr><td>TAMIL</td><td>[\"சீராக்கின் ஞானம்\",\"Sir\",\"சீராக்கின்ஞானம்\"]</td></tr><tr><td>THAI</td><td>[\"บุตรสิรา\",\"Sir\",\"บุตรสิรา\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Huấn Ca | Truyền Đạo\",\"Sir\",\"Huấnca\",\"Truyềnđạo\"]</td></tr><tr><td rowspan=\"25\">Book 28</td><td>ENGLISH</td><td>[\"Isaiah\",\"Is\",\"Isaiah\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Jesaja\",\"Is\",\"Jesaja\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Isaia\",\"Is\",\"Isaia\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"اشعياء\",\"Is\",\"اشعياء\"]</td></tr><tr><td>CHINESE</td><td>[\"依撒意亞\",\"Is\",\"依撒意亞\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Is\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Izajáš\",\"Is\",\"Izajáš\"]</td></tr><tr><td>FILIPINO</td><td>[\"Isaias\",\"Isa\",\"Isaias\"]</td></tr><tr><td>FRENCH</td><td>[\"Isaïe\",\"Is\",\"Isaïe\"]</td></tr><tr><td>GERMAN</td><td>[\"Jesaja\",\"Is\",\"Jesaja\"]</td></tr><tr><td>GREEK</td><td>[\"Ησαΐας\",\"Is\",\"Ησαΐας\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Ézsaiás\",\"Is\",\"Ézsaiás\"]</td></tr><tr><td>ITALIAN</td><td>[\"Isaia\",\"Is\",\"Isaia\"]</td></tr><tr><td>JAPANESE</td><td>[\"イザヤ書\",\"Is\",\"イザヤ書\"]</td></tr><tr><td>KOREAN</td><td>[\"이사야\",\"사\",\"이사야\"]</td></tr><tr><td>LATIN</td><td>[\"Isaiæ | Isaiae\",\"Is\",\"Isaiæ\",\"Isaiae\"]</td></tr><tr><td>POLISH</td><td>[\"Izajasza\",\"Iz\",\"Izajasza\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Isaías\",\"Is\",\"Isaías\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Isaia\",\"Is\",\"Isaia\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Исаия\",\"Ис | Исаи\",\"Исаия\",\"Ис\",\"Исаи\"]</td></tr><tr><td>SPANISH</td><td>[\"Isaías\",\"Is\",\"Isaías\"]</td></tr><tr><td>TAMIL</td><td>[\"எசாயா\",\"Is\",\"எசாயா\"]</td></tr><tr><td>THAI</td><td>[\"อิสยาห์\",\"Is\",\"อิสยาห์\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Isaia | Yeshvahu\",\"Is\",\"Isaia\",\"Yeshvahu\"]</td></tr><tr><td rowspan=\"25\">Book 29</td><td>ENGLISH</td><td>[\"Jeremiah\",\"Jer\",\"Jeremiah\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Jeremia\",\"Jr\",\"Jeremia\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Jeremia\",\"Jer\",\"Jeremia\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"ارميا\",\"Jer\",\"ارميا\"]</td></tr><tr><td>CHINESE</td><td>[\"耶肋米亞\",\"Jer\",\"耶肋米亞\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Jer\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Jeremjáš\",\"Jer\",\"Jeremjáš\"]</td></tr><tr><td>FILIPINO</td><td>[\"Jeremias\",\"Jer\",\"Jeremias\"]</td></tr><tr><td>FRENCH</td><td>[\"Jérémie\",\"Jer\",\"Jérémie\"]</td></tr><tr><td>GERMAN</td><td>[\"Jeremia\",\"Jer\",\"Jeremia\"]</td></tr><tr><td>GREEK</td><td>[\"Ιερεμίας\",\"Jer\",\"Ιερεμίας\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Jeremiás\",\"Jer\",\"Jeremiás\"]</td></tr><tr><td>ITALIAN</td><td>[\"Geremia\",\"Ger\",\"Geremia\"]</td></tr><tr><td>JAPANESE</td><td>[\"エレミヤ書\",\"Jer\",\"エレミヤ書\"]</td></tr><tr><td>KOREAN</td><td>[\"예레미야\",\"렘\",\"예레미야\"]</td></tr><tr><td>LATIN</td><td>[\"Ieremiæ | Ieremiae | Jeremiæ | Jeremiae\",\"Ier\",\"Ieremiæ\",\"Ieremiae\",\"Jeremiæ\",\"Jeremiae\"]</td></tr><tr><td>POLISH</td><td>[\"Jeremiasza\",\"Jr\",\"Jeremiasza\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Jeremias\",\"Jer\",\"Jeremias\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Ieremia\",\"Jer\",\"Ieremia\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Иеремия\",\"Иер\",\"Иеремия\"]</td></tr><tr><td>SPANISH</td><td>[\"Jeremías\",\"Jr | Jer\",\"Jeremías\",\"Jr\",\"Jer\"]</td></tr><tr><td>TAMIL</td><td>[\"எரேமியா\",\"Jer\",\"எரேமியா\"]</td></tr><tr><td>THAI</td><td>[\"เยเรมีย์\",\"Jer\",\"เยเรมีย์\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Giêrêmia | Yirmiyahu\",\"Jer\",\"Giêrêmia\",\"Yirmiyahu\"]</td></tr><tr><td rowspan=\"25\">Book 30</td><td>ENGLISH</td><td>[\"Lamentations\",\"Lam\",\"Lamentations\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Klaagliedere | Klaagliedere van Jeremia\",\"Lm\",\"Klaagliedere\",\"Klaagliederevanjeremia\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Vajtimet\",\"Lam\",\"Vajtimet\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"مراثي\",\"Lam\",\"مراثي\"]</td></tr><tr><td>CHINESE</td><td>[\"耶肋米亞哀歌\",\"Lam\",\"耶肋米亞哀歌\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Lam\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Pláč\",\"Lam\",\"Pláč\"]</td></tr><tr><td>FILIPINO</td><td>[\"Panaghoy | Mga Panaghoy\",\"Panag\",\"Panaghoy\",\"Mgapanaghoy\"]</td></tr><tr><td>FRENCH</td><td>[\"Lamentations\",\"Lam\",\"Lamentations\"]</td></tr><tr><td>GERMAN</td><td>[\"Klagelieder\",\"Lam\",\"Klagelieder\"]</td></tr><tr><td>GREEK</td><td>[\"Θρήνοι\",\"Lam\",\"Θρήνοι\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Jeremiás sír\",\"Lam\",\"Jeremiássír\"]</td></tr><tr><td>ITALIAN</td><td>[\"Lamentazioni\",\"Lam\",\"Lamentazioni\"]</td></tr><tr><td>JAPANESE</td><td>[\"哀歌\",\"Lam\",\"哀歌\"]</td></tr><tr><td>KOREAN</td><td>[\"예레미야애가 | 애가\",\"애\",\"예레미야애가\",\"애가\"]</td></tr><tr><td>LATIN</td><td>[\"Lamentationes\",\"Lam\",\"Lamentationes\"]</td></tr><tr><td>POLISH</td><td>[\"Lamentacje\",\"Lm\",\"Lamentacje\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Lamentações\",\"Lam\",\"Lamentações\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Plângeri\",\"Lam\",\"Plângeri\"]</td></tr><tr><td>RUSSIAN</td><td>[\"ПлачИеремии\",\"Плач\",\"Плачиеремии\"]</td></tr><tr><td>SPANISH</td><td>[\"Lamentaciones\",\"Lam\",\"Lamentaciones\"]</td></tr><tr><td>TAMIL</td><td>[\"புலம்பல்\",\"Lam\",\"புலம்பல்\"]</td></tr><tr><td>THAI</td><td>[\"เพลงคร่ำครวญ\",\"Lam\",\"เพลงคร่ำครวญ\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Ai Ca | Ca Thương\",\"Lam\",\"Aica\",\"Cathương\"]</td></tr><tr><td rowspan=\"25\">Book 31</td><td>ENGLISH</td><td>[\"Baruch\",\"Bar\",\"Baruch\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Baruch\",\"\",\"Baruch\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Baruku\",\"Bar\",\"Baruku\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"باروك\",\"Bar\",\"باروك\"]</td></tr><tr><td>CHINESE</td><td>[\"巴路克\",\"Bar\",\"巴路克\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Bar\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Báruch\",\"Bar\",\"Báruch\"]</td></tr><tr><td>FILIPINO</td><td>[\"Baruc\",\"Bar\",\"Baruc\"]</td></tr><tr><td>FRENCH</td><td>[\"Baruch\",\"Bar\",\"Baruch\"]</td></tr><tr><td>GERMAN</td><td>[\"Baruch\",\"Bar\",\"Baruch\"]</td></tr><tr><td>GREEK</td><td>[\"Βαρούχ\",\"Bar\",\"Βαρούχ\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Báruk\",\"Bar\",\"Báruk\"]</td></tr><tr><td>ITALIAN</td><td>[\"Baruc\",\"Bar\",\"Baruc\"]</td></tr><tr><td>JAPANESE</td><td>[\"バルク書\",\"Bar\",\"バルク書\"]</td></tr><tr><td>KOREAN</td><td>[\"바룩\",\"Bar\",\"바룩\"]</td></tr><tr><td>LATIN</td><td>[\"Baruch\",\"Bar\",\"Baruch\"]</td></tr><tr><td>POLISH</td><td>[\"Barucha\",\"Ba\",\"Barucha\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Baruc\",\"Bar\",\"Baruc\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Baruh\",\"Bar\",\"Baruh\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Варуха\",\"Bar\",\"Варуха\"]</td></tr><tr><td>SPANISH</td><td>[\"Baruc\",\"Ba | Bar\",\"Baruc\",\"Ba\",\"Bar\"]</td></tr><tr><td>TAMIL</td><td>[\"பாரூக்கு\",\"Bar\",\"பாரூக்கு\"]</td></tr><tr><td>THAI</td><td>[\"บารุค\",\"Bar\",\"บารุค\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Baruch\",\"Bar\",\"Baruch\"]</td></tr><tr><td rowspan=\"25\">Book 32</td><td>ENGLISH</td><td>[\"Ezekiel\",\"Ez\",\"Ezekiel\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Eségiël\",\"Ek\",\"Eségiël\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Ezekieli\",\"Ez\",\"Ezekieli\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"حزقيال\",\"Ez\",\"حزقيال\"]</td></tr><tr><td>CHINESE</td><td>[\"厄則克爾\",\"Ez\",\"厄則克爾\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Ez\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Ezechiel\",\"Ez\",\"Ezechiel\"]</td></tr><tr><td>FILIPINO</td><td>[\"Ezekiel\",\"Eze\",\"Ezekiel\"]</td></tr><tr><td>FRENCH</td><td>[\"Ézéchiel\",\"Ez\",\"Ézéchiel\"]</td></tr><tr><td>GERMAN</td><td>[\"Ezechiel | Hesekiel\",\"Ez\",\"Ezechiel\",\"Hesekiel\"]</td></tr><tr><td>GREEK</td><td>[\"Ιεζεκιήλ\",\"Ez\",\"Ιεζεκιήλ\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Ezékiel\",\"Ez\",\"Ezékiel\"]</td></tr><tr><td>ITALIAN</td><td>[\"Ezechiele\",\"Ez\",\"Ezechiele\"]</td></tr><tr><td>JAPANESE</td><td>[\"エゼキエル書\",\"Ez\",\"エゼキエル書\"]</td></tr><tr><td>KOREAN</td><td>[\"에스겔 | 에제키엘\",\"겔\",\"에스겔\",\"에제키엘\"]</td></tr><tr><td>LATIN</td><td>[\"Ezechielis\",\"Ez\",\"Ezechielis\"]</td></tr><tr><td>POLISH</td><td>[\"Ezechiela\",\"Ez\",\"Ezechiela\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Ezequiel\",\"Ez\",\"Ezequiel\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Ezechiel\",\"Ez\",\"Ezechiel\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Иезекииль\",\"Иез\",\"Иезекииль\"]</td></tr><tr><td>SPANISH</td><td>[\"Ezequiel\",\"Ez\",\"Ezequiel\"]</td></tr><tr><td>TAMIL</td><td>[\"எசேக்கியேல்\",\"Ez\",\"எசேக்கியேல்\"]</td></tr><tr><td>THAI</td><td>[\"เอเสเคียล\",\"Ez\",\"เอเสเคียล\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Êdêkien | Êxêkiên\",\"Ez\",\"Êdêkien\",\"Êxêkiên\"]</td></tr><tr><td rowspan=\"25\">Book 33</td><td>ENGLISH</td><td>[\"Daniel\",\"Dan | Dn\",\"Daniel\",\"Dan\",\"Dn\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Daniël\",\"Dn\",\"Daniël\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Danieli\",\"Dan | Dn\",\"Danieli\",\"Dan\",\"Dn\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"دانيال\",\"Dan | Dn\",\"دانيال\",\"Dan\",\"Dn\"]</td></tr><tr><td>CHINESE</td><td>[\"達尼爾\",\"Dan | Dn\",\"達尼爾\",\"Dan\",\"Dn\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Dan | Dn\",\"\",\"Dan\",\"Dn\"]</td></tr><tr><td>CZECH</td><td>[\"Daniel\",\"Dan | Dn\",\"Daniel\",\"Dan\",\"Dn\"]</td></tr><tr><td>FILIPINO</td><td>[\"Daniel\",\"Dan | Dn\",\"Daniel\",\"Dan\",\"Dn\"]</td></tr><tr><td>FRENCH</td><td>[\"Daniel\",\"Dan | Dn\",\"Daniel\",\"Dan\",\"Dn\"]</td></tr><tr><td>GERMAN</td><td>[\"Daniel\",\"Dan | Dn\",\"Daniel\",\"Dan\",\"Dn\"]</td></tr><tr><td>GREEK</td><td>[\"Δανιήλ\",\"Dan | Dn\",\"Δανιήλ\",\"Dan\",\"Dn\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Dániel\",\"Dan | Dn\",\"Dániel\",\"Dan\",\"Dn\"]</td></tr><tr><td>ITALIAN</td><td>[\"Daniele\",\"Dn\",\"Daniele\"]</td></tr><tr><td>JAPANESE</td><td>[\"ダニエル書\",\"Dan | Dn\",\"ダニエル書\",\"Dan\",\"Dn\"]</td></tr><tr><td>KOREAN</td><td>[\"다니엘\",\"단\",\"다니엘\"]</td></tr><tr><td>LATIN</td><td>[\"Danielis\",\"Dan\",\"Danielis\"]</td></tr><tr><td>POLISH</td><td>[\"Daniela\",\"Dn\",\"Daniela\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Daniel\",\"Dan | Dn\",\"Daniel\",\"Dan\",\"Dn\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Daniel\",\"Dan | Dn\",\"Daniel\",\"Dan\",\"Dn\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Даниил\",\"Дан\",\"Даниил\"]</td></tr><tr><td>SPANISH</td><td>[\"Daniel\",\"Dn | Dan\",\"Daniel\",\"Dn\",\"Dan\"]</td></tr><tr><td>TAMIL</td><td>[\"தானியேல்\",\"Dan | Dn\",\"தானியேல்\",\"Dan\",\"Dn\"]</td></tr><tr><td>THAI</td><td>[\"ดาเนียล\",\"Dan | Dn\",\"ดาเนียล\",\"Dan\",\"Dn\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Daniel\",\"Dan | Dn\",\"Daniel\",\"Dan\",\"Dn\"]</td></tr><tr><td rowspan=\"25\">Book 34</td><td>ENGLISH</td><td>[\"Hosea\",\"Hos\",\"Hosea\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Hoséa\",\"Hs\",\"Hoséa\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Osea\",\"Hos\",\"Osea\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"هوشع\",\"Hos\",\"هوشع\"]</td></tr><tr><td>CHINESE</td><td>[\"甌瑟亞\",\"Hos\",\"甌瑟亞\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Hos\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Ozeáš\",\"Hos\",\"Ozeáš\"]</td></tr><tr><td>FILIPINO</td><td>[\"Hosea\",\"Hos\",\"Hosea\"]</td></tr><tr><td>FRENCH</td><td>[\"Osée\",\"Hos\",\"Osée\"]</td></tr><tr><td>GERMAN</td><td>[\"Hosea\",\"Hos\",\"Hosea\"]</td></tr><tr><td>GREEK</td><td>[\"Ωσηέ\",\"Hos\",\"Ωσηέ\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Hóseás\",\"Hos\",\"Hóseás\"]</td></tr><tr><td>ITALIAN</td><td>[\"Osea\",\"Os\",\"Osea\"]</td></tr><tr><td>JAPANESE</td><td>[\"ホセア書\",\"Hos\",\"ホセア書\"]</td></tr><tr><td>KOREAN</td><td>[\"호세아\",\"호\",\"호세아\"]</td></tr><tr><td>LATIN</td><td>[\"Osee\",\"Os\",\"Osee\"]</td></tr><tr><td>POLISH</td><td>[\"Ozeasza\",\"Oz\",\"Ozeasza\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Oseias\",\"Hos\",\"Oseias\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Osea\",\"Hos\",\"Osea\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Осия\",\"Ос\",\"Осия\"]</td></tr><tr><td>SPANISH</td><td>[\"Oseas\",\"Os\",\"Oseas\"]</td></tr><tr><td>TAMIL</td><td>[\"ஓசேயா\",\"Hos\",\"ஓசேயா\"]</td></tr><tr><td>THAI</td><td>[\"โฮเชยา\",\"Hos\",\"โฮเชยา\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Hosea | Hoshea\",\"Hos\",\"Hosea\",\"Hoshea\"]</td></tr><tr><td rowspan=\"25\">Book 35</td><td>ENGLISH</td><td>[\"Joel\",\"Jl\",\"Joel\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Joël\",\"Jl\",\"Joël\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Joeli\",\"Jl\",\"Joeli\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"يوئيل\",\"Jl\",\"يوئيل\"]</td></tr><tr><td>CHINESE</td><td>[\"岳厄爾\",\"Jl\",\"岳厄爾\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Jl\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Jóel\",\"Jl\",\"Jóel\"]</td></tr><tr><td>FILIPINO</td><td>[\"Joel\",\"Joel\",\"Joel\"]</td></tr><tr><td>FRENCH</td><td>[\"Joël\",\"Jl\",\"Joël\"]</td></tr><tr><td>GERMAN</td><td>[\"Joel\",\"Jl\",\"Joel\"]</td></tr><tr><td>GREEK</td><td>[\"Ιωήλ\",\"Jl\",\"Ιωήλ\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Jóel\",\"Jl\",\"Jóel\"]</td></tr><tr><td>ITALIAN</td><td>[\"Gioele\",\"Gl\",\"Gioele\"]</td></tr><tr><td>JAPANESE</td><td>[\"ヨエル書\",\"Jl\",\"ヨエル書\"]</td></tr><tr><td>KOREAN</td><td>[\"요엘\",\"욜\",\"요엘\"]</td></tr><tr><td>LATIN</td><td>[\"Ioel\",\"Ioel\",\"Ioel\"]</td></tr><tr><td>POLISH</td><td>[\"Joela\",\"Jl\",\"Joela\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Joel\",\"Jl\",\"Joel\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Ioel\",\"Jl\",\"Ioel\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Иоиль\",\"Иоил\",\"Иоиль\"]</td></tr><tr><td>SPANISH</td><td>[\"Joel\",\"Jl\",\"Joel\"]</td></tr><tr><td>TAMIL</td><td>[\"யோவேல்\",\"Jl\",\"யோவேல்\"]</td></tr><tr><td>THAI</td><td>[\"โยเอล\",\"Jl\",\"โยเอล\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Joel | Giôên\",\"Jl\",\"Joel\",\"Giôên\"]</td></tr><tr><td rowspan=\"25\">Book 36</td><td>ENGLISH</td><td>[\"Amos\",\"Am\",\"Amos\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Amos\",\"Am\",\"Amos\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Amosi\",\"Am\",\"Amosi\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"عاموس\",\"Am\",\"عاموس\"]</td></tr><tr><td>CHINESE</td><td>[\"亞毛斯\",\"Am\",\"亞毛斯\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Am\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Ámos\",\"Am\",\"Ámos\"]</td></tr><tr><td>FILIPINO</td><td>[\"Amos\",\"Amos\",\"Amos\"]</td></tr><tr><td>FRENCH</td><td>[\"Amos\",\"Am\",\"Amos\"]</td></tr><tr><td>GERMAN</td><td>[\"Amos\",\"Am\",\"Amos\"]</td></tr><tr><td>GREEK</td><td>[\"Αμώς\",\"Am\",\"Αμώς\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Ámos\",\"Am\",\"Ámos\"]</td></tr><tr><td>ITALIAN</td><td>[\"Amos\",\"Am\",\"Amos\"]</td></tr><tr><td>JAPANESE</td><td>[\"アモス書\",\"Am\",\"アモス書\"]</td></tr><tr><td>KOREAN</td><td>[\"아모스\",\"암\",\"아모스\"]</td></tr><tr><td>LATIN</td><td>[\"Amos\",\"Am\",\"Amos\"]</td></tr><tr><td>POLISH</td><td>[\"Amosa\",\"Am\",\"Amosa\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Amós\",\"Am\",\"Amós\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Amos\",\"Am\",\"Amos\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Амос\",\"Амос\",\"Амос\"]</td></tr><tr><td>SPANISH</td><td>[\"Amós\",\"Am\",\"Amós\"]</td></tr><tr><td>TAMIL</td><td>[\"ஆமோஸ்\",\"Am\",\"ஆமோஸ்\"]</td></tr><tr><td>THAI</td><td>[\"อาโมส\",\"Am\",\"อาโมส\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Amos\",\"Am\",\"Amos\"]</td></tr><tr><td rowspan=\"25\">Book 37</td><td>ENGLISH</td><td>[\"Obadiah\",\"Ob\",\"Obadiah\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Obádja\",\"Ob\",\"Obádja\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Abdia\",\"Ob\",\"Abdia\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"عوبديا\",\"Ob\",\"عوبديا\"]</td></tr><tr><td>CHINESE</td><td>[\"亞北底亞\",\"Ob\",\"亞北底亞\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Ob\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Abdijáš\",\"Ob\",\"Abdijáš\"]</td></tr><tr><td>FILIPINO</td><td>[\"Obadias\",\"Oba\",\"Obadias\"]</td></tr><tr><td>FRENCH</td><td>[\"Abdias\",\"Ob\",\"Abdias\"]</td></tr><tr><td>GERMAN</td><td>[\"Obadja\",\"Ob\",\"Obadja\"]</td></tr><tr><td>GREEK</td><td>[\"Αβδιού\",\"Ob\",\"Αβδιού\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Abdiás\",\"Ob\",\"Abdiás\"]</td></tr><tr><td>ITALIAN</td><td>[\"Abdia\",\"Abd\",\"Abdia\"]</td></tr><tr><td>JAPANESE</td><td>[\"オバデヤ書\",\"Ob\",\"オバデヤ書\"]</td></tr><tr><td>KOREAN</td><td>[\"오바댜\",\"옵\",\"오바댜\"]</td></tr><tr><td>LATIN</td><td>[\"Abdiæ | Abdiae | Abdia\",\"Abd\",\"Abdiæ\",\"Abdiae\",\"Abdia\"]</td></tr><tr><td>POLISH</td><td>[\"Abdiasza\",\"Ab\",\"Abdiasza\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Abdias\",\"Ob\",\"Abdias\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Obadia\",\"Ob\",\"Obadia\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Авдия\",\"Авд\",\"Авдия\"]</td></tr><tr><td>SPANISH</td><td>[\"Abdías\",\"Abd\",\"Abdías\"]</td></tr><tr><td>TAMIL</td><td>[\"ஒபதியா\",\"Ob\",\"ஒபதியா\"]</td></tr><tr><td>THAI</td><td>[\"โอบาดีห์\",\"Ob\",\"โอบาดีห์\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Obadiah | Ovadyah\",\"Ob\",\"Obadiah\",\"Ovadyah\"]</td></tr><tr><td rowspan=\"25\">Book 38</td><td>ENGLISH</td><td>[\"Jonah\",\"Jon\",\"Jonah\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Jona\",\"Jon\",\"Jona\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Jona\",\"Jon\",\"Jona\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"يونان\",\"Jon\",\"يونان\"]</td></tr><tr><td>CHINESE</td><td>[\"約納\",\"Jon\",\"約納\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Jon\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Jonáš\",\"Jon\",\"Jonáš\"]</td></tr><tr><td>FILIPINO</td><td>[\"Jonas\",\"Jon\",\"Jonas\"]</td></tr><tr><td>FRENCH</td><td>[\"Jonas\",\"Jon\",\"Jonas\"]</td></tr><tr><td>GERMAN</td><td>[\"Jona\",\"Jon\",\"Jona\"]</td></tr><tr><td>GREEK</td><td>[\"Ιωνάς\",\"Jon\",\"Ιωνάς\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Jónás\",\"Jon\",\"Jónás\"]</td></tr><tr><td>ITALIAN</td><td>[\"Giona\",\"Gna\",\"Giona\"]</td></tr><tr><td>JAPANESE</td><td>[\"ヨナ書\",\"Jon\",\"ヨナ書\"]</td></tr><tr><td>KOREAN</td><td>[\"요나\",\"욘\",\"요나\"]</td></tr><tr><td>LATIN</td><td>[\"Ionæ | Ionae | Jonæ | Jonae | Iona | Jona\",\"Ion\",\"Ionæ\",\"Ionae\",\"Jonæ\",\"Jonae\",\"Iona\",\"Jona\"]</td></tr><tr><td>POLISH</td><td>[\"Jonasza\",\"Jon\",\"Jonasza\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Jonas\",\"Jon\",\"Jonas\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Iona\",\"Jon\",\"Iona\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Иона\",\"Иона\",\"Иона\"]</td></tr><tr><td>SPANISH</td><td>[\"Jonás\",\"Jon\",\"Jonás\"]</td></tr><tr><td>TAMIL</td><td>[\"யோனா\",\"Jon\",\"யோனா\"]</td></tr><tr><td>THAI</td><td>[\"โยนาห์\",\"Jon\",\"โยนาห์\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Jonah | Yonah\",\"Jon\",\"Jonah\",\"Yonah\"]</td></tr><tr><td rowspan=\"25\">Book 39</td><td>ENGLISH</td><td>[\"Micah\",\"Mi | Mic\",\"Micah\",\"Mi\",\"Mic\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Miga\",\"Mi\",\"Miga\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Mikea\",\"Mi | Mic\",\"Mikea\",\"Mi\",\"Mic\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"ميخا\",\"Mi | Mic\",\"ميخا\",\"Mi\",\"Mic\"]</td></tr><tr><td>CHINESE</td><td>[\"米該亞\",\"Mi | Mic\",\"米該亞\",\"Mi\",\"Mic\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Mi | Mic\",\"\",\"Mi\",\"Mic\"]</td></tr><tr><td>CZECH</td><td>[\"Micheáš\",\"Mi | Mic\",\"Micheáš\",\"Mi\",\"Mic\"]</td></tr><tr><td>FILIPINO</td><td>[\"Mikas\",\"Mik\",\"Mikas\"]</td></tr><tr><td>FRENCH</td><td>[\"Michée\",\"Mi | Mic\",\"Michée\",\"Mi\",\"Mic\"]</td></tr><tr><td>GERMAN</td><td>[\"Micha\",\"Mi | Mic\",\"Micha\",\"Mi\",\"Mic\"]</td></tr><tr><td>GREEK</td><td>[\"Μιχαίας\",\"Mi | Mic\",\"Μιχαίας\",\"Mi\",\"Mic\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Mikeás\",\"Mi | Mic\",\"Mikeás\",\"Mi\",\"Mic\"]</td></tr><tr><td>ITALIAN</td><td>[\"Michea\",\"Mi\",\"Michea\"]</td></tr><tr><td>JAPANESE</td><td>[\"ミカ書\",\"Mi | Mic\",\"ミカ書\",\"Mi\",\"Mic\"]</td></tr><tr><td>KOREAN</td><td>[\"미가 | 미카\",\"미\",\"미가\",\"미카\"]</td></tr><tr><td>LATIN</td><td>[\"Michææ | Michaeae\",\"Mich\",\"Michææ\",\"Michaeae\"]</td></tr><tr><td>POLISH</td><td>[\"Micheasza\",\"Mi\",\"Micheasza\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Miqueias\",\"Mi | Mic\",\"Miqueias\",\"Mi\",\"Mic\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Mica\",\"Mi | Mic\",\"Mica\",\"Mi\",\"Mic\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Михей\",\"Мих\",\"Михей\"]</td></tr><tr><td>SPANISH</td><td>[\"Miqueas\",\"Mi | Miq\",\"Miqueas\",\"Mi\",\"Miq\"]</td></tr><tr><td>TAMIL</td><td>[\"மீக்கா\",\"Mi | Mic\",\"மீக்கா\",\"Mi\",\"Mic\"]</td></tr><tr><td>THAI</td><td>[\"มีคาห์\",\"Mi | Mic\",\"มีคาห์\",\"Mi\",\"Mic\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Micah | Mikhah\",\"Mi | Mic\",\"Micah\",\"Mikhah\",\"Mi\",\"Mic\"]</td></tr><tr><td rowspan=\"25\">Book 40</td><td>ENGLISH</td><td>[\"Nahum\",\"Na | Nah\",\"Nahum\",\"Na\",\"Nah\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Nahum\",\"Na\",\"Nahum\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Nahumi\",\"Na | Nah\",\"Nahumi\",\"Na\",\"Nah\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"ناحوم\",\"Na | Nah\",\"ناحوم\",\"Na\",\"Nah\"]</td></tr><tr><td>CHINESE</td><td>[\"納鴻\",\"Na | Nah\",\"納鴻\",\"Na\",\"Nah\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Na | Nah\",\"\",\"Na\",\"Nah\"]</td></tr><tr><td>CZECH</td><td>[\"Nahum\",\"Na | Nah\",\"Nahum\",\"Na\",\"Nah\"]</td></tr><tr><td>FILIPINO</td><td>[\"Nahum\",\"Nah\",\"Nahum\"]</td></tr><tr><td>FRENCH</td><td>[\"Nahoum\",\"Na | Nah\",\"Nahoum\",\"Na\",\"Nah\"]</td></tr><tr><td>GERMAN</td><td>[\"Nahum\",\"Na | Nah\",\"Nahum\",\"Na\",\"Nah\"]</td></tr><tr><td>GREEK</td><td>[\"Ναούμ\",\"Na | Nah\",\"Ναούμ\",\"Na\",\"Nah\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Náhum\",\"Na | Nah\",\"Náhum\",\"Na\",\"Nah\"]</td></tr><tr><td>ITALIAN</td><td>[\"Naum\",\"Na\",\"Naum\"]</td></tr><tr><td>JAPANESE</td><td>[\"ナホム書\",\"Na | Nah\",\"ナホム書\",\"Na\",\"Nah\"]</td></tr><tr><td>KOREAN</td><td>[\"나훔\",\"나\",\"나훔\"]</td></tr><tr><td>LATIN</td><td>[\"Nahum\",\"Nah\",\"Nahum\"]</td></tr><tr><td>POLISH</td><td>[\"Nahuma\",\"Na\",\"Nahuma\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Naum\",\"Na | Nah\",\"Naum\",\"Na\",\"Nah\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Naum\",\"Na | Nah\",\"Naum\",\"Na\",\"Nah\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Наум\",\"Наум\",\"Наум\"]</td></tr><tr><td>SPANISH</td><td>[\"Nahúm\",\"Na | Nah\",\"Nahúm\",\"Na\",\"Nah\"]</td></tr><tr><td>TAMIL</td><td>[\"நாகூம்\",\"Na | Nah\",\"நாகூம்\",\"Na\",\"Nah\"]</td></tr><tr><td>THAI</td><td>[\"นาฮูม\",\"Na | Nah\",\"นาฮูม\",\"Na\",\"Nah\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Nahum | Nachum\",\"Na | Nah\",\"Nahum\",\"Nachum\",\"Na\",\"Nah\"]</td></tr><tr><td rowspan=\"25\">Book 41</td><td>ENGLISH</td><td>[\"Habakkuk\",\"Hab\",\"Habakkuk\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Hábakuk\",\"Hk\",\"Hábakuk\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Habakuku\",\"Hab\",\"Habakuku\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"حبقوق\",\"Hab\",\"حبقوق\"]</td></tr><tr><td>CHINESE</td><td>[\"哈巴谷\",\"Hab\",\"哈巴谷\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Hab\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Abakuk\",\"Hab\",\"Abakuk\"]</td></tr><tr><td>FILIPINO</td><td>[\"Habakuk\",\"Hab\",\"Habakuk\"]</td></tr><tr><td>FRENCH</td><td>[\"Habaquq\",\"Hab\",\"Habaquq\"]</td></tr><tr><td>GERMAN</td><td>[\"Habakuk\",\"Hab\",\"Habakuk\"]</td></tr><tr><td>GREEK</td><td>[\"Αββακούμ\",\"Hab\",\"Αββακούμ\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Habakuk\",\"Hab\",\"Habakuk\"]</td></tr><tr><td>ITALIAN</td><td>[\"Abacuc\",\"Ab\",\"Abacuc\"]</td></tr><tr><td>JAPANESE</td><td>[\"ハバクク書\",\"Hab\",\"ハバクク書\"]</td></tr><tr><td>KOREAN</td><td>[\"하박국 | 하바쿡\",\"합\",\"하박국\",\"하바쿡\"]</td></tr><tr><td>LATIN</td><td>[\"Habacuc\",\"Hab\",\"Habacuc\"]</td></tr><tr><td>POLISH</td><td>[\"Habakuka\",\"Ha\",\"Habakuka\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Habacuc\",\"Hab\",\"Habacuc\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Habacuc\",\"Hab\",\"Habacuc\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Аввакум\",\"Авв\",\"Аввакум\"]</td></tr><tr><td>SPANISH</td><td>[\"Habacuc\",\"Ha | Hab\",\"Habacuc\",\"Ha\",\"Hab\"]</td></tr><tr><td>TAMIL</td><td>[\"அபக்கூக்கு\",\"Hab\",\"அபக்கூக்கு\"]</td></tr><tr><td>THAI</td><td>[\"ฮาบากุก\",\"Hab\",\"ฮาบากุก\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Habakkuk | Habaquq\",\"Hab\",\"Habakkuk\",\"Habaquq\"]</td></tr><tr><td rowspan=\"25\">Book 42</td><td>ENGLISH</td><td>[\"Zephaniah\",\"Zeph\",\"Zephaniah\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Sefánja\",\"Zp\",\"Sefánja\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Sofonia\",\"Zeph\",\"Sofonia\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"صفنيا\",\"Zeph\",\"صفنيا\"]</td></tr><tr><td>CHINESE</td><td>[\"索福尼亞\",\"Zeph\",\"索福尼亞\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Zeph\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Sofonjáš\",\"Zeph\",\"Sofonjáš\"]</td></tr><tr><td>FILIPINO</td><td>[\"Zefanias\",\"Zef\",\"Zefanias\"]</td></tr><tr><td>FRENCH</td><td>[\"Sophonie\",\"Zeph\",\"Sophonie\"]</td></tr><tr><td>GERMAN</td><td>[\"Zefanja\",\"Zeph\",\"Zefanja\"]</td></tr><tr><td>GREEK</td><td>[\"Σοφονίας\",\"Zeph\",\"Σοφονίας\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Sofoniás\",\"Zeph\",\"Sofoniás\"]</td></tr><tr><td>ITALIAN</td><td>[\"Sofonia\",\"Sof\",\"Sofonia\"]</td></tr><tr><td>JAPANESE</td><td>[\"ゼパニヤ書\",\"Zeph\",\"ゼパニヤ書\"]</td></tr><tr><td>KOREAN</td><td>[\"스바냐 | 스바니야\",\"습\",\"스바냐\",\"스바니야\"]</td></tr><tr><td>LATIN</td><td>[\"Sophoniæ | Sophoniae | Sophonia\",\"Soph\",\"Sophoniæ\",\"Sophoniae\",\"Sophonia\"]</td></tr><tr><td>POLISH</td><td>[\"Sofoniasza\",\"So\",\"Sofoniasza\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Sofonias\",\"Zeph\",\"Sofonias\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Tefania\",\"Zeph\",\"Tefania\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Софония\",\"Соф\",\"Софония\"]</td></tr><tr><td>SPANISH</td><td>[\"Sofonías\",\"Sof\",\"Sofonías\"]</td></tr><tr><td>TAMIL</td><td>[\"செப்பனியா\",\"Zeph\",\"செப்பனியா\"]</td></tr><tr><td>THAI</td><td>[\"เศฟันยาห์\",\"Zeph\",\"เศฟันยาห์\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Zephaniah | Tsefania\",\"Zeph\",\"Zephaniah\",\"Tsefania\"]</td></tr><tr><td rowspan=\"25\">Book 43</td><td>ENGLISH</td><td>[\"Haggai\",\"Hag | Hg\",\"Haggai\",\"Hag\",\"Hg\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Haggai\",\"Hg\",\"Haggai\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Hagai\",\"Hag | Hg\",\"Hagai\",\"Hag\",\"Hg\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"حجى\",\"Hag | Hg\",\"حجى\",\"Hag\",\"Hg\"]</td></tr><tr><td>CHINESE</td><td>[\"哈蓋\",\"Hag | Hg\",\"哈蓋\",\"Hag\",\"Hg\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Hag | Hg\",\"\",\"Hag\",\"Hg\"]</td></tr><tr><td>CZECH</td><td>[\"Ageus\",\"Hag | Hg\",\"Ageus\",\"Hag\",\"Hg\"]</td></tr><tr><td>FILIPINO</td><td>[\"Hagai\",\"Hag\",\"Hagai\"]</td></tr><tr><td>FRENCH</td><td>[\"Aggée\",\"Hag | Hg\",\"Aggée\",\"Hag\",\"Hg\"]</td></tr><tr><td>GERMAN</td><td>[\"Haggai\",\"Hag | Hg\",\"Haggai\",\"Hag\",\"Hg\"]</td></tr><tr><td>GREEK</td><td>[\"Αγγαίος\",\"Hag | Hg\",\"Αγγαίος\",\"Hag\",\"Hg\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Aggeus\",\"Hag | Hg\",\"Aggeus\",\"Hag\",\"Hg\"]</td></tr><tr><td>ITALIAN</td><td>[\"Aggeo\",\"Ag\",\"Aggeo\"]</td></tr><tr><td>JAPANESE</td><td>[\"ハガイ書\",\"Hag | Hg\",\"ハガイ書\",\"Hag\",\"Hg\"]</td></tr><tr><td>KOREAN</td><td>[\"학개 | 하까이\",\"학\",\"학개\",\"하까이\"]</td></tr><tr><td>LATIN</td><td>[\"Aggæi | Aggaei\",\"Agg\",\"Aggæi\",\"Aggaei\"]</td></tr><tr><td>POLISH</td><td>[\"Aggeusza\",\"Ag\",\"Aggeusza\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Ageu\",\"Hag | Hg\",\"Ageu\",\"Hag\",\"Hg\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Hagai\",\"Hag | Hg\",\"Hagai\",\"Hag\",\"Hg\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Аггей\",\"Агг\",\"Аггей\"]</td></tr><tr><td>SPANISH</td><td>[\"Ageo\",\"Ag\",\"Ageo\"]</td></tr><tr><td>TAMIL</td><td>[\"ஆகாய்\",\"Hag | Hg\",\"ஆகாய்\",\"Hag\",\"Hg\"]</td></tr><tr><td>THAI</td><td>[\"ฮักกัย\",\"Hag | Hg\",\"ฮักกัย\",\"Hag\",\"Hg\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Haggai\",\"Hag | Hg\",\"Haggai\",\"Hag\",\"Hg\"]</td></tr><tr><td rowspan=\"25\">Book 44</td><td>ENGLISH</td><td>[\"Zechariah\",\"Zech\",\"Zechariah\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Sagaría\",\"Zc\",\"Sagaría\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Zakaria\",\"Zech\",\"Zakaria\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"زكريا\",\"Zech\",\"زكريا\"]</td></tr><tr><td>CHINESE</td><td>[\"匝加利亞\",\"Zech\",\"匝加利亞\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Zech\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Zacharjáš\",\"Zech\",\"Zacharjáš\"]</td></tr><tr><td>FILIPINO</td><td>[\"Zacarias\",\"Zac\",\"Zacarias\"]</td></tr><tr><td>FRENCH</td><td>[\"Zacharie\",\"Zech\",\"Zacharie\"]</td></tr><tr><td>GERMAN</td><td>[\"Sacharja\",\"Zech\",\"Sacharja\"]</td></tr><tr><td>GREEK</td><td>[\"Ζαχαρίας\",\"Zech\",\"Ζαχαρίας\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Zakariás\",\"Zech\",\"Zakariás\"]</td></tr><tr><td>ITALIAN</td><td>[\"Zaccaria\",\"Zc\",\"Zaccaria\"]</td></tr><tr><td>JAPANESE</td><td>[\"ゼカリヤ書\",\"Zech\",\"ゼカリヤ書\"]</td></tr><tr><td>KOREAN</td><td>[\"스가랴 | 즈카르야\",\"슥\",\"스가랴\",\"즈카르야\"]</td></tr><tr><td>LATIN</td><td>[\"Zachariæ | Zachariae\",\"Zach\",\"Zachariæ\",\"Zachariae\"]</td></tr><tr><td>POLISH</td><td>[\"Zachariasza\",\"Za\",\"Zachariasza\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Zacarias\",\"Zech\",\"Zacarias\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Zaharia\",\"Zech\",\"Zaharia\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Захария\",\"Зах\",\"Захария\"]</td></tr><tr><td>SPANISH</td><td>[\"Zacarías\",\"Za | Zac\",\"Zacarías\",\"Za\",\"Zac\"]</td></tr><tr><td>TAMIL</td><td>[\"செக்கரியா\",\"Zech\",\"செக்கரியா\"]</td></tr><tr><td>THAI</td><td>[\"เศคาริยาห์\",\"Zech\",\"เศคาริยาห์\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Zechariah | Zekharia\",\"Zech\",\"Zechariah\",\"Zekharia\"]</td></tr><tr><td rowspan=\"25\">Book 45</td><td>ENGLISH</td><td>[\"Malachi\",\"Mal | Ml\",\"Malachi\",\"Mal\",\"Ml\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Maleági\",\"Ml\",\"Maleági\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Malakia\",\"Mal | Ml\",\"Malakia\",\"Mal\",\"Ml\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"ملاخي\",\"Mal | Ml\",\"ملاخي\",\"Mal\",\"Ml\"]</td></tr><tr><td>CHINESE</td><td>[\"瑪拉基亞\",\"Mal | Ml\",\"瑪拉基亞\",\"Mal\",\"Ml\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Mal | Ml\",\"\",\"Mal\",\"Ml\"]</td></tr><tr><td>CZECH</td><td>[\"Malachiáš\",\"Mal | Ml\",\"Malachiáš\",\"Mal\",\"Ml\"]</td></tr><tr><td>FILIPINO</td><td>[\"Malakias\",\"Mal\",\"Malakias\"]</td></tr><tr><td>FRENCH</td><td>[\"Malachie\",\"Mal | Ml\",\"Malachie\",\"Mal\",\"Ml\"]</td></tr><tr><td>GERMAN</td><td>[\"Maleachi\",\"Mal | Ml\",\"Maleachi\",\"Mal\",\"Ml\"]</td></tr><tr><td>GREEK</td><td>[\"Μαλαχίος\",\"Mal | Ml\",\"Μαλαχίος\",\"Mal\",\"Ml\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Malakiás\",\"Mal | Ml\",\"Malakiás\",\"Mal\",\"Ml\"]</td></tr><tr><td>ITALIAN</td><td>[\"Malachia\",\"Ml\",\"Malachia\"]</td></tr><tr><td>JAPANESE</td><td>[\"マラキ書\",\"Mal | Ml\",\"マラキ書\",\"Mal\",\"Ml\"]</td></tr><tr><td>KOREAN</td><td>[\"말라기 | 말라키\",\"말\",\"말라기\",\"말라키\"]</td></tr><tr><td>LATIN</td><td>[\"Malachiæ | Malachiae\",\"Mal\",\"Malachiæ\",\"Malachiae\"]</td></tr><tr><td>POLISH</td><td>[\"Malachiasza\",\"Ml\",\"Malachiasza\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Malaquias\",\"Mal | Ml\",\"Malaquias\",\"Mal\",\"Ml\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Maleahi\",\"Mal | Ml\",\"Maleahi\",\"Mal\",\"Ml\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Малахия\",\"Мал\",\"Малахия\"]</td></tr><tr><td>SPANISH</td><td>[\"Malaquías\",\"Ml | Mal\",\"Malaquías\",\"Ml\",\"Mal\"]</td></tr><tr><td>TAMIL</td><td>[\"மலாக்கி\",\"Mal | Ml\",\"மலாக்கி\",\"Mal\",\"Ml\"]</td></tr><tr><td>THAI</td><td>[\"มาลาคี\",\"Mal | Ml\",\"มาลาคี\",\"Mal\",\"Ml\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Malachi | Malakhi\",\"Mal | Ml\",\"Malachi\",\"Malakhi\",\"Mal\",\"Ml\"]</td></tr><tr><td rowspan=\"25\">Book 46</td><td>ENGLISH</td><td>[\"Matthew\",\"Matt | Mt\",\"Matthew\",\"Matt\",\"Mt\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Matthéüs\",\"Mt\",\"Matthéüs\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Mateu\",\"Matt | Mt\",\"Mateu\",\"Matt\",\"Mt\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"متى\",\"Matt | Mt\",\"متى\",\"Matt\",\"Mt\"]</td></tr><tr><td>CHINESE</td><td>[\"瑪竇福音\",\"Matt | Mt\",\"瑪竇福音\",\"Matt\",\"Mt\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Matt | Mt\",\"\",\"Matt\",\"Mt\"]</td></tr><tr><td>CZECH</td><td>[\"Matouše\",\"Matt | Mt\",\"Matouše\",\"Matt\",\"Mt\"]</td></tr><tr><td>FILIPINO</td><td>[\"Mateo\",\"Mt\",\"Mateo\"]</td></tr><tr><td>FRENCH</td><td>[\"Matthieu\",\"Matt | Mt\",\"Matthieu\",\"Matt\",\"Mt\"]</td></tr><tr><td>GERMAN</td><td>[\"Matthäus\",\"Matt | Mt\",\"Matthäus\",\"Matt\",\"Mt\"]</td></tr><tr><td>GREEK</td><td>[\"Ματθαίος\",\"Matt | Mt\",\"Ματθαίος\",\"Matt\",\"Mt\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Máté\",\"Matt | Mt\",\"Máté\",\"Matt\",\"Mt\"]</td></tr><tr><td>ITALIAN</td><td>[\"Matteo\",\"Mt\",\"Matteo\"]</td></tr><tr><td>JAPANESE</td><td>[\"マタイによる福音書\",\"Matt | Mt\",\"マタイによる福音書\",\"Matt\",\"Mt\"]</td></tr><tr><td>KOREAN</td><td>[\"마태 | 마태오 복음\",\"Matt | Mt\",\"마태\",\"마태오복음\",\"Matt\",\"Mt\"]</td></tr><tr><td>LATIN</td><td>[\"Matthæum | Matthaeum | Matthaeus\",\"Mt\",\"Matthæum\",\"Matthaeum\",\"Matthaeus\"]</td></tr><tr><td>POLISH</td><td>[\"Mateusza\",\"Mt\",\"Mateusza\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Mateus\",\"Matt | Mt\",\"Mateus\",\"Matt\",\"Mt\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Matei\",\"Matt | Mt\",\"Matei\",\"Matt\",\"Mt\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Матфея\",\"Matt | Mt\",\"Матфея\",\"Matt\",\"Mt\"]</td></tr><tr><td>SPANISH</td><td>[\"Mateo\",\"Mt\",\"Mateo\"]</td></tr><tr><td>TAMIL</td><td>[\"மத்தேயு\",\"Matt | Mt\",\"மத்தேயு\",\"Matt\",\"Mt\"]</td></tr><tr><td>THAI</td><td>[\"มัทธิว\",\"Matt | Mt\",\"มัทธิว\",\"Matt\",\"Mt\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Mátthêu | Mathiơ\",\"Matt | Mt\",\"Mátthêu\",\"Mathiơ\",\"Matt\",\"Mt\"]</td></tr><tr><td rowspan=\"25\">Book 47</td><td>ENGLISH</td><td>[\"Mark\",\"Mk\",\"Mark\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Markus\",\"Mr\",\"Markus\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Marku\",\"Mk\",\"Marku\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"مرقس\",\"Mk\",\"مرقس\"]</td></tr><tr><td>CHINESE</td><td>[\"馬爾谷福音\",\"Mk\",\"馬爾谷福音\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Mk\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Marka\",\"Mk\",\"Marka\"]</td></tr><tr><td>FILIPINO</td><td>[\"Marcos\",\"Mc\",\"Marcos\"]</td></tr><tr><td>FRENCH</td><td>[\"Marc\",\"Mk\",\"Marc\"]</td></tr><tr><td>GERMAN</td><td>[\"Markus\",\"Mk\",\"Markus\"]</td></tr><tr><td>GREEK</td><td>[\"Μάρκος\",\"Mk\",\"Μάρκος\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Márk\",\"Mk\",\"Márk\"]</td></tr><tr><td>ITALIAN</td><td>[\"Marco\",\"Mc\",\"Marco\"]</td></tr><tr><td>JAPANESE</td><td>[\"マルコによる福音書\",\"Mk\",\"マルコによる福音書\"]</td></tr><tr><td>KOREAN</td><td>[\"마가 | 마르코 복음\",\"Mk\",\"마가\",\"마르코복음\"]</td></tr><tr><td>LATIN</td><td>[\"Marcum | Marcus\",\"Mc\",\"Marcum\",\"Marcus\"]</td></tr><tr><td>POLISH</td><td>[\"Marka\",\"Mk\",\"Marka\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Marcos\",\"Mk\",\"Marcos\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Marcu\",\"Mk\",\"Marcu\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Марка\",\"Mk\",\"Марка\"]</td></tr><tr><td>SPANISH</td><td>[\"Marcos\",\"Mc\",\"Marcos\"]</td></tr><tr><td>TAMIL</td><td>[\"மாற்கு\",\"Mk\",\"மாற்கு\"]</td></tr><tr><td>THAI</td><td>[\"มาระโก\",\"Mk\",\"มาระโก\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Máccô | Mác\",\"Mk\",\"Máccô\",\"Mác\"]</td></tr><tr><td rowspan=\"25\">Book 48</td><td>ENGLISH</td><td>[\"Luke\",\"Lk\",\"Luke\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Lukas\",\"Lk\",\"Lukas\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Luka\",\"Lk\",\"Luka\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"لوقا\",\"Lk\",\"لوقا\"]</td></tr><tr><td>CHINESE</td><td>[\"路加福音\",\"Lk\",\"路加福音\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Lk\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Lukáše\",\"Lk\",\"Lukáše\"]</td></tr><tr><td>FILIPINO</td><td>[\"Lucas\",\"Lu\",\"Lucas\"]</td></tr><tr><td>FRENCH</td><td>[\"Luc\",\"Lk\",\"Luc\"]</td></tr><tr><td>GERMAN</td><td>[\"Lukas\",\"Lk\",\"Lukas\"]</td></tr><tr><td>GREEK</td><td>[\"Λουκάς\",\"Lk\",\"Λουκάς\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Lukács\",\"Lk\",\"Lukács\"]</td></tr><tr><td>ITALIAN</td><td>[\"Luca\",\"Lc\",\"Luca\"]</td></tr><tr><td>JAPANESE</td><td>[\"ルカによる福音書\",\"Lk\",\"ルカによる福音書\"]</td></tr><tr><td>KOREAN</td><td>[\"누가 | 루카 복음\",\"Lk\",\"누가\",\"루카복음\"]</td></tr><tr><td>LATIN</td><td>[\"Lucam | Lucas\",\"Lc\",\"Lucam\",\"Lucas\"]</td></tr><tr><td>POLISH</td><td>[\"Łukasza\",\"Łk\",\"Łukasza\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Lucas\",\"Lk\",\"Lucas\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Luca\",\"Lk\",\"Luca\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Луки\",\"Lk\",\"Луки\"]</td></tr><tr><td>SPANISH</td><td>[\"Lucas\",\"Lc\",\"Lucas\"]</td></tr><tr><td>TAMIL</td><td>[\"லூக்கா\",\"Lk\",\"லூக்கா\"]</td></tr><tr><td>THAI</td><td>[\"ลูกา\",\"Lk\",\"ลูกา\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Luca\",\"Lk\",\"Luca\"]</td></tr><tr><td rowspan=\"25\">Book 49</td><td>ENGLISH</td><td>[\"John\",\"Jn\",\"John\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Johannes\",\"Jh\",\"Johannes\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Gjoni\",\"Jn\",\"Gjoni\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"يوحنا\",\"Jn\",\"يوحنا\"]</td></tr><tr><td>CHINESE</td><td>[\"若望福音\",\"Jn\",\"若望福音\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Jn\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Jana\",\"Jn\",\"Jana\"]</td></tr><tr><td>FILIPINO</td><td>[\"Juan\",\"Jn\",\"Juan\"]</td></tr><tr><td>FRENCH</td><td>[\"Jean\",\"Jn\",\"Jean\"]</td></tr><tr><td>GERMAN</td><td>[\"Johannes\",\"Jn\",\"Johannes\"]</td></tr><tr><td>GREEK</td><td>[\"Ιωάννης\",\"Jn\",\"Ιωάννης\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"János\",\"Jn\",\"János\"]</td></tr><tr><td>ITALIAN</td><td>[\"Giovanni\",\"Gv\",\"Giovanni\"]</td></tr><tr><td>JAPANESE</td><td>[\"ヨハネによる福音書\",\"Jn\",\"ヨハネによる福音書\"]</td></tr><tr><td>KOREAN</td><td>[\"요한 복음\",\"Jn\",\"요한복음\"]</td></tr><tr><td>LATIN</td><td>[\"Ioannem | Ioannes | Joannes | Johannes | Iohannes\",\"Ioh\",\"Ioannem\",\"Ioannes\",\"Joannes\",\"Johannes\",\"Iohannes\"]</td></tr><tr><td>POLISH</td><td>[\"Jana\",\"J\",\"Jana\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"João\",\"Jn\",\"João\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Ioan\",\"Jn\",\"Ioan\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Иоанна\",\"Jn\",\"Иоанна\"]</td></tr><tr><td>SPANISH</td><td>[\"Juan\",\"Jn\",\"Juan\"]</td></tr><tr><td>TAMIL</td><td>[\"யோவான்\",\"Jn\",\"யோவான்\"]</td></tr><tr><td>THAI</td><td>[\"ยอห์น\",\"Jn\",\"ยอห์น\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Gioan | Giăng\",\"Jn\",\"Gioan\",\"Giăng\"]</td></tr><tr><td rowspan=\"25\">Book 50</td><td>ENGLISH</td><td>[\"Acts | Acts of the Apostles\",\"Ac\",\"Acts\",\"Actsoftheapostles\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Handelinge | Die handelinge van die apostels\",\"Ac\",\"Handelinge\",\"Diehandelingevandieapostels\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Veprat | Veprat e Apostujve\",\"Ac\",\"Veprat\",\"Veprateapostujve\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"اعمال\",\"Ac\",\"اعمال\"]</td></tr><tr><td>CHINESE</td><td>[\"宗徒大事錄\",\"Ac\",\"宗徒大事錄\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Ac\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Skutky apoštolů\",\"Ac\",\"Skutkyapoštolů\"]</td></tr><tr><td>FILIPINO</td><td>[\"Gawa | Mga Gawa\",\"Gw\",\"Gawa\",\"Mgagawa\"]</td></tr><tr><td>FRENCH</td><td>[\"Actes\",\"Ac\",\"Actes\"]</td></tr><tr><td>GERMAN</td><td>[\"Apostelgeschichte\",\"Ac\",\"Apostelgeschichte\"]</td></tr><tr><td>GREEK</td><td>[\"Πράξεις | Πράξεις των Αποστόλων\",\"Ac\",\"Πράξεις\",\"Πράξειςτωναποστόλων\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Apostolok\",\"Ac\",\"Apostolok\"]</td></tr><tr><td>ITALIAN</td><td>[\"Atti | Atti degli Apostoli\",\"At\",\"Atti\",\"Attidegliapostoli\"]</td></tr><tr><td>JAPANESE</td><td>[\"使徒行伝\",\"Ac\",\"使徒行伝\"]</td></tr><tr><td>KOREAN</td><td>[\"사도행전\",\"Ac\",\"사도행전\"]</td></tr><tr><td>LATIN</td><td>[\"Actus Apostolorum\",\"Ac\",\"Actusapostolorum\"]</td></tr><tr><td>POLISH</td><td>[\"Dzieje | Dzieje Apostolskie\",\"Dz\",\"Dzieje\",\"Dziejeapostolskie\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Actos\",\"Ac\",\"Actos\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Faptele | Faptele Apostolilor\",\"Ac\",\"Faptele\",\"Fapteleapostolilor\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Деяния\",\"Ac\",\"Деяния\"]</td></tr><tr><td>SPANISH</td><td>[\"Hechos | Hechos de los Apóstoles\",\"He | Hch | Hech\",\"Hechos\",\"Hechosdelosapóstoles\",\"He\",\"Hch\",\"Hech\"]</td></tr><tr><td>TAMIL</td><td>[\"திருத்தூதர் பணிகள்\",\"Ac\",\"திருத்தூதர்பணிகள்\"]</td></tr><tr><td>THAI</td><td>[\"กิจการของอัครทูต | กิจการอัครสาวก\",\"Ac\",\"กิจการของอัครทูต\",\"กิจการอัครสาวก\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Công vụ các Sứ đồ | Công vụ Tông đồ\",\"Ac\",\"Côngvụcácsứđồ\",\"Côngvụtôngđồ\"]</td></tr><tr><td rowspan=\"25\">Book 51</td><td>ENGLISH</td><td>[\"Romans\",\"Rm | Rom\",\"Romans\",\"Rm\",\"Rom\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Romeine\",\"Rm\",\"Romeine\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Romakëve\",\"Rm | Rom\",\"Romakëve\",\"Rm\",\"Rom\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"رومية\",\"Rm | Rom\",\"رومية\",\"Rm\",\"Rom\"]</td></tr><tr><td>CHINESE</td><td>[\"羅馬書\",\"Rm | Rom\",\"羅馬書\",\"Rm\",\"Rom\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Rm | Rom\",\"\",\"Rm\",\"Rom\"]</td></tr><tr><td>CZECH</td><td>[\"Římanům\",\"Rm | Rom\",\"Římanům\",\"Rm\",\"Rom\"]</td></tr><tr><td>FILIPINO</td><td>[\"Taga-Roma | Mga Taga-Roma\",\"Ro\",\"Taga-roma\",\"Mgataga-roma\"]</td></tr><tr><td>FRENCH</td><td>[\"Romains\",\"Rm | Rom\",\"Romains\",\"Rm\",\"Rom\"]</td></tr><tr><td>GERMAN</td><td>[\"Römer\",\"Rm | Rom\",\"Römer\",\"Rm\",\"Rom\"]</td></tr><tr><td>GREEK</td><td>[\"Ρωμαίους\",\"Rm | Rom\",\"Ρωμαίους\",\"Rm\",\"Rom\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Rómaiakhoz\",\"Rm | Rom\",\"Rómaiakhoz\",\"Rm\",\"Rom\"]</td></tr><tr><td>ITALIAN</td><td>[\"Romani\",\"Rm\",\"Romani\"]</td></tr><tr><td>JAPANESE</td><td>[\"ローマ人への手紙\",\"Rm | Rom\",\"ローマ人への手紙\",\"Rm\",\"Rom\"]</td></tr><tr><td>KOREAN</td><td>[\"로마서\",\"Rm | Rom\",\"로마서\",\"Rm\",\"Rom\"]</td></tr><tr><td>LATIN</td><td>[\"Romanos\",\"Rom\",\"Romanos\"]</td></tr><tr><td>POLISH</td><td>[\"Rzymian\",\"Rz\",\"Rzymian\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Romanos\",\"Rm | Rom\",\"Romanos\",\"Rm\",\"Rom\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Romani\",\"Rm | Rom\",\"Romani\",\"Rm\",\"Rom\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Римлянам\",\"Rm | Rom\",\"Римлянам\",\"Rm\",\"Rom\"]</td></tr><tr><td>SPANISH</td><td>[\"Romanos\",\"Rm | Rom\",\"Romanos\",\"Rm\",\"Rom\"]</td></tr><tr><td>TAMIL</td><td>[\"உரோமையர்\",\"Rm | Rom\",\"உரோமையர்\",\"Rm\",\"Rom\"]</td></tr><tr><td>THAI</td><td>[\"โรม\",\"Rm | Rom\",\"โรม\",\"Rm\",\"Rom\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Rôma\",\"Rm | Rom\",\"Rôma\",\"Rm\",\"Rom\"]</td></tr><tr><td rowspan=\"25\">Book 52</td><td>ENGLISH</td><td>[\"1 Corinthians\",\"1Cor\",\"1Corinthians\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"1 Korintiërs\",\"1Cr\",\"1Korintiërs\"]</td></tr><tr><td>ALBANIAN</td><td>[\"1Korintasve\",\"1Cor\",\"1Korintasve\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"1كورنثوس\",\"1Cor\",\"1كورنثوس\"]</td></tr><tr><td>CHINESE</td><td>[\"格林多前書\",\"1Cor\",\"格林多前書\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"1Cor\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"1Korintským\",\"1Cor\",\"1Korintským\"]</td></tr><tr><td>FILIPINO</td><td>[\"1 Taga-Corinto | 1 Mga Taga-Corinto\",\"1Cor\",\"1Taga-corinto\",\"1Mgataga-corinto\"]</td></tr><tr><td>FRENCH</td><td>[\"1Corinthiens\",\"1Cor\",\"1Corinthiens\"]</td></tr><tr><td>GERMAN</td><td>[\"1Korinther\",\"1Cor\",\"1Korinther\"]</td></tr><tr><td>GREEK</td><td>[\"Α Κορινθίους\",\"1Cor\",\"Ακορινθίους\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"1Korintusi\",\"1Cor\",\"1Korintusi\"]</td></tr><tr><td>ITALIAN</td><td>[\"1Corinzi\",\"1Cor\",\"1Corinzi\"]</td></tr><tr><td>JAPANESE</td><td>[\"コリント人への第一の手紙\",\"1Cor\",\"コリント人への第一の手紙\"]</td></tr><tr><td>KOREAN</td><td>[\"고린도1서 | 코린토1서\",\"1Cor\",\"고린도1서\",\"코린토1서\"]</td></tr><tr><td>LATIN</td><td>[\"I Corinthios\",\"I Cor\",\"Icorinthios\"]</td></tr><tr><td>POLISH</td><td>[\"1Koryntian\",\"1Kor\",\"1Koryntian\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"1 Coríntios\",\"1Cor\",\"1Coríntios\"]</td></tr><tr><td>ROMANIAN</td><td>[\"1Corinteni\",\"1Cor\",\"1Corinteni\"]</td></tr><tr><td>RUSSIAN</td><td>[\"1Коринфянам\",\"1Cor\",\"1Коринфянам\"]</td></tr><tr><td>SPANISH</td><td>[\"1Corintios\",\"1Co | 1Cor\",\"1Corintios\",\"1Co\",\"1Cor\"]</td></tr><tr><td>TAMIL</td><td>[\"1 கொரிந்தியர்\",\"1Cor\",\"1கொரிந்தியர்\"]</td></tr><tr><td>THAI</td><td>[\"1 โครินธ์ | โครินธ์ฉบับที่หึ่ง\",\"1Cor\",\"1โครินธ์\",\"โครินธ์ฉบับที่หึ่ง\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"1 Côrintô\",\"1Cor\",\"1Côrintô\"]</td></tr><tr><td rowspan=\"25\">Book 53</td><td>ENGLISH</td><td>[\"2 Corinthians\",\"2Cor\",\"2Corinthians\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"2 Korintiërs\",\"2Cr\",\"2Korintiërs\"]</td></tr><tr><td>ALBANIAN</td><td>[\"2Koristasve\",\"2Cor\",\"2Koristasve\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"2كورنثوس\",\"2Cor\",\"2كورنثوس\"]</td></tr><tr><td>CHINESE</td><td>[\"格林多後書\",\"2Cor\",\"格林多後書\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"2Cor\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"2Korintským\",\"2Cor\",\"2Korintským\"]</td></tr><tr><td>FILIPINO</td><td>[\"2 Taga-Corinto | 2 Mga Taga-Corinto\",\"2Cor\",\"2Taga-corinto\",\"2Mgataga-corinto\"]</td></tr><tr><td>FRENCH</td><td>[\"2Corinthiens\",\"2Cor\",\"2Corinthiens\"]</td></tr><tr><td>GERMAN</td><td>[\"2Korinther\",\"2Cor\",\"2Korinther\"]</td></tr><tr><td>GREEK</td><td>[\"Β Κορινθίους\",\"2Cor\",\"Βκορινθίους\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"2Korintusi\",\"2Cor\",\"2Korintusi\"]</td></tr><tr><td>ITALIAN</td><td>[\"2Corinzi\",\"2Cor\",\"2Corinzi\"]</td></tr><tr><td>JAPANESE</td><td>[\"コリント人への第二の手紙\",\"2Cor\",\"コリント人への第二の手紙\"]</td></tr><tr><td>KOREAN</td><td>[\"고린도2서 | 코린토2서\",\"2Cor\",\"고린도2서\",\"코린토2서\"]</td></tr><tr><td>LATIN</td><td>[\"II Corinthios\",\"II Cor\",\"Iicorinthios\"]</td></tr><tr><td>POLISH</td><td>[\"2Koryntian\",\"2Kor\",\"2Koryntian\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"2 Coríntios\",\"2Cor\",\"2Coríntios\"]</td></tr><tr><td>ROMANIAN</td><td>[\"2Corinteni\",\"2Cor\",\"2Corinteni\"]</td></tr><tr><td>RUSSIAN</td><td>[\"2Коринфянам\",\"2Cor\",\"2Коринфянам\"]</td></tr><tr><td>SPANISH</td><td>[\"2Corintios\",\"2Co | 2Cor\",\"2Corintios\",\"2Co\",\"2Cor\"]</td></tr><tr><td>TAMIL</td><td>[\"2 கொரிந்தியர்\",\"2Cor\",\"2கொரிந்தியர்\"]</td></tr><tr><td>THAI</td><td>[\"2 โครินธ์ | โครินธ์ฉบับที่สอง\",\"2Cor\",\"2โครินธ์\",\"โครินธ์ฉบับที่สอง\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"2 Côrintô\",\"2Cor\",\"2Côrintô\"]</td></tr><tr><td rowspan=\"25\">Book 54</td><td>ENGLISH</td><td>[\"Galatians\",\"Gal\",\"Galatians\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Galasiërs\",\"Gl\",\"Galasiërs\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Galatasve\",\"Gal\",\"Galatasve\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"غلاطية\",\"Gal\",\"غلاطية\"]</td></tr><tr><td>CHINESE</td><td>[\"迦拉達書\",\"Gal\",\"迦拉達書\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Gal\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Galatským\",\"Gal\",\"Galatským\"]</td></tr><tr><td>FILIPINO</td><td>[\"Taga-Galacia | Mga Taga-Galacia\",\"Ga\",\"Taga-galacia\",\"Mgataga-galacia\"]</td></tr><tr><td>FRENCH</td><td>[\"Galates\",\"Gal\",\"Galates\"]</td></tr><tr><td>GERMAN</td><td>[\"Galater\",\"Gal\",\"Galater\"]</td></tr><tr><td>GREEK</td><td>[\"Γαλάτας\",\"Gal\",\"Γαλάτας\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Galatákhoz\",\"Gal\",\"Galatákhoz\"]</td></tr><tr><td>ITALIAN</td><td>[\"Galati\",\"Gal\",\"Galati\"]</td></tr><tr><td>JAPANESE</td><td>[\"ガラテヤ人への手紙\",\"Gal\",\"ガラテヤ人への手紙\"]</td></tr><tr><td>KOREAN</td><td>[\"갈라디아서\",\"Gal\",\"갈라디아서\"]</td></tr><tr><td>LATIN</td><td>[\"Galatas\",\"Gal\",\"Galatas\"]</td></tr><tr><td>POLISH</td><td>[\"Galatów\",\"Ga\",\"Galatów\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Gálatas\",\"Gal\",\"Gálatas\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Galateni\",\"Gal\",\"Galateni\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Галатам\",\"Gal\",\"Галатам\"]</td></tr><tr><td>SPANISH</td><td>[\"Gálatas\",\"Ga | Gál\",\"Gálatas\",\"Ga\",\"Gál\"]</td></tr><tr><td>TAMIL</td><td>[\"கலாத்தியர்\",\"Gal\",\"கலாத்தியர்\"]</td></tr><tr><td>THAI</td><td>[\"กาลาเทีย\",\"Gal\",\"กาลาเทีย\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Galát\",\"Gal\",\"Galát\"]</td></tr><tr><td rowspan=\"25\">Book 55</td><td>ENGLISH</td><td>[\"Ephesians\",\"Eph\",\"Ephesians\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Efésiërs\",\"Ep\",\"Efésiërs\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Efesianëve\",\"Eph\",\"Efesianëve\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"افسس\",\"Eph\",\"افسس\"]</td></tr><tr><td>CHINESE</td><td>[\"厄弗所書\",\"Eph\",\"厄弗所書\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Eph\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Efezským\",\"Eph\",\"Efezským\"]</td></tr><tr><td>FILIPINO</td><td>[\"Taga-Efeso | Mga Taga-Efeso\",\"Ef\",\"Taga-efeso\",\"Mgataga-efeso\"]</td></tr><tr><td>FRENCH</td><td>[\"Éphésiens\",\"Eph\",\"Éphésiens\"]</td></tr><tr><td>GERMAN</td><td>[\"Epheser\",\"Eph\",\"Epheser\"]</td></tr><tr><td>GREEK</td><td>[\"Εφεσίους\",\"Eph\",\"Εφεσίους\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Efézusiakhoz\",\"Eph\",\"Efézusiakhoz\"]</td></tr><tr><td>ITALIAN</td><td>[\"Efesini\",\"Ef\",\"Efesini\"]</td></tr><tr><td>JAPANESE</td><td>[\"エペソ人への手紙\",\"Eph\",\"エペソ人への手紙\"]</td></tr><tr><td>KOREAN</td><td>[\"에베소서 | 에페소서\",\"Eph\",\"에베소서\",\"에페소서\"]</td></tr><tr><td>LATIN</td><td>[\"Ephesios\",\"Eph\",\"Ephesios\"]</td></tr><tr><td>POLISH</td><td>[\"Efezjan\",\"Ef\",\"Efezjan\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Efésios\",\"Eph\",\"Efésios\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Efeseni\",\"Eph\",\"Efeseni\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Ефесянам\",\"Eph\",\"Ефесянам\"]</td></tr><tr><td>SPANISH</td><td>[\"Efesios\",\"Ef\",\"Efesios\"]</td></tr><tr><td>TAMIL</td><td>[\"எபேசியர்\",\"Eph\",\"எபேசியர்\"]</td></tr><tr><td>THAI</td><td>[\"เอเฟซัส\",\"Eph\",\"เอเฟซัส\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Êphêsô\",\"Eph\",\"Êphêsô\"]</td></tr><tr><td rowspan=\"25\">Book 56</td><td>ENGLISH</td><td>[\"Philippians\",\"Phil\",\"Philippians\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Filippense\",\"Ph\",\"Filippense\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Filipianëve\",\"Phil\",\"Filipianëve\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"فيلبي\",\"Phil\",\"فيلبي\"]</td></tr><tr><td>CHINESE</td><td>[\"斐理伯書\",\"Phil\",\"斐理伯書\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Phil\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Filipským\",\"Phil\",\"Filipským\"]</td></tr><tr><td>FILIPINO</td><td>[\"Taga-Filipos | Mga Taga-Filipos\",\"Fil\",\"Taga-filipos\",\"Mgataga-filipos\"]</td></tr><tr><td>FRENCH</td><td>[\"Philippiens\",\"Phil\",\"Philippiens\"]</td></tr><tr><td>GERMAN</td><td>[\"Philipper\",\"Phil\",\"Philipper\"]</td></tr><tr><td>GREEK</td><td>[\"Φιλιππησίους\",\"Phil\",\"Φιλιππησίους\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Filippiekhez\",\"Phil\",\"Filippiekhez\"]</td></tr><tr><td>ITALIAN</td><td>[\"Filippesi\",\"Fil\",\"Filippesi\"]</td></tr><tr><td>JAPANESE</td><td>[\"ピリピ人への手紙\",\"Phil\",\"ピリピ人への手紙\"]</td></tr><tr><td>KOREAN</td><td>[\"빌립보서 | 필리피서\",\"Phil\",\"빌립보서\",\"필리피서\"]</td></tr><tr><td>LATIN</td><td>[\"Philippenses\",\"Phil\",\"Philippenses\"]</td></tr><tr><td>POLISH</td><td>[\"Filipian\",\"Flp\",\"Filipian\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Filipenses\",\"Phil\",\"Filipenses\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Filipeni\",\"Phil\",\"Filipeni\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Филиппийцам\",\"Phil\",\"Филиппийцам\"]</td></tr><tr><td>SPANISH</td><td>[\"Filipenses\",\"Flp\",\"Filipenses\"]</td></tr><tr><td>TAMIL</td><td>[\"பிலிப்பியர்\",\"Phil\",\"பிலிப்பியர்\"]</td></tr><tr><td>THAI</td><td>[\"ฟีลิปปี\",\"Phil\",\"ฟีลิปปี\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Philípphê\",\"Phil\",\"Philípphê\"]</td></tr><tr><td rowspan=\"25\">Book 57</td><td>ENGLISH</td><td>[\"Colossians\",\"Col\",\"Colossians\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Kolossense\",\"Cl\",\"Kolossense\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Kolosianëve\",\"Col\",\"Kolosianëve\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"كولوسي\",\"Col\",\"كولوسي\"]</td></tr><tr><td>CHINESE</td><td>[\"哥羅森書\",\"Col\",\"哥羅森書\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Col\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Koloským\",\"Col\",\"Koloským\"]</td></tr><tr><td>FILIPINO</td><td>[\"Taga-Colosas | Mga Taga-Colosas\",\"Co\",\"Taga-colosas\",\"Mgataga-colosas\"]</td></tr><tr><td>FRENCH</td><td>[\"Colossiens\",\"Col\",\"Colossiens\"]</td></tr><tr><td>GERMAN</td><td>[\"Kolosser\",\"Col\",\"Kolosser\"]</td></tr><tr><td>GREEK</td><td>[\"Κολοσσαείς\",\"Col\",\"Κολοσσαείς\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Kolosséiakhoz\",\"Col\",\"Kolosséiakhoz\"]</td></tr><tr><td>ITALIAN</td><td>[\"Colossesi\",\"Col\",\"Colossesi\"]</td></tr><tr><td>JAPANESE</td><td>[\"コロサイ人への手紙\",\"Col\",\"コロサイ人への手紙\"]</td></tr><tr><td>KOREAN</td><td>[\"골로새서 | 콜로새서\",\"Col\",\"골로새서\",\"콜로새서\"]</td></tr><tr><td>LATIN</td><td>[\"Colossenses\",\"Col\",\"Colossenses\"]</td></tr><tr><td>POLISH</td><td>[\"Kolosan\",\"Kol\",\"Kolosan\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Colossenses\",\"Col\",\"Colossenses\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Coloseni\",\"Col\",\"Coloseni\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Колоссянам\",\"Col\",\"Колоссянам\"]</td></tr><tr><td>SPANISH</td><td>[\"Colosenses\",\"Col\",\"Colosenses\"]</td></tr><tr><td>TAMIL</td><td>[\"கொலோசையர்\",\"Col\",\"கொலோசையர்\"]</td></tr><tr><td>THAI</td><td>[\"โคโลสี\",\"Col\",\"โคโลสี\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Thư Côlôxê\",\"Col\",\"Thưcôlôxê\"]</td></tr><tr><td rowspan=\"25\">Book 58</td><td>ENGLISH</td><td>[\"1Thessalonians\",\"1Th | 1Thess\",\"1Thessalonians\",\"1Th\",\"1Thess\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"1 Tessalonicense\",\"1Th\",\"1Tessalonicense\"]</td></tr><tr><td>ALBANIAN</td><td>[\"1Thesalonikasve\",\"1Th | 1Thess\",\"1Thesalonikasve\",\"1Th\",\"1Thess\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"1تسالونيكي\",\"1Th | 1Thess\",\"1تسالونيكي\",\"1Th\",\"1Thess\"]</td></tr><tr><td>CHINESE</td><td>[\"得撒洛尼前書\",\"1Th | 1Thess\",\"得撒洛尼前書\",\"1Th\",\"1Thess\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"1Th | 1Thess\",\"\",\"1Th\",\"1Thess\"]</td></tr><tr><td>CZECH</td><td>[\"1Soluňským | 1Tesalonickým\",\"1Th | 1Thess\",\"1Soluňským\",\"1Tesalonickým\",\"1Th\",\"1Thess\"]</td></tr><tr><td>FILIPINO</td><td>[\"1 Taga-Tesalonica | 1 Mga Taga-Tesalonica\",\"1Tes\",\"1Taga-tesalonica\",\"1Mgataga-tesalonica\"]</td></tr><tr><td>FRENCH</td><td>[\"1Thessaloniciens\",\"1Th | 1Thess\",\"1Thessaloniciens\",\"1Th\",\"1Thess\"]</td></tr><tr><td>GERMAN</td><td>[\"1Thessalonicher\",\"1Th | 1Thess\",\"1Thessalonicher\",\"1Th\",\"1Thess\"]</td></tr><tr><td>GREEK</td><td>[\"Α Θεσσαλονικείς\",\"1Th | 1Thess\",\"Αθεσσαλονικείς\",\"1Th\",\"1Thess\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"1Tesszalonika\",\"1Th | 1Thess\",\"1Tesszalonika\",\"1Th\",\"1Thess\"]</td></tr><tr><td>ITALIAN</td><td>[\"1Tessalonicesi\",\"1Ts\",\"1Tessalonicesi\"]</td></tr><tr><td>JAPANESE</td><td>[\"テサロニケ人への第一の手紙\",\"1Th | 1Thess\",\"テサロニケ人への第一の手紙\",\"1Th\",\"1Thess\"]</td></tr><tr><td>KOREAN</td><td>[\"데살로니가1서 | 테살로니카1서\",\"1Th | 1Thess\",\"데살로니가1서\",\"테살로니카1서\",\"1Th\",\"1Thess\"]</td></tr><tr><td>LATIN</td><td>[\"I Thessalonicenses\",\"I Thess\",\"Ithessalonicenses\"]</td></tr><tr><td>POLISH</td><td>[\"1Tesaloniczan\",\"1Tes\",\"1Tesaloniczan\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Filémon\",\"1Th | 1Thess\",\"Filémon\",\"1Th\",\"1Thess\"]</td></tr><tr><td>ROMANIAN</td><td>[\"1Tesaloniceni\",\"1Th | 1Thess\",\"1Tesaloniceni\",\"1Th\",\"1Thess\"]</td></tr><tr><td>RUSSIAN</td><td>[\"1Фессалоникийцам\",\"1Th | 1Thess\",\"1Фессалоникийцам\",\"1Th\",\"1Thess\"]</td></tr><tr><td>SPANISH</td><td>[\"1Tesalonicenses\",\"1Ts | 1Tes\",\"1Tesalonicenses\",\"1Ts\",\"1Tes\"]</td></tr><tr><td>TAMIL</td><td>[\"1 தெசலோனிக்கர்\",\"1Th | 1Thess\",\"1தெசலோனிக்கர்\",\"1Th\",\"1Thess\"]</td></tr><tr><td>THAI</td><td>[\"1 เธสะโลนิกา | เธสะโลนิกาฉบับที่หึ่ง\",\"1Th | 1Thess\",\"1เธสะโลนิกา\",\"เธสะโลนิกาฉบับที่หึ่ง\",\"1Th\",\"1Thess\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"1 Thêxalônica\",\"1Th | 1Thess\",\"1Thêxalônica\",\"1Th\",\"1Thess\"]</td></tr><tr><td rowspan=\"25\">Book 59</td><td>ENGLISH</td><td>[\"2Thessalonians\",\"2Th | 2Thess\",\"2Thessalonians\",\"2Th\",\"2Thess\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"2 Tessalonicense\",\"2Th\",\"2Tessalonicense\"]</td></tr><tr><td>ALBANIAN</td><td>[\"2Thesalonikasve\",\"2Th | 2Thess\",\"2Thesalonikasve\",\"2Th\",\"2Thess\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"2تسالونيكي\",\"2Th | 2Thess\",\"2تسالونيكي\",\"2Th\",\"2Thess\"]</td></tr><tr><td>CHINESE</td><td>[\"得撒洛尼後書\",\"2Th | 2Thess\",\"得撒洛尼後書\",\"2Th\",\"2Thess\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"2Th | 2Thess\",\"\",\"2Th\",\"2Thess\"]</td></tr><tr><td>CZECH</td><td>[\"2Soluňským | 2Tesalonickým\",\"2Th | 2Thess\",\"2Soluňským\",\"2Tesalonickým\",\"2Th\",\"2Thess\"]</td></tr><tr><td>FILIPINO</td><td>[\"2 Taga-Tesalonica | 2 Mga Taga-Tesalonica\",\"2Tes\",\"2Taga-tesalonica\",\"2Mgataga-tesalonica\"]</td></tr><tr><td>FRENCH</td><td>[\"2Thessaloniciens\",\"2Th | 2Thess\",\"2Thessaloniciens\",\"2Th\",\"2Thess\"]</td></tr><tr><td>GERMAN</td><td>[\"2Thessalonicher\",\"2Th | 2Thess\",\"2Thessalonicher\",\"2Th\",\"2Thess\"]</td></tr><tr><td>GREEK</td><td>[\"Β Θεσσαλονικείς\",\"2Th | 2Thess\",\"Βθεσσαλονικείς\",\"2Th\",\"2Thess\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"2Tesszalonika\",\"2Th | 2Thess\",\"2Tesszalonika\",\"2Th\",\"2Thess\"]</td></tr><tr><td>ITALIAN</td><td>[\"2Tessalonicesi\",\"2Ts\",\"2Tessalonicesi\"]</td></tr><tr><td>JAPANESE</td><td>[\"テサロニケ人への第二の手紙\",\"2Th | 2Thess\",\"テサロニケ人への第二の手紙\",\"2Th\",\"2Thess\"]</td></tr><tr><td>KOREAN</td><td>[\"데살로니가2서 | 테살로니카2서\",\"2Th | 2Thess\",\"데살로니가2서\",\"테살로니카2서\",\"2Th\",\"2Thess\"]</td></tr><tr><td>LATIN</td><td>[\"II Thessalonicenses\",\"II Thess\",\"Iithessalonicenses\"]</td></tr><tr><td>POLISH</td><td>[\"2Tesaloniczan\",\"2Tes\",\"2Tesaloniczan\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"1 Tessalonicenses\",\"2Th | 2Thess\",\"1Tessalonicenses\",\"2Th\",\"2Thess\"]</td></tr><tr><td>ROMANIAN</td><td>[\"2Tesaloniceni\",\"2Th | 2Thess\",\"2Tesaloniceni\",\"2Th\",\"2Thess\"]</td></tr><tr><td>RUSSIAN</td><td>[\"2Фессалоникийцам\",\"2Th | 2Thess\",\"2Фессалоникийцам\",\"2Th\",\"2Thess\"]</td></tr><tr><td>SPANISH</td><td>[\"2Tesalonicenses\",\"2Ts | 2Tes\",\"2Tesalonicenses\",\"2Ts\",\"2Tes\"]</td></tr><tr><td>TAMIL</td><td>[\"2 தெசலோனிக்கர்\",\"2Th | 2Thess\",\"2தெசலோனிக்கர்\",\"2Th\",\"2Thess\"]</td></tr><tr><td>THAI</td><td>[\"2 เธสะโลนิกา | เธสะโลนิกาฉบับที่สอง\",\"2Th | 2Thess\",\"2เธสะโลนิกา\",\"เธสะโลนิกาฉบับที่สอง\",\"2Th\",\"2Thess\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"2 Thêxalônica\",\"2Th | 2Thess\",\"2Thêxalônica\",\"2Th\",\"2Thess\"]</td></tr><tr><td rowspan=\"25\">Book 60</td><td>ENGLISH</td><td>[\"1Timothy\",\"1Tim | 1Tm\",\"1Timothy\",\"1Tim\",\"1Tm\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"1 Timótheüs\",\"1Tm\",\"1Timótheüs\"]</td></tr><tr><td>ALBANIAN</td><td>[\"1Timoteut\",\"1Tim | 1Tm\",\"1Timoteut\",\"1Tim\",\"1Tm\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"1تيموثاوس\",\"1Tim | 1Tm\",\"1تيموثاوس\",\"1Tim\",\"1Tm\"]</td></tr><tr><td>CHINESE</td><td>[\"弟茂德前書\",\"1Tim | 1Tm\",\"弟茂德前書\",\"1Tim\",\"1Tm\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"1Tim | 1Tm\",\"\",\"1Tim\",\"1Tm\"]</td></tr><tr><td>CZECH</td><td>[\"1Timoteovi\",\"1Tim | 1Tm\",\"1Timoteovi\",\"1Tim\",\"1Tm\"]</td></tr><tr><td>FILIPINO</td><td>[\"1 Timoteo\",\"1Tim\",\"1Timoteo\"]</td></tr><tr><td>FRENCH</td><td>[\"1Timothée\",\"1Tim | 1Tm\",\"1Timothée\",\"1Tim\",\"1Tm\"]</td></tr><tr><td>GERMAN</td><td>[\"1Timotheus\",\"1Tim | 1Tm\",\"1Timotheus\",\"1Tim\",\"1Tm\"]</td></tr><tr><td>GREEK</td><td>[\"Α Τιμόθεον\",\"1Tim | 1Tm\",\"Ατιμόθεον\",\"1Tim\",\"1Tm\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"1Timóteushoz\",\"1Tim | 1Tm\",\"1Timóteushoz\",\"1Tim\",\"1Tm\"]</td></tr><tr><td>ITALIAN</td><td>[\"1Timoteo\",\"1Tm\",\"1Timoteo\"]</td></tr><tr><td>JAPANESE</td><td>[\"テモテヘの第一の手紙\",\"1Tim | 1Tm\",\"テモテヘの第一の手紙\",\"1Tim\",\"1Tm\"]</td></tr><tr><td>KOREAN</td><td>[\"디모데1서 | 티모테오1서\",\"1Tim | 1Tm\",\"디모데1서\",\"티모테오1서\",\"1Tim\",\"1Tm\"]</td></tr><tr><td>LATIN</td><td>[\"I Timotheum\",\"I Tim\",\"Itimotheum\"]</td></tr><tr><td>POLISH</td><td>[\"1Tymoteusza\",\"1Tm\",\"1Tymoteusza\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"2 Tessalonicenses\",\"1Tim | 1Tm\",\"2Tessalonicenses\",\"1Tim\",\"1Tm\"]</td></tr><tr><td>ROMANIAN</td><td>[\"1Timotei\",\"1Tim | 1Tm\",\"1Timotei\",\"1Tim\",\"1Tm\"]</td></tr><tr><td>RUSSIAN</td><td>[\"1Тимофею\",\"1Tim | 1Tm\",\"1Тимофею\",\"1Tim\",\"1Tm\"]</td></tr><tr><td>SPANISH</td><td>[\"1Timoteo\",\"1Tm | 1Tim\",\"1Timoteo\",\"1Tm\",\"1Tim\"]</td></tr><tr><td>TAMIL</td><td>[\"1 திமொத்தேயு\",\"1Tim | 1Tm\",\"1திமொத்தேயு\",\"1Tim\",\"1Tm\"]</td></tr><tr><td>THAI</td><td>[\"1 ทิโมธี | ทิโมธีฉบับที่หึ่ง\",\"1Tim | 1Tm\",\"1ทิโมธี\",\"ทิโมธีฉบับที่หึ่ง\",\"1Tim\",\"1Tm\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"1 Timôthê\",\"1Tim | 1Tm\",\"1Timôthê\",\"1Tim\",\"1Tm\"]</td></tr><tr><td rowspan=\"25\">Book 61</td><td>ENGLISH</td><td>[\"2Timothy\",\"2Tim | 2Tm\",\"2Timothy\",\"2Tim\",\"2Tm\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"2 Timótheüs\",\"2Tm\",\"2Timótheüs\"]</td></tr><tr><td>ALBANIAN</td><td>[\"2Timoteut\",\"2Tim | 2Tm\",\"2Timoteut\",\"2Tim\",\"2Tm\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"2تيموثاوس\",\"2Tim | 2Tm\",\"2تيموثاوس\",\"2Tim\",\"2Tm\"]</td></tr><tr><td>CHINESE</td><td>[\"弟茂德後書\",\"2Tim | 2Tm\",\"弟茂德後書\",\"2Tim\",\"2Tm\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"2Tim | 2Tm\",\"\",\"2Tim\",\"2Tm\"]</td></tr><tr><td>CZECH</td><td>[\"2Timoteovi\",\"2Tim | 2Tm\",\"2Timoteovi\",\"2Tim\",\"2Tm\"]</td></tr><tr><td>FILIPINO</td><td>[\"2 Timoteo\",\"2Tim\",\"2Timoteo\"]</td></tr><tr><td>FRENCH</td><td>[\"2Timothée\",\"2Tim | 2Tm\",\"2Timothée\",\"2Tim\",\"2Tm\"]</td></tr><tr><td>GERMAN</td><td>[\"2Timotheus\",\"2Tim | 2Tm\",\"2Timotheus\",\"2Tim\",\"2Tm\"]</td></tr><tr><td>GREEK</td><td>[\"Β Τιμόθεον\",\"2Tim | 2Tm\",\"Βτιμόθεον\",\"2Tim\",\"2Tm\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"2Timóteushoz\",\"2Tim | 2Tm\",\"2Timóteushoz\",\"2Tim\",\"2Tm\"]</td></tr><tr><td>ITALIAN</td><td>[\"2Timoteo\",\"2Tm\",\"2Timoteo\"]</td></tr><tr><td>JAPANESE</td><td>[\"テモテヘの第二の手紙\",\"2Tim | 2Tm\",\"テモテヘの第二の手紙\",\"2Tim\",\"2Tm\"]</td></tr><tr><td>KOREAN</td><td>[\"디모데2서 | 티모테오2서\",\"2Tim | 2Tm\",\"디모데2서\",\"티모테오2서\",\"2Tim\",\"2Tm\"]</td></tr><tr><td>LATIN</td><td>[\"II Timotheum\",\"II Tim\",\"Iitimotheum\"]</td></tr><tr><td>POLISH</td><td>[\"2Tymoteusza\",\"2Tm\",\"2Tymoteusza\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"1 Timóteo\",\"2Tim | 2Tm\",\"1Timóteo\",\"2Tim\",\"2Tm\"]</td></tr><tr><td>ROMANIAN</td><td>[\"2Timotei\",\"2Tim | 2Tm\",\"2Timotei\",\"2Tim\",\"2Tm\"]</td></tr><tr><td>RUSSIAN</td><td>[\"2Тимофею\",\"2Tim | 2Tm\",\"2Тимофею\",\"2Tim\",\"2Tm\"]</td></tr><tr><td>SPANISH</td><td>[\"2Timoteo\",\"2Tm | 2Tim\",\"2Timoteo\",\"2Tm\",\"2Tim\"]</td></tr><tr><td>TAMIL</td><td>[\"2 திமொத்தேயு\",\"2Tim | 2Tm\",\"2திமொத்தேயு\",\"2Tim\",\"2Tm\"]</td></tr><tr><td>THAI</td><td>[\"2 ทิโมธี | ทิโมธีฉบับที่สอง\",\"2Tim | 2Tm\",\"2ทิโมธี\",\"ทิโมธีฉบับที่สอง\",\"2Tim\",\"2Tm\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"2 Timôthê\",\"2Tim | 2Tm\",\"2Timôthê\",\"2Tim\",\"2Tm\"]</td></tr><tr><td rowspan=\"25\">Book 62</td><td>ENGLISH</td><td>[\"Titus\",\"Tt\",\"Titus\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Titus\",\"Tt\",\"Titus\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Titi\",\"Tt\",\"Titi\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"تيطس\",\"Tt\",\"تيطس\"]</td></tr><tr><td>CHINESE</td><td>[\"弟鐸書\",\"Tt\",\"弟鐸書\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Tt\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Titovi\",\"Tt\",\"Titovi\"]</td></tr><tr><td>FILIPINO</td><td>[\"Tito\",\"Tito\",\"Tito\"]</td></tr><tr><td>FRENCH</td><td>[\"Tite\",\"Tt\",\"Tite\"]</td></tr><tr><td>GERMAN</td><td>[\"Titus\",\"Tt\",\"Titus\"]</td></tr><tr><td>GREEK</td><td>[\"Τίτον\",\"Tt\",\"Τίτον\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Titushoz\",\"Tt\",\"Titushoz\"]</td></tr><tr><td>ITALIAN</td><td>[\"Tito\",\"Tt\",\"Tito\"]</td></tr><tr><td>JAPANESE</td><td>[\"テトスヘの手紙\",\"Tt\",\"テトスヘの手紙\"]</td></tr><tr><td>KOREAN</td><td>[\"디도서 | 티토서\",\"Tt\",\"디도서\",\"티토서\"]</td></tr><tr><td>LATIN</td><td>[\"Titum\",\"Tt\",\"Titum\"]</td></tr><tr><td>POLISH</td><td>[\"Tytusa\",\"Tt\",\"Tytusa\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"2 Timóteo\",\"Tt\",\"2Timóteo\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Tit\",\"Tt\",\"Tit\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Титу\",\"Tt\",\"Титу\"]</td></tr><tr><td>SPANISH</td><td>[\"Tito\",\"Tt | Tit\",\"Tito\",\"Tt\",\"Tit\"]</td></tr><tr><td>TAMIL</td><td>[\"தீத்து\",\"Tt\",\"தீத்து\"]</td></tr><tr><td>THAI</td><td>[\"ทิตัส\",\"Tt\",\"ทิตัส\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Titô\",\"Tt\",\"Titô\"]</td></tr><tr><td rowspan=\"25\">Book 63</td><td>ENGLISH</td><td>[\"Philemon\",\"Phlm\",\"Philemon\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Filemon\",\"Pl\",\"Filemon\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Filemonit\",\"Phlm\",\"Filemonit\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"فليمون\",\"Phlm\",\"فليمون\"]</td></tr><tr><td>CHINESE</td><td>[\"費肋孟書\",\"Phlm\",\"費肋孟書\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Phlm\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Filemonovi\",\"Phlm\",\"Filemonovi\"]</td></tr><tr><td>FILIPINO</td><td>[\"Filemon\",\"Filem\",\"Filemon\"]</td></tr><tr><td>FRENCH</td><td>[\"Philémon\",\"Phlm\",\"Philémon\"]</td></tr><tr><td>GERMAN</td><td>[\"Philemon\",\"Phlm\",\"Philemon\"]</td></tr><tr><td>GREEK</td><td>[\"Φιλήμονα\",\"Phlm\",\"Φιλήμονα\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Filemonhoz\",\"Phlm\",\"Filemonhoz\"]</td></tr><tr><td>ITALIAN</td><td>[\"Filemone\",\"Fm\",\"Filemone\"]</td></tr><tr><td>JAPANESE</td><td>[\"ピレモンヘの手紙\",\"Phlm\",\"ピレモンヘの手紙\"]</td></tr><tr><td>KOREAN</td><td>[\"빌레몬서 | 필레몬서\",\"Phlm\",\"빌레몬서\",\"필레몬서\"]</td></tr><tr><td>LATIN</td><td>[\"Philemonem\",\"Phlm\",\"Philemonem\"]</td></tr><tr><td>POLISH</td><td>[\"Filemona\",\"Flm\",\"Filemona\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Tito\",\"Phlm\",\"Tito\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Filimon\",\"Phlm\",\"Filimon\"]</td></tr><tr><td>RUSSIAN</td><td>[\"К Филимону\",\"Phlm\",\"Кфилимону\"]</td></tr><tr><td>SPANISH</td><td>[\"Filemón\",\"Flm\",\"Filemón\"]</td></tr><tr><td>TAMIL</td><td>[\"பிலமோன்\",\"Phlm\",\"பிலமோன்\"]</td></tr><tr><td>THAI</td><td>[\"ฟีเลโมน\",\"Phlm\",\"ฟีเลโมน\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Philêmon\",\"Phlm\",\"Philêmon\"]</td></tr><tr><td rowspan=\"25\">Book 64</td><td>ENGLISH</td><td>[\"Hebrews\",\"Heb\",\"Hebrews\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Hebreërs\",\"Hb\",\"Hebreërs\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Hebrenjve\",\"Heb\",\"Hebrenjve\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"عبرانيين\",\"Heb\",\"عبرانيين\"]</td></tr><tr><td>CHINESE</td><td>[\"希伯來書\",\"Heb\",\"希伯來書\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Heb\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"Židům\",\"Heb\",\"Židům\"]</td></tr><tr><td>FILIPINO</td><td>[\"Hebreo | Mga Hebreo\",\"Heb\",\"Hebreo\",\"Mgahebreo\"]</td></tr><tr><td>FRENCH</td><td>[\"Hébreux\",\"Heb\",\"Hébreux\"]</td></tr><tr><td>GERMAN</td><td>[\"Hebräer\",\"Heb\",\"Hebräer\"]</td></tr><tr><td>GREEK</td><td>[\"Εβραίους\",\"Heb\",\"Εβραίους\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Zsidókhoz\",\"Heb\",\"Zsidókhoz\"]</td></tr><tr><td>ITALIAN</td><td>[\"Ebrei\",\"Eb\",\"Ebrei\"]</td></tr><tr><td>JAPANESE</td><td>[\"ヘブル人への手紙\",\"Heb\",\"ヘブル人への手紙\"]</td></tr><tr><td>KOREAN</td><td>[\"히브리서\",\"Heb\",\"히브리서\"]</td></tr><tr><td>LATIN</td><td>[\"Hebræos |  Hebraeos\",\"Heb\",\"Hebræos\",\"Hebraeos\"]</td></tr><tr><td>POLISH</td><td>[\"Hebrajczyków\",\"Hbr\",\"Hebrajczyków\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Hebreus\",\"Heb\",\"Hebreus\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Evrei\",\"Heb\",\"Evrei\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Евреям\",\"Heb\",\"Евреям\"]</td></tr><tr><td>SPANISH</td><td>[\"Hebreos\",\"Hb | Heb\",\"Hebreos\",\"Hb\",\"Heb\"]</td></tr><tr><td>TAMIL</td><td>[\"எபிரேயர்\",\"Heb\",\"எபிரேயர்\"]</td></tr><tr><td>THAI</td><td>[\"ฮีบรู\",\"Heb\",\"ฮีบรู\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Do Thái\",\"Heb\",\"Dothái\"]</td></tr><tr><td rowspan=\"25\">Book 65</td><td>ENGLISH</td><td>[\"James\",\"Jm | Jas\",\"James\",\"Jm\",\"Jas\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Jakobus\",\"Jm\",\"Jakobus\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Jakobit\",\"Jm | Jas\",\"Jakobit\",\"Jm\",\"Jas\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"يعقوب\",\"Jm | Jas\",\"يعقوب\",\"Jm\",\"Jas\"]</td></tr><tr><td>CHINESE</td><td>[\"雅各伯書\",\"Jm | Jas\",\"雅各伯書\",\"Jm\",\"Jas\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Jm | Jas\",\"\",\"Jm\",\"Jas\"]</td></tr><tr><td>CZECH</td><td>[\"Jakubův\",\"Jm | Jas\",\"Jakubův\",\"Jm\",\"Jas\"]</td></tr><tr><td>FILIPINO</td><td>[\"Santiago\",\"San\",\"Santiago\"]</td></tr><tr><td>FRENCH</td><td>[\"Jacques\",\"Jm | Jas\",\"Jacques\",\"Jm\",\"Jas\"]</td></tr><tr><td>GERMAN</td><td>[\"Jakobus\",\"Jm | Jas\",\"Jakobus\",\"Jm\",\"Jas\"]</td></tr><tr><td>GREEK</td><td>[\"Ιάκωβος\",\"Jm | Jas\",\"Ιάκωβος\",\"Jm\",\"Jas\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Jakab\",\"Jm | Jas\",\"Jakab\",\"Jm\",\"Jas\"]</td></tr><tr><td>ITALIAN</td><td>[\"Giacomo\",\"Gc\",\"Giacomo\"]</td></tr><tr><td>JAPANESE</td><td>[\"ヤコブの手紙\",\"Jm | Jas\",\"ヤコブの手紙\",\"Jm\",\"Jas\"]</td></tr><tr><td>KOREAN</td><td>[\"야고보서\",\"Jm | Jas\",\"야고보서\",\"Jm\",\"Jas\"]</td></tr><tr><td>LATIN</td><td>[\"Iacobi\",\"Iac\",\"Iacobi\"]</td></tr><tr><td>POLISH</td><td>[\"Jakuba\",\"Jk\",\"Jakuba\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Tiago\",\"Jm | Jas\",\"Tiago\",\"Jm\",\"Jas\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Iacob\",\"Jm | Jas\",\"Iacob\",\"Jm\",\"Jas\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Иакова\",\"Jm | Jas\",\"Иакова\",\"Jm\",\"Jas\"]</td></tr><tr><td>SPANISH</td><td>[\"Santiago\",\"St\",\"Santiago\"]</td></tr><tr><td>TAMIL</td><td>[\"யாக்கோபு\",\"Jm | Jas\",\"யாக்கோபு\",\"Jm\",\"Jas\"]</td></tr><tr><td>THAI</td><td>[\"ยากอบ\",\"Jm | Jas\",\"ยากอบ\",\"Jm\",\"Jas\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Giacôbê\",\"Jm | Jas\",\"Giacôbê\",\"Jm\",\"Jas\"]</td></tr><tr><td rowspan=\"25\">Book 66</td><td>ENGLISH</td><td>[\"1 Peter\",\"1Pt | 1Pet\",\"1Peter\",\"1Pt\",\"1Pet\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"1 Petrus\",\"1Pt\",\"1Petrus\"]</td></tr><tr><td>ALBANIAN</td><td>[\"1Pjetrit\",\"1Pt | 1Pet\",\"1Pjetrit\",\"1Pt\",\"1Pet\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"1بطرس\",\"1Pt | 1Pet\",\"1بطرس\",\"1Pt\",\"1Pet\"]</td></tr><tr><td>CHINESE</td><td>[\"伯多祿前書\",\"1Pt | 1Pet\",\"伯多祿前書\",\"1Pt\",\"1Pet\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"1Pt | 1Pet\",\"\",\"1Pt\",\"1Pet\"]</td></tr><tr><td>CZECH</td><td>[\"1Petrův\",\"1Pt | 1Pet\",\"1Petrův\",\"1Pt\",\"1Pet\"]</td></tr><tr><td>FILIPINO</td><td>[\"1 Pedro\",\"1Ped\",\"1Pedro\"]</td></tr><tr><td>FRENCH</td><td>[\"1Pierre\",\"1Pt | 1Pet\",\"1Pierre\",\"1Pt\",\"1Pet\"]</td></tr><tr><td>GERMAN</td><td>[\"1Petrus\",\"1Pt | 1Pet\",\"1Petrus\",\"1Pt\",\"1Pet\"]</td></tr><tr><td>GREEK</td><td>[\"Α Πέτρου\",\"1Pt | 1Pet\",\"Απέτρου\",\"1Pt\",\"1Pet\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"1Péter\",\"1Pt | 1Pet\",\"1Péter\",\"1Pt\",\"1Pet\"]</td></tr><tr><td>ITALIAN</td><td>[\"1Pietro\",\"1Pt\",\"1Pietro\"]</td></tr><tr><td>JAPANESE</td><td>[\"ペテロの第一の手紙\",\"1Pt | 1Pet\",\"ペテロの第一の手紙\",\"1Pt\",\"1Pet\"]</td></tr><tr><td>KOREAN</td><td>[\"베드로1서\",\"1Pt | 1Pet\",\"베드로1서\",\"1Pt\",\"1Pet\"]</td></tr><tr><td>LATIN</td><td>[\"I Petri\",\"I Pet\",\"Ipetri\"]</td></tr><tr><td>POLISH</td><td>[\"1Piotra\",\"1P\",\"1Piotra\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"1 Pedro\",\"1Pt | 1Pet\",\"1Pedro\",\"1Pt\",\"1Pet\"]</td></tr><tr><td>ROMANIAN</td><td>[\"1Petru\",\"1Pt | 1Pet\",\"1Petru\",\"1Pt\",\"1Pet\"]</td></tr><tr><td>RUSSIAN</td><td>[\"1Петра\",\"1Pt | 1Pet\",\"1Петра\",\"1Pt\",\"1Pet\"]</td></tr><tr><td>SPANISH</td><td>[\"1Pedro\",\"1P | 1Pe\",\"1Pedro\",\"1P\",\"1Pe\"]</td></tr><tr><td>TAMIL</td><td>[\"1 பேதுரு\",\"1Pt | 1Pet\",\"1பேதுரு\",\"1Pt\",\"1Pet\"]</td></tr><tr><td>THAI</td><td>[\"1 เปโตร | เปโตรฉบับที่หึ่ง\",\"1Pt | 1Pet\",\"1เปโตร\",\"เปโตรฉบับที่หึ่ง\",\"1Pt\",\"1Pet\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"1 Phêrô\",\"1Pt | 1Pet\",\"1Phêrô\",\"1Pt\",\"1Pet\"]</td></tr><tr><td rowspan=\"25\">Book 67</td><td>ENGLISH</td><td>[\"2 Peter\",\"2Pt | 2Pet\",\"2Peter\",\"2Pt\",\"2Pet\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"2 Petrus\",\"2Pt\",\"2Petrus\"]</td></tr><tr><td>ALBANIAN</td><td>[\"2Pjetrit\",\"2Pt | 2Pet\",\"2Pjetrit\",\"2Pt\",\"2Pet\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"2بطرس\",\"2Pt | 2Pet\",\"2بطرس\",\"2Pt\",\"2Pet\"]</td></tr><tr><td>CHINESE</td><td>[\"伯多祿後書\",\"2Pt | 2Pet\",\"伯多祿後書\",\"2Pt\",\"2Pet\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"2Pt | 2Pet\",\"\",\"2Pt\",\"2Pet\"]</td></tr><tr><td>CZECH</td><td>[\"2Petrův\",\"2Pt | 2Pet\",\"2Petrův\",\"2Pt\",\"2Pet\"]</td></tr><tr><td>FILIPINO</td><td>[\"2 Pedro\",\"2Ped\",\"2Pedro\"]</td></tr><tr><td>FRENCH</td><td>[\"2Pierre\",\"2Pt | 2Pet\",\"2Pierre\",\"2Pt\",\"2Pet\"]</td></tr><tr><td>GERMAN</td><td>[\"2Petrus\",\"2Pt | 2Pet\",\"2Petrus\",\"2Pt\",\"2Pet\"]</td></tr><tr><td>GREEK</td><td>[\"Β Πέτρου\",\"2Pt | 2Pet\",\"Βπέτρου\",\"2Pt\",\"2Pet\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"2Péter\",\"2Pt | 2Pet\",\"2Péter\",\"2Pt\",\"2Pet\"]</td></tr><tr><td>ITALIAN</td><td>[\"2Pietro\",\"2Pt\",\"2Pietro\"]</td></tr><tr><td>JAPANESE</td><td>[\"ペテロの第二の手紙\",\"2Pt | 2Pet\",\"ペテロの第二の手紙\",\"2Pt\",\"2Pet\"]</td></tr><tr><td>KOREAN</td><td>[\"베드로2서\",\"2Pt | 2Pet\",\"베드로2서\",\"2Pt\",\"2Pet\"]</td></tr><tr><td>LATIN</td><td>[\"II Petri\",\"II Pet\",\"Iipetri\"]</td></tr><tr><td>POLISH</td><td>[\"2Piotra\",\"2P\",\"2Piotra\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"2 Pedro\",\"2Pt | 2Pet\",\"2Pedro\",\"2Pt\",\"2Pet\"]</td></tr><tr><td>ROMANIAN</td><td>[\"2Petru\",\"2Pt | 2Pet\",\"2Petru\",\"2Pt\",\"2Pet\"]</td></tr><tr><td>RUSSIAN</td><td>[\"2Петра\",\"2Pt | 2Pet\",\"2Петра\",\"2Pt\",\"2Pet\"]</td></tr><tr><td>SPANISH</td><td>[\"2Pedro\",\"2P | 2Pe\",\"2Pedro\",\"2P\",\"2Pe\"]</td></tr><tr><td>TAMIL</td><td>[\"2 பேதுரு\",\"2Pt | 2Pet\",\"2பேதுரு\",\"2Pt\",\"2Pet\"]</td></tr><tr><td>THAI</td><td>[\"2 เปโตร | เปโตรฉบับที่สอง\",\"2Pt | 2Pet\",\"2เปโตร\",\"เปโตรฉบับที่สอง\",\"2Pt\",\"2Pet\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"2 Phêrô\",\"2Pt | 2Pet\",\"2Phêrô\",\"2Pt\",\"2Pet\"]</td></tr><tr><td rowspan=\"25\">Book 68</td><td>ENGLISH</td><td>[\"1 John\",\"1Jn\",\"1John\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"1 Johannes\",\"1Jh\",\"1Johannes\"]</td></tr><tr><td>ALBANIAN</td><td>[\"1Gjonit\",\"1Jn\",\"1Gjonit\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"1يوحنا\",\"1Jn\",\"1يوحنا\"]</td></tr><tr><td>CHINESE</td><td>[\"若望一書\",\"1Jn\",\"若望一書\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"1Jn\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"1Janův\",\"1Jn\",\"1Janův\"]</td></tr><tr><td>FILIPINO</td><td>[\"1 Juan\",\"1Jn\",\"1Juan\"]</td></tr><tr><td>FRENCH</td><td>[\"1Jean\",\"1Jn\",\"1Jean\"]</td></tr><tr><td>GERMAN</td><td>[\"1Johannes\",\"1Jn\",\"1Johannes\"]</td></tr><tr><td>GREEK</td><td>[\"Α Ιωάννου\",\"1Jn\",\"Αιωάννου\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"1János\",\"1Jn\",\"1János\"]</td></tr><tr><td>ITALIAN</td><td>[\"1Giovanni\",\"1Gv\",\"1Giovanni\"]</td></tr><tr><td>JAPANESE</td><td>[\"ヨハネの第一の手紙\",\"1Jn\",\"ヨハネの第一の手紙\"]</td></tr><tr><td>KOREAN</td><td>[\"요한1서\",\"1Jn\",\"요한1서\"]</td></tr><tr><td>LATIN</td><td>[\"I Ioannis | I Iohannis | I Joannis | I Johannis\",\"I Ioh\",\"Iioannis\",\"Iiohannis\",\"Ijoannis\",\"Ijohannis\"]</td></tr><tr><td>POLISH</td><td>[\"1Jana\",\"1J\",\"1Jana\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Judas\",\"1Jn\",\"Judas\"]</td></tr><tr><td>ROMANIAN</td><td>[\"1Ioan\",\"1Jn\",\"1Ioan\"]</td></tr><tr><td>RUSSIAN</td><td>[\"1Иоанна\",\"1Jn\",\"1Иоанна\"]</td></tr><tr><td>SPANISH</td><td>[\"1Juan\",\"1Jn\",\"1Juan\"]</td></tr><tr><td>TAMIL</td><td>[\"1 யோவான்\",\"1Jn\",\"1யோவான்\"]</td></tr><tr><td>THAI</td><td>[\"1 ยอห์น | ยอห์นฉบับที่หึ่ง\",\"1Jn\",\"1ยอห์น\",\"ยอห์นฉบับที่หึ่ง\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"1 Gioan\",\"1Jn\",\"1Gioan\"]</td></tr><tr><td rowspan=\"25\">Book 69</td><td>ENGLISH</td><td>[\"2 John\",\"2Jn\",\"2John\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"2 Johannes\",\"2Jh\",\"2Johannes\"]</td></tr><tr><td>ALBANIAN</td><td>[\"2Gjonit\",\"2Jn\",\"2Gjonit\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"2يوحنا\",\"2Jn\",\"2يوحنا\"]</td></tr><tr><td>CHINESE</td><td>[\"若望二書\",\"2Jn\",\"若望二書\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"2Jn\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"2Janův\",\"2Jn\",\"2Janův\"]</td></tr><tr><td>FILIPINO</td><td>[\"2 Juan\",\"2Jn\",\"2Juan\"]</td></tr><tr><td>FRENCH</td><td>[\"2Jean\",\"2Jn\",\"2Jean\"]</td></tr><tr><td>GERMAN</td><td>[\"2Johannes\",\"2Jn\",\"2Johannes\"]</td></tr><tr><td>GREEK</td><td>[\"Β Ιωάννου\",\"2Jn\",\"Βιωάννου\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"2János\",\"2Jn\",\"2János\"]</td></tr><tr><td>ITALIAN</td><td>[\"2Giovanni\",\"2Gv\",\"2Giovanni\"]</td></tr><tr><td>JAPANESE</td><td>[\"ヨハネの第二の手紙\",\"2Jn\",\"ヨハネの第二の手紙\"]</td></tr><tr><td>KOREAN</td><td>[\"요한2서\",\"2Jn\",\"요한2서\"]</td></tr><tr><td>LATIN</td><td>[\"II Ioannis | II Iohannis | II Joannis | II Johannis\",\"II Ioh\",\"Iiioannis\",\"Iiiohannis\",\"Iijoannis\",\"Iijohannis\"]</td></tr><tr><td>POLISH</td><td>[\"2Jana\",\"2J\",\"2Jana\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"1 João\",\"2Jn\",\"1João\"]</td></tr><tr><td>ROMANIAN</td><td>[\"2Ioan\",\"2Jn\",\"2Ioan\"]</td></tr><tr><td>RUSSIAN</td><td>[\"2Иоанна\",\"2Jn\",\"2Иоанна\"]</td></tr><tr><td>SPANISH</td><td>[\"2Juan\",\"2Jn\",\"2Juan\"]</td></tr><tr><td>TAMIL</td><td>[\"2 யோவான்\",\"2Jn\",\"2யோவான்\"]</td></tr><tr><td>THAI</td><td>[\"2 ยอห์น | ยอห์นฉบับที่สอง\",\"2Jn\",\"2ยอห์น\",\"ยอห์นฉบับที่สอง\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"2 Gioan\",\"2Jn\",\"2Gioan\"]</td></tr><tr><td rowspan=\"25\">Book 70</td><td>ENGLISH</td><td>[\"3 John\",\"3Jn\",\"3John\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"3 Johannes\",\"3Jh\",\"3Johannes\"]</td></tr><tr><td>ALBANIAN</td><td>[\"3Gjonit\",\"3Jn\",\"3Gjonit\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"3يوحنا\",\"3Jn\",\"3يوحنا\"]</td></tr><tr><td>CHINESE</td><td>[\"若望三書\",\"3Jn\",\"若望三書\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"3Jn\",\"\"]</td></tr><tr><td>CZECH</td><td>[\"3Janův\",\"3Jn\",\"3Janův\"]</td></tr><tr><td>FILIPINO</td><td>[\"3 Juan\",\"3Jn\",\"3Juan\"]</td></tr><tr><td>FRENCH</td><td>[\"3Jean\",\"3Jn\",\"3Jean\"]</td></tr><tr><td>GERMAN</td><td>[\"3Johannes\",\"3Jn\",\"3Johannes\"]</td></tr><tr><td>GREEK</td><td>[\"Γ Ιωάννου\",\"3Jn\",\"Γιωάννου\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"3János\",\"3Jn\",\"3János\"]</td></tr><tr><td>ITALIAN</td><td>[\"3Giovanni\",\"3Gv\",\"3Giovanni\"]</td></tr><tr><td>JAPANESE</td><td>[\"ヨハネの第三の手紙\",\"3Jn\",\"ヨハネの第三の手紙\"]</td></tr><tr><td>KOREAN</td><td>[\"요한3서\",\"3Jn\",\"요한3서\"]</td></tr><tr><td>LATIN</td><td>[\"III Ioannis | III Iohannis | III Joannis | III Johannis\",\"III Ioh\",\"Iiiioannis\",\"Iiiiohannis\",\"Iiijoannis\",\"Iiijohannis\"]</td></tr><tr><td>POLISH</td><td>[\"3Jana\",\"3J\",\"3Jana\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"2 João\",\"3Jn\",\"2João\"]</td></tr><tr><td>ROMANIAN</td><td>[\"3Ioan\",\"3Jn\",\"3Ioan\"]</td></tr><tr><td>RUSSIAN</td><td>[\"3Иоанна\",\"3Jn\",\"3Иоанна\"]</td></tr><tr><td>SPANISH</td><td>[\"3Juan\",\"3Jn\",\"3Juan\"]</td></tr><tr><td>TAMIL</td><td>[\"3 யோவான்\",\"3Jn\",\"3யோவான்\"]</td></tr><tr><td>THAI</td><td>[\"3 ยอห์น | ยอห์นฉบับที่สาม\",\"3Jn\",\"3ยอห์น\",\"ยอห์นฉบับที่สาม\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"3 Gioan\",\"3Jn\",\"3Gioan\"]</td></tr><tr><td rowspan=\"25\">Book 71</td><td>ENGLISH</td><td>[\"Jude\",\"Jud | Jd\",\"Jude\",\"Jud\",\"Jd\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Judas\",\"Jd\",\"Judas\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Juda\",\"Jud | Jd\",\"Juda\",\"Jud\",\"Jd\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"يهوذا\",\"Jud | Jd\",\"يهوذا\",\"Jud\",\"Jd\"]</td></tr><tr><td>CHINESE</td><td>[\"猶達書\",\"Jud | Jd\",\"猶達書\",\"Jud\",\"Jd\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Jud | Jd\",\"\",\"Jud\",\"Jd\"]</td></tr><tr><td>CZECH</td><td>[\"Judův\",\"Jud | Jd\",\"Judův\",\"Jud\",\"Jd\"]</td></tr><tr><td>FILIPINO</td><td>[\"Judas\",\"Ju\",\"Judas\"]</td></tr><tr><td>FRENCH</td><td>[\"Jude\",\"Jud | Jd\",\"Jude\",\"Jud\",\"Jd\"]</td></tr><tr><td>GERMAN</td><td>[\"Judas\",\"Jud | Jd\",\"Judas\",\"Jud\",\"Jd\"]</td></tr><tr><td>GREEK</td><td>[\"Ιούδας\",\"Jud | Jd\",\"Ιούδας\",\"Jud\",\"Jd\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Júdás\",\"Jud | Jd\",\"Júdás\",\"Jud\",\"Jd\"]</td></tr><tr><td>ITALIAN</td><td>[\"Giuda\",\"Gd\",\"Giuda\"]</td></tr><tr><td>JAPANESE</td><td>[\"ユダの手紙\",\"Jud | Jd\",\"ユダの手紙\",\"Jud\",\"Jd\"]</td></tr><tr><td>KOREAN</td><td>[\"유다서\",\"Jud | Jd\",\"유다서\",\"Jud\",\"Jd\"]</td></tr><tr><td>LATIN</td><td>[\"Iudæ | Iudae | Judæ | Judae\",\"Iud\",\"Iudæ\",\"Iudae\",\"Judæ\",\"Judae\"]</td></tr><tr><td>POLISH</td><td>[\"Judy\",\"Jud\",\"Judy\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"3 João\",\"Jud | Jd\",\"3João\",\"Jud\",\"Jd\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Iuda\",\"Jud | Jd\",\"Iuda\",\"Jud\",\"Jd\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Иуда\",\"Jud | Jd\",\"Иуда\",\"Jud\",\"Jd\"]</td></tr><tr><td>SPANISH</td><td>[\"Judas\",\"Jd | Jud\",\"Judas\",\"Jd\",\"Jud\"]</td></tr><tr><td>TAMIL</td><td>[\"யூதா\",\"Jud | Jd\",\"யூதா\",\"Jud\",\"Jd\"]</td></tr><tr><td>THAI</td><td>[\"ยูดา\",\"Jud | Jd\",\"ยูดา\",\"Jud\",\"Jd\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Giuđa\",\"Jud | Jd\",\"Giuđa\",\"Jud\",\"Jd\"]</td></tr><tr><td rowspan=\"25\">Book 72</td><td>ENGLISH</td><td>[\"Revelation | Apocalypse\",\"Rev | Apoc\",\"Revelation\",\"Apocalypse\",\"Rev\",\"Apoc\"]</td></tr><tr><td>AFRIKAANS</td><td>[\"Openbaring | Die openbaring\",\"Rv\",\"Openbaring\",\"Dieopenbaring\"]</td></tr><tr><td>ALBANIAN</td><td>[\"Zbulesa\",\"Rev | Apoc\",\"Zbulesa\",\"Rev\",\"Apoc\"]</td></tr><tr><td>AMHARIC</td><td>[\"\",\"\",\"\"]</td></tr><tr><td>ARABIC</td><td>[\"رؤيا\",\"Rev | Apoc\",\"رؤيا\",\"Rev\",\"Apoc\"]</td></tr><tr><td>CHINESE</td><td>[\"若望默示錄\",\"Rev | Apoc\",\"若望默示錄\",\"Rev\",\"Apoc\"]</td></tr><tr><td>CROATIAN</td><td>[\"\",\"Rev | Apoc\",\"\",\"Rev\",\"Apoc\"]</td></tr><tr><td>CZECH</td><td>[\"Zjevení | Apokalypsa\",\"Rev | Apoc\",\"Zjevení\",\"Apokalypsa\",\"Rev\",\"Apoc\"]</td></tr><tr><td>FILIPINO</td><td>[\"Pahayag\",\"Pah\",\"Pahayag\"]</td></tr><tr><td>FRENCH</td><td>[\"Apocalypse\",\"Rev | Apoc\",\"Apocalypse\",\"Rev\",\"Apoc\"]</td></tr><tr><td>GERMAN</td><td>[\"Offenbarung\",\"Rev | Apoc\",\"Offenbarung\",\"Rev\",\"Apoc\"]</td></tr><tr><td>GREEK</td><td>[\"Αποκάλυψη\",\"Rev | Apoc\",\"Αποκάλυψη\",\"Rev\",\"Apoc\"]</td></tr><tr><td>HUNGARIAN</td><td>[\"Jelenések\",\"Rev | Apoc\",\"Jelenések\",\"Rev\",\"Apoc\"]</td></tr><tr><td>ITALIAN</td><td>[\"Apocalisse\",\"Ap\",\"Apocalisse\"]</td></tr><tr><td>JAPANESE</td><td>[\"ヨハネの黙示録\",\"Rev | Apoc\",\"ヨハネの黙示録\",\"Rev\",\"Apoc\"]</td></tr><tr><td>KOREAN</td><td>[\"요한계시록 | 요한묵시록\",\"Rev | Apoc\",\"요한계시록\",\"요한묵시록\",\"Rev\",\"Apoc\"]</td></tr><tr><td>LATIN</td><td>[\"Apocalypsis\",\"Apoc\",\"Apocalypsis\"]</td></tr><tr><td>POLISH</td><td>[\"Apokalipsa\",\"Ap\",\"Apokalipsa\"]</td></tr><tr><td>PORTUGUESE</td><td>[\"Apocalipse\",\"Rev | Apoc\",\"Apocalipse\",\"Rev\",\"Apoc\"]</td></tr><tr><td>ROMANIAN</td><td>[\"Apocalipsa\",\"Rev | Apoc\",\"Apocalipsa\",\"Rev\",\"Apoc\"]</td></tr><tr><td>RUSSIAN</td><td>[\"Откровение\",\"Rev | Apoc\",\"Откровение\",\"Rev\",\"Apoc\"]</td></tr><tr><td>SPANISH</td><td>[\"Apocalipsis\",\"Ap\",\"Apocalipsis\"]</td></tr><tr><td>TAMIL</td><td>[\"திருவெளிப்பாடு\",\"Rev | Apoc\",\"திருவெளிப்பாடு\",\"Rev\",\"Apoc\"]</td></tr><tr><td>THAI</td><td>[\"วิวรณ์\",\"Rev | Apoc\",\"วิวรณ์\",\"Rev\",\"Apoc\"]</td></tr><tr><td>VIETNAMESE</td><td>[\"Khải Huyền\",\"Rev | Apoc\",\"Khảihuyền\",\"Rev\",\"Apoc\"]</td></tr></tbody></table></div><div class=\"errors\" id=\"errors\"></div><input type=\"hidden\" value=\"3.0\" name=\"ENDPOINT_VERSION\"></body></html>"
+          },
+          "MetadataVersionIndexHTML": {
+            "type": "string",
+            "example": "<html><head></head><body><div class=\"results\" id=\"results\"><table id=\"VersionIndexesTbl\" class=\"VersionIndexesTbl\"><thead><tr><td>VERSION</td><td>BIBLEBOOKS</td><td>ABBREVIATIONS</td><td>CHAPTER_LIMIT</td><td>VERSE_LIMIT</td><td>BOOK_NUM</td></tr></thead><tbody><tr><td>NABRE</td><td>[\"Genesis\",\"Exodus\",\"Leviticus\",\"Numbers\",\"Deuteronomy\",\"Joshua\",\"Judges\",\"Ruth\",\"1Samuel\",\"2Samuel\",\"1Kings\",\"2Kings\",\"1Chronicles\",\"2Chronicles\",\"Ezra\",\"Nehemiah\",\"Tobit\",\"Judith\",\"Esther\",\"1Maccabees\",\"2Maccabees\",\"Job\",\"Psalms\",\"Proverbs\",\"Ecclesiastes\",\"Song of Songs\",\"Wisdom\",\"Sirach\",\"Isaiah\",\"Jeremiah\",\"Lamentations\",\"Baruch\",\"Ezekiel\",\"Daniel\",\"Hosea\",\"Joel\",\"Amos\",\"Obadiah\",\"Jonah\",\"Micah\",\"Nahum\",\"Habakkuk\",\"Zephaniah\",\"Haggai\",\"Zechariah\",\"Malachi\",\"Matthew\",\"Mark\",\"Luke\",\"John\",\"Acts of the Apostles\",\"Romans\",\"1Corinthians\",\"2Corinthians\",\"Galatians\",\"Ephesians\",\"Philippians\",\"Colossians\",\"1Thessalonians\",\"2Thessalonians\",\"1Timothy\",\"2Timothy\",\"Titus\",\"Philemon\",\"Hebrews\",\"James\",\"1Peter\",\"2Peter\",\"1John\",\"2John\",\"3John\",\"Jude\",\"Revelation\"]</td><td>[\"Gn\",\"Ex\",\"Lv\",\"Nm\",\"Dt\",\"Jos\",\"Jgs\",\"Ru\",\"1Sm\",\"2Sm\",\"1Kgs\",\"2Kgs\",\"1Chr\",\"2Chr\",\"Ezr\",\"Neh\",\"Tb\",\"Jdt\",\"Est\",\"1Mc\",\"2Mc\",\"Jb\",\"Ps\",\"Prv\",\"Eccl\",\"Sg\",\"Wis\",\"Sir\",\"Is\",\"Jer\",\"Lam\",\"Bar\",\"Ez\",\"Dn\",\"Hos\",\"Jl\",\"Am\",\"Ob\",\"Jon\",\"Mi\",\"Na\",\"Hb\",\"Zep\",\"Hg\",\"Zec\",\"Mal\",\"Mt\",\"Mk\",\"Lk\",\"Jn\",\"Acts\",\"Rom\",\"1Cor\",\"2Cor\",\"Gal\",\"Eph\",\"Phil\",\"Col\",\"1Thes\",\"2Thes\",\"1Tm\",\"2Tm\",\"Ti\",\"Phlm\",\"Heb\",\"Jas\",\"1Pt\",\"2Pt\",\"1Jn\",\"2Jn\",\"3Jn\",\"Jude\",\"Rev\"]</td><td>[50,40,27,36,34,24,21,4,31,24,22,25,29,36,10,13,14,16,20,16,15,42,150,31,12,8,19,51,66,52,5,6,48,14,14,4,9,1,4,7,3,3,3,2,14,3,28,16,24,21,28,16,16,13,6,6,4,4,5,3,6,4,3,1,13,5,5,3,5,1,1,1,22]</td><td>[[31,25,24,26,32,22,24,22,29,32,32,20,18,24,21,16,27,33,38,18,34,24,20,67,34,35,46,22,35,43,54,33,20,31,29,43,36,30,23,23,57,38,34,34,28,34,31,22,33,26],[22,25,22,31,23,30,29,28,35,29,10,51,22,31,27,36,16,27,25,26,37,30,33,18,40,37,21,43,46,38,18,35,23,35,35,38,29,31,43,38],[17,16,17,35,26,23,38,36,24,20,47,8,59,57,33,34,16,30,37,27,24,33,44,23,55,46,34],[54,34,51,49,31,27,89,26,23,36,35,16,33,45,41,35,28,32,22,29,35,41,30,25,18,65,23,31,39,17,54,42,56,29,34,13],[46,37,29,49,33,25,26,20,29,22,32,31,19,29,23,22,20,22,21,20,23,29,26,22,19,19,26,69,28,20,30,52,29,12],[18,24,17,24,15,27,26,35,27,43,23,24,33,15,63,10,18,28,51,9,45,34,16,33],[36,23,31,24,31,40,25,35,57,18,40,15,25,20,20,31,13,31,30,48,25],[22,23,18,22],[28,36,21,22,12,21,17,22,27,27,15,25,23,52,35,23,58,30,24,42,16,23,28,23,44,25,12,25,11,31,13],[27,32,39,12,25,23,29,18,13,19,27,31,39,33,37,23,29,32,44,26,22,51,39,25],[53,46,28,20,32,38,51,66,28,29,43,33,34,31,34,34,24,46,21,43,29,54],[18,25,27,44,27,33,20,29,37,36,20,22,25,29,38,20,41,37,37,21,26,20,37,20,30],[54,55,24,43,41,66,40,40,44,14,47,41,14,17,29,43,27,17,19,8,30,19,32,31,31,32,34,21,30],[18,17,17,22,14,42,22,18,31,19,23,16,23,14,19,14,19,34,11,37,20,12,21,27,28,23,9,27,36,27,21,33,25,33,27,23],[11,70,13,24,17,22,28,36,15,44],[11,20,38,17,19,19,72,18,37,40,36,47,31],[22,14,17,21,1,18,17,21,6,13,18,22,18,15],[16,28,10,15,24,21,32,36,14,23,23,20,20,19,14,25],[22,23,15,17,14,14,10,17,32,3,22,23,15,17,14,14,10,17,32,3],[64,70,60,61,68,63,50,32,73,89,74,53,53,49,41,24],[36,32,40,50,27,31,42,36,29,38,38,46,26,46,39],[22,13,26,21,27,30,21,22,10,22,20,25,28,22,35,22,16,21,29,29,34,30,17,25,6,14,23,28,25,31,40,22,33,37,16,33,24,41,30,32,26,17],[6,11,9,9,13,11,18,10,21,18,7,9,6,7,5,11,15,51,15,10,14,32,6,10,22,12,14,9,11,13,25,11,22,23,28,13,40,23,14,18,14,12,5,27,18,12,10,15,21,23,21,11,7,9,24,14,12,12,18,14,9,13,12,11,14,20,8,36,37,6,24,20,28,23,11,13,21,72,13,20,17,8,19,13,14,17,7,19,53,17,16,16,5,23,11,13,12,9,9,5,8,29,22,35,45,48,43,14,31,7,10,10,9,8,18,19,2,29,176,7,8,9,4,8,5,6,5,6,8,8,3,18,3,3,21,26,9,8,24,14,10,8,12,15,21,10,20,14,9,6],[33,22,35,27,23,35,27,36,18,32,31,28,25,35,33,33,28,24,29,30,31,29,35,34,28,28,27,28,27,33,31],[18,26,22,17,19,12,29,17,18,20,10,14],[17,17,11,16,16,12,14,14],[16,24,19,20,23,25,30,21,18,21,12,27,19,31,19,29,21,25,22],[30,18,31,31,15,37,36,19,18,31,34,18,26,27,20,30,32,33,30,31,28,27,27,33,26,29,30,26,28,25,31,24,33,31,26,31,31,34,35,30,22,25,33,23,26,20,25,25,16,29,30],[31,22,26,6,30,13,25,23,20,34,16,6,22,32,9,14,14,7,25,6,17,25,18,23,12,21,13,29,24,33,9,20,24,17,10,22,38,22,8,31,29,25,28,28,25,13,15,22,26,11,23,15,12,17,13,12,21,14,21,22,11,12,19,11,25,24],[19,37,25,31,31,30,34,23,25,25,23,17,27,22,21,21,27,23,15,18,14,30,40,10,38,24,22,17,32,24,40,44,26,22,19,32,21,28,18,16,18,22,13,30,5,28,7,47,39,46,64,34],[22,22,66,22,22],[22,35,38,37,9,72],[28,10,27,17,17,14,27,18,11,22,25,28,23,23,8,63,24,32,14,44,37,31,49,27,17,21,36,26,21,26,18,32,33,31,15,38,28,23,29,49,26,20,27,31,25,24,23,35],[21,49,100,34,30,29,28,27,27,1,45,13,64,42],[9,25,5,19,15,11,16,14,17,15,11,15,15,10],[20,27,5,21],[15,16,15,13,27,14,17,14,15],[21],[16,11,10,11],[16,13,12,14,14,16,20],[14,14,19],[17,20,19],[18,15,20],[15,23],[17,17,10,14,11,15,14,23,17,12,17,14,9,21],[14,17,24],[25,23,17,25,48,34,29,34,38,42,30,50,58,36,39,28,27,35,30,34,46,46,39,51,46,75,66,20],[45,28,35,41,43,56,37,38,50,52,33,44,37,72,47,20],[80,52,38,44,39,49,50,56,62,42,54,59,35,35,32,31,37,43,48,47,38,71,56,53],[51,25,36,54,47,71,52,59,41,42,57,50,38,31,27,33,26,40,42,31,25],[26,47,26,37,42,15,60,40,43,49,30,25,52,28,41,40,34,28,40,38,40,30,35,27,27,32,44,31],[32,29,31,25,21,23,25,39,33,21,36,21,14,23,33,27],[31,16,23,21,13,20,40,13,27,33,34,31,13,40,58,24],[24,17,18,18,21,18,16,24,15,18,33,21,13],[24,21,29,31,26,18],[23,22,21,32,33,24],[30,30,21,23],[29,23,25,18],[10,20,13,18,28],[12,17,18],[20,15,16,16,25,21],[18,26,17,22],[16,15,15],[25],[14,18,19,16,14,20,28,13,28,39,40,29,25],[27,26,18,17,20],[25,25,22,19,14],[21,22,18],[10,29,24,21,21],[13],[15],[25],[20,29,22,11,14,17,17,13,21,11,19,18,18,20,8,21,18,24,21,15,27,21]]</td><td>[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73]</td></tr></tbody></table></div><div class=\"errors\" id=\"errors\"></div><input type=\"hidden\" value=\"3.0\" name=\"ENDPOINT_VERSION\"></body></html>"
+          },
+          "KeywordSearchResponseHTML": {
+            "type": "string",
+            "example": "<html><head></head><body><div class=\"results\" id=\"results\"><table id=\"SearchResultsTbl\" class=\"SearchResultsTbl\"><tbody><tr><td>1</td><td>2</td><td>1Maccabees</td><td>9</td><td></td><td>7</td><td></td><td></td><td>When Judas saw that his army was melting away just as the battle was imminent, he was brokenhearted, because he had no time to gather them together. </td><td></td><td></td><td></td><td>NABRE</td><td>1Mc</td><td>19</td><td>20</td><td>1Mc9:7</td></tr><tr><td>1</td><td>3</td><td>Psalms</td><td>34</td><td></td><td>19</td><td></td><td></td><td>&lt;po&gt;The L&lt;sm&gt;ORD&lt;/sm&gt; is close to the brokenhearted,&lt;/po&gt;&lt;poi&gt;saves those whose spirit is crushed.&lt;/poi&gt;</td><td></td><td></td><td></td><td>NABRE</td><td>Ps</td><td>22</td><td>23</td><td>Ps34:19</td></tr><tr><td>1</td><td>3</td><td>Psalms</td><td>109</td><td></td><td>16</td><td></td><td></td><td>&lt;po&gt;For he did not remember to show mercy,&lt;/po&gt;&lt;poi&gt;but hounded the wretched poor&lt;/poi&gt;&lt;poi&gt;and brought death to the brokenhearted.&lt;/poi&gt;</td><td></td><td></td><td></td><td>NABRE</td><td>Ps</td><td>22</td><td>23</td><td>Ps109:16</td></tr><tr><td>1</td><td>3</td><td>Psalms</td><td>147</td><td></td><td>3</td><td></td><td></td><td>&lt;po&gt;Healing the brokenhearted,&lt;/po&gt;&lt;poi&gt;and binding up their wounds.&lt;/poi&gt;</td><td></td><td></td><td></td><td>NABRE</td><td>Ps</td><td>22</td><td>23</td><td>Ps147:3</td></tr><tr><td>1</td><td>4</td><td>Isaiah</td><td>61</td><td></td><td>1</td><td></td><td></td><td>&lt;pof&gt; The spirit of the Lord G&lt;sm&gt;OD&lt;/sm&gt; is upon me,&lt;/pof&gt;&lt;poi&gt;because the L&lt;sm&gt;ORD&lt;/sm&gt; has anointed me;&lt;/poi&gt;&lt;po&gt;He has sent me to bring good news to the afflicted,&lt;/po&gt;&lt;poi&gt;to bind up the brokenhearted,&lt;/poi&gt;&lt;po&gt;To proclaim liberty to the captives,&lt;/po&gt;&lt;poi&gt;release to the prisoners,&lt;/poi&gt;</td><td></td><td></td><td></td><td>NABRE</td><td>Is</td><td>28</td><td>29</td><td>Is61:1</td></tr></tbody></table></div><div class=\"errors\" id=\"errors\"></div><input type=\"hidden\" name=\"ENDPOINT_VERSION\" value=\"3.0\"></body></html>"
           }
-        },
-        "required" : [ "query", "version", "appid" ]
       },
-      "BibleQuoteJSON" : {
-        "type" : "object",
-        "properties" : {
-          "results" : {
-            "type" : "array",
-            "description" : "Array of objects each of which represents a Bible verse with all associated information",
-            "items" : {
-              "type" : "object",
-              "properties" : {
-                "testament" : {
-                  "type" : "integer",
-                  "enum" : [ 1, 2 ],
-                  "description" : "`1` = *Old Testament*, `2` = *New Testament*",
-                  "xml" : {
-                    "attribute" : true
+      "parameters": {
+          "query": {
+              "name": "query",
+              "in": "query",
+              "description": "Bible reference using standard Bible citation notation. ",
+              "required": true,
+              "schema": {
+                  "type": "string"
+              },
+              "examples": {
+                  "internationalNotation": {
+                      "value": "Genesis1,1-5.7-9",
+                      "summary": "International style Bible citation notation"
+                  },
+                  "englishNotation": {
+                      "value": "Genesis1:1-5,7-9",
+                      "summary": "English style Bible citation notation"
+                  },
+                  "chainedQueries": {
+                      "value": "John3:16;1John4:7-8",
+                      "summary": "Chaining together multiple Bible quotes using a semicolon"
+                  },
+                  "chainedQueriesSameBook": {
+                      "value": "Matthew1:1-5;2:6-8",
+                      "summary": "Chaining together multiple Bible quotes from the same book using a semicolon"
                   }
+              }
+          },
+          "version": {
+              "name": "version",
+              "in": "query",
+              "description": "Bible version or versions from which to retrieve the Bible quote. A list of valid versions can be retrieved from the `metadata.php` API using `query=bibleversions`",
+              "required": true,
+              "schema": {
+                  "type": "array",
+                  "items": {
+                      "type": "string"
+                  }
+              },
+              "style": "form",
+              "explode": false,
+              "examples": {
+                  "multipleVersions": {
+                      "value": [
+                          "NABRE",
+                          "CEI2008"
+                      ],
+                      "summary": "retrieve Bible quote from multiple Bible versions"
+                  },
+                  "singleVersion": {
+                      "value": [
+                          "NVBSE"
+                      ],
+                      "summary": "retrieve Bible quote from a single Bible version"
+                  }
+              }
+          },
+          "return": {
+              "name": "return",
+              "in": "query",
+              "description": "Desired content type for the response data. An `Accept` header can be used instead, and should be preferred to using the `return` parameter / property",
+              "required": false,
+              "schema": {
+                  "type": "string",
+                  "enum": [
+                      "json",
+                      "xml",
+                      "html"
+                  ],
+                  "default": "json"
+              },
+              "examples": {
+                "json": {
+                  "value": "json",
+                  "summary": "return data in JSON format"
                 },
-                "section" : {
-                  "type" : "integer",
-                  "enum" : [ 1, 2, 3, 4, 5, 6, 7, 8, 9 ],
-                  "description" : "`1` = *Pentateuch*, `2` = *Historical Books*, `3` = *Wisdom Books*, `4` = *Prophets*, `5` = *Gospels*, `6` = *Acts of the Apostles*, `7` = *Letters of Saint Paul*, `8` = *Catholic Letters*, `9` = *Apocalypse*",
-                  "xml" : {
-                    "attribute" : true
-                  }
+                "xml": {
+                  "value": "xml",
+                  "summary": "return data in XML format"
                 },
-                "book" : {
-                  "type" : "string",
-                  "description" : "Name of the book of the Bible in the language of the Bible version being quoted from",
-                  "xml" : {
-                    "attribute" : true
-                  }
-                },
-                "bookabbrev" : {
-                  "type" : "string",
-                  "description" : "Abbreviated form of the book of the Bible in the language of the Bible version being quoted from",
-                  "xml" : {
-                    "attribute" : true
-                  }
-                },
-                "booknum" : {
-                  "type" : "integer",
-                  "description" : "0 based index of the Book of the Bible in the Bible version being quoted from (not all versions have the same books in the same order, especially when considering differences between Catholic and evangelical versions). The value is returned as a number value ready to be used against index information for the Bible version being quoted from. The corresponding name of the Book of the Bible as used in the printed edition of the current Bible version can be retrieved using the `metadata.php` API endpoint, as can index information about the number of chapters in the book and the number of verses in each chapter.",
-                  "xml" : {
-                    "attribute" : true
-                  }
-                },
-                "univbooknum" : {
-                  "type" : "string",
-                  "description" : "A number identifying the Book of the Bible according to the universally recognized Catholic version of the Canon of the Sacred Scriptures (*i.e. universally recognized by the Roman Catholic Church*). This is not a 0 based index, but rather `1` = *Genesis*, `2` = *Exodus*, etc. Therefore it is returned as a string, but can be treated as a number.",
-                  "enum" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "55", "56", "57", "58", "59", "60", "61", "62", "63", "64", "65", "66", "67", "68", "69", "70", "71", "72", "73" ],
-                  "xml" : {
-                    "attribute" : true
-                  }
-                },
-                "chapter" : {
-                  "type" : "integer",
-                  "description" : "Chapter of the book of the Bible in the Bible version that the verse is being quoted from",
-                  "xml" : {
-                    "attribute" : true
-                  }
-                },
-                "versedescr" : {
-                  "type" : "string",
-                  "description" : "Not currently used, comes back as a `null` value. Could possible be used in the future for scholarly notes associated with a Bible verse",
-                  "nullable" : true,
-                  "xml" : {
-                    "attribute" : true
-                  }
-                },
-                "verse" : {
-                  "type" : "string",
-                  "description" : "Verse Number of the verse being quoted. *N.B. this is returned as a string because it will not always necessarily be a number value, there are verses that have letters in them. The value must be treated as a string and not as a number.*",
-                  "xml" : {
-                    "attribute" : true
-                  }
-                },
-                "verseequiv" : {
-                  "type" : "integer",
-                  "description" : "I'm not actually sure if this is currently being used or not, I believe the idea was to have a number value for those verses that have a letter in the verse number... Will mostly return a `null` value.",
-                  "nullable" : true,
-                  "xml" : {
-                    "attribute" : true
-                  }
-                },
-                "text" : {
-                  "type" : "string",
-                  "description" : "Contains the actual text of the verse being quoted. May contain `newline` characters that may need to be dealt with. The **NABRE** version will contain ***it's own formatting tags that need to be dealt with***, whether that means producing the proper formatting associated with these tags, or removing them to have a basic formatting. The legal requirements for usage of the NABRE version require the proper formatting to be used where possible. Please [contact the project author](mailto:admin@bibleget.io) for information on how to deal with these tags and their formatting.",
-                  "xml" : {
-                    "attribute" : true
-                  }
-                },
-                "version" : {
-                  "type" : "string",
-                  "description" : "the acronym of the Bible version being quoted from. For data associated with any given Bible version, for example index information, the `metadata.php` API endpoint can be used",
-                  "xml" : {
-                    "attribute" : true
-                  }
-                },
-                "title1" : {
-                  "type" : "string",
-                  "description" : "not currently used. The original idea (which may yet be implemented) was for this to contain any first-level title text preceding the given verse in the version of the Bible being quoted from.",
-                  "xml" : {
-                    "attribute" : true
-                  }
-                },
-                "title2" : {
-                  "type" : "string",
-                  "description" : "not currently used. The original idea (which may yet be implemented) was for this to contain any second-level title text preceding the given verse in the version of the Bible being quoted from.",
-                  "xml" : {
-                    "attribute" : true
-                  }
-                },
-                "title3" : {
-                  "type" : "string",
-                  "description" : "not currently used. The original idea (which may yet be implemented) was for this to contain any third-level title text preceding the given verse in the version of the Bible being quoted from.",
-                  "xml" : {
-                    "attribute" : true
-                  }
-                },
-                "originalquery" : {
-                  "type" : "string",
-                  "description" : "The original query (Bible reference indicated in the `query` parameter of the sent request) that the endpoint received, which produced this result.",
-                  "xml" : {
-                    "attribute" : true
-                  }
+                "html": {
+                  "value": "html",
+                  "summary": "return data in HTML format"
                 }
               }
-            },
-            "xml" : {
-              "wrapped" : true,
-              "name" : "results"
-            }
           },
-          "errors" : {
-            "type" : "array",
-            "description" : "An array of any error messages that may have been generated indicating a badly formed `query` parameter, a bad value for the `version` parameter, or an API server error",
-            "items" : {
-              "type" : "string"
-            }
+          "appid": {
+              "name": "appid",
+              "in": "query",
+              "description": "Unique identifier of the application making the request, to be agreed upon with the owner of the API endpoint",
+              "required": true,
+              "schema": {
+                  "type": "string"
+              },
+              "example": "swaggerhub"
           },
-          "info" : {
-            "type" : "object",
-            "description" : "An object containing metadata about the API endpoint",
-            "properties" : {
-              "ENDPOINT_VERSION" : {
-                "type" : "string"
-              }
-            }
-          }
-        }
-      },
-      "BibleQuoteXML" : {
-        "type" : "object",
-        "properties" : {
-          "results" : {
-            "type" : "array",
-            "description" : "Array of objects each of which represents a Bible verse with all associated information",
-            "items" : {
-              "$ref" : "#/components/schemas/BibleQuoteResult"
-            },
-            "xml" : {
-              "name" : "results",
-              "wrapped" : true
-            }
+          "pluginversion": {
+              "name": "pluginversion",
+              "in": "query",
+              "description": "Version number of the application making the request. Useful not only for statistics, to help understand which version of an application is being actively used, but also (especially in the case of the official applications) to help deal with possibly breaking changes between the application version and versions of the API endpoint",
+              "required": false,
+              "schema": {
+                  "type": "string"
+              },
+              "example": "v1.0"
           },
-          "errors" : {
-            "type" : "array",
-            "description" : "An array of any error messages that may have been generated indicating a badly formed `query` parameter, a bad value for the `version` parameter, or an API server error",
-            "items" : {
-              "type" : "string"
-            }
+          "domain": {
+              "name": "domain",
+              "in": "query",
+              "description": "In the case of web based applications, should indicate the domain from which the request is generated. Currently used by the official plugin for WordPress to better understand usage of the plugin and monitor requests. When the application or plugin making the request can be installed on different domains (as is the case with the WordPress plugin), this value should be generated dynamically from a server variable identifying the domain. If instead it will always be the same domain making the requests, the value can be hardcoded with the actual domain.",
+              "required": false,
+              "schema": {
+                  "type": "string"
+              },
+              "example": "app.swaggerhub.com"
           },
-          "info" : {
-            "type" : "object",
-            "description" : "An object containing metadata about the API endpoint",
-            "properties" : {
-              "ENDPOINT_VERSION" : {
-                "type" : "string"
-              }
-            }
-          }
-        },
-        "xml" : {
-          "name" : "BibleQuote"
-        }
-      },
-      "BibleQuoteResult" : {
-        "type" : "object",
-        "properties" : {
-          "testament" : {
-            "type" : "integer",
-            "enum" : [ 1, 2 ],
-            "description" : "`1` = *Old Testament*, `2` = *New Testament*",
-            "xml" : {
-              "attribute" : true
-            }
-          },
-          "section" : {
-            "type" : "integer",
-            "enum" : [ 1, 2, 3, 4, 5, 6, 7, 8, 9 ],
-            "description" : "`1` = *Pentateuch*, `2` = *Historical Books*, `3` = *Wisdom Books*, `4` = *Prophets*, `5` = *Gospels*, `6` = *Acts of the Apostles*, `7` = *Letters of Saint Paul*, `8` = *Catholic Letters*, `9` = *Apocalypse*",
-            "xml" : {
-              "attribute" : true
-            }
-          },
-          "book" : {
-            "type" : "string",
-            "description" : "Name of the book of the Bible in the language of the Bible version being quoted from",
-            "xml" : {
-              "attribute" : true
-            }
-          },
-          "bookabbrev" : {
-            "type" : "string",
-            "description" : "Abbreviated form of the book of the Bible in the language of the Bible version being quoted from",
-            "xml" : {
-              "attribute" : true
-            }
-          },
-          "booknum" : {
-            "type" : "integer",
-            "description" : "0 based index of the Book of the Bible in the Bible version being quoted from (not all versions have the same books in the same order, especially when considering differences between Catholic and evangelical versions). The value is returned as a number value ready to be used against index information for the Bible version being quoted from. The corresponding name of the Book of the Bible as used in the printed edition of the current Bible version can be retrieved using the `metadata.php` API endpoint, as can index information about the number of chapters in the book and the number of verses in each chapter.",
-            "xml" : {
-              "attribute" : true
-            }
-          },
-          "univbooknum" : {
-            "type" : "string",
-            "description" : "A number identifying the Book of the Bible according to the universally recognized Catholic version of the Canon of the Sacred Scriptures (*i.e. universally recognized by the Roman Catholic Church*). This is not a 0 based index, but rather `1` = *Genesis*, `2` = *Exodus*, etc. Therefore it is returned as a string, but can be treated as a number.",
-            "enum" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "55", "56", "57", "58", "59", "60", "61", "62", "63", "64", "65", "66", "67", "68", "69", "70", "71", "72", "73" ],
-            "xml" : {
-              "attribute" : true
-            }
-          },
-          "chapter" : {
-            "type" : "integer",
-            "description" : "Chapter of the book of the Bible in the Bible version that the verse is being quoted from",
-            "xml" : {
-              "attribute" : true
-            }
-          },
-          "versedescr" : {
-            "type" : "string",
-            "description" : "Not currently used, comes back as a `null` value. Could possible be used in the future for scholarly notes associated with a Bible verse",
-            "nullable" : true,
-            "xml" : {
-              "attribute" : true
-            }
-          },
-          "verse" : {
-            "type" : "string",
-            "description" : "Verse Number of the verse being quoted. *N.B. this is returned as a string because it will not always necessarily be a number value, there are verses that have letters in them. The value must be treated as a string and not as a number.*",
-            "xml" : {
-              "attribute" : true
-            }
-          },
-          "verseequiv" : {
-            "type" : "integer",
-            "description" : "I'm not actually sure if this is currently being used or not, I believe the idea was to have a number value for those verses that have a letter in the verse number... Will mostly return a `null` value.",
-            "nullable" : true,
-            "xml" : {
-              "attribute" : true
-            }
-          },
-          "text" : {
-            "type" : "string",
-            "description" : "Contains the actual text of the verse being quoted. May contain `newline` characters that may need to be dealt with. The **NABRE** version will contain ***it's own formatting tags that need to be dealt with***, whether that means producing the proper formatting associated with these tags, or removing them to have a basic formatting. The legal requirements for usage of the NABRE version require the proper formatting to be used where possible. Please [contact the project author](mailto:admin@bibleget.io) for information on how to deal with these tags and their formatting.",
-            "xml" : {
-              "attribute" : true
-            }
-          },
-          "version" : {
-            "type" : "string",
-            "description" : "the acronym of the Bible version being quoted from. For data associated with any given Bible version, for example index information, the `metadata.php` API endpoint can be used",
-            "xml" : {
-              "attribute" : true
-            }
-          },
-          "title1" : {
-            "type" : "string",
-            "description" : "not currently used. The original idea (which may yet be implemented) was for this to contain any first-level title text preceding the given verse in the version of the Bible being quoted from.",
-            "xml" : {
-              "attribute" : true
-            }
-          },
-          "title2" : {
-            "type" : "string",
-            "description" : "not currently used. The original idea (which may yet be implemented) was for this to contain any second-level title text preceding the given verse in the version of the Bible being quoted from.",
-            "xml" : {
-              "attribute" : true
-            }
-          },
-          "title3" : {
-            "type" : "string",
-            "description" : "not currently used. The original idea (which may yet be implemented) was for this to contain any third-level title text preceding the given verse in the version of the Bible being quoted from.",
-            "xml" : {
-              "attribute" : true
-            }
-          },
-          "originalquery" : {
-            "type" : "string",
-            "description" : "The original query (Bible reference indicated in the `query` parameter of the sent request) that the endpoint received, which produced this result.",
-            "xml" : {
-              "attribute" : true
-            }
-          }
-        },
-        "xml" : {
-          "name" : "result"
-        }
-      },
-      "MetadataBibleVersions" : {
-        "type" : "object",
-        "properties" : {
-          "validversions" : {
-            "type" : "array",
-            "description" : "An array of the acronyms of the Bible versions that are currently supported by the main BibleGet API endpoint",
-            "items" : {
-              "type" : "string"
-            }
-          },
-          "validversions_fullname" : {
-            "type" : "object",
-            "description" : "An object the keys of which are the acronyms of the Bible versions that are currently supported by the main BibleGet API endpoint, and the values of which are a pipe separated list of 1. The full name of the Bible version 2. The year it was published 3. The two letter ISO 639-1 code of the **language** of the Bible version",
-            "additionalProperties" : {
-              "type" : "string"
-            }
-          },
-          "copyrightversions" : {
-            "type" : "array",
-            "description" : "An array containing the acronyms of Bible versions that have a copyright holder, the usage of which is regulated under a legally binding agreement with the copyright holder. For example, some copyright holders (usually Episcopal Conferences for Catholic versions) may request that no more than a certain number of verses be issued from a single request to the endpoint (in other words, please don't try to copy the whole Bible through the BibleGet endpoint!). Enforcement of the usage required by the copyright holder is done by the endpoint itself, so applications cannot overcome these limits. If the owner of the endpoint notices that an application attempts in a sly manner to overcome these limitations, access to the main API endpoint may be denied to the application and authorization mechanisms will be necessarily put in place for usage of the endpoints. We are assuming a model of responsible usage for the time being, but if it becomes necessary access will be restricted and authorization will be required",
-            "items" : {
-              "type" : "string"
-            }
-          },
-          "errors" : {
-            "type" : "array",
-            "description" : "An array of any error messages that may have been generated indicating a badly formed `query` parameter or an API server error",
-            "items" : {
-              "type" : "string"
-            }
-          },
-          "info" : {
-            "type" : "object",
-            "description" : "An object containing metadata about the API endpoint",
-            "properties" : {
-              "ENDPOINT_VERSION" : {
-                "type" : "string"
-              }
-            }
-          }
-        },
-        "xml" : {
-          "name" : "BibleGetMetadata"
-        }
-      },
-      "MetadataBibleBooks" : {
-        "type" : "object",
-        "properties" : {
-          "languages" : {
-            "type" : "array",
-            "description" : "An array indicating the languages supported by the main BibleGet endpoint, for the names of the Books of the Bible. The single languages are returned in the English form, all caps. The implict numbered index of this array will be useful for the data associated with the `results` key.",
-            "items" : {
-              "type" : "string"
-            }
-          },
-          "results" : {
-            "type" : "array",
-            "description" : "An array containing information about the names of the Bible books that can be used to make queries to the main endpoint. The implict numbered index of this array corresponds with the Bible books universally recognized by the Roman Catholic Church. Bible versions used by evangelicals will generally have a few less Bible books, so the index of reference is the Canon of the Scriptures as recognized by the Roman Catholic Church.",
-            "items" : {
-              "$ref" : "#/components/schemas/MetadataBibleBooksResult"
-            }
-          },
-          "errors" : {
-            "type" : "array",
-            "description" : "An array of any error messages that may have been generated indicating a badly formed `query` parameter or an API server error",
-            "items" : {
-              "type" : "string"
-            }
-          },
-          "info" : {
-            "type" : "object",
-            "description" : "An object containing metadata about the API endpoint",
-            "properties" : {
-              "ENDPOINT_VERSION" : {
-                "type" : "string"
-              }
-            }
-          }
-        },
-        "xml" : {
-          "name" : "BibleGetMetadata"
-        }
-      },
-      "MetadataVersionIndex" : {
-        "type" : "object",
-        "properties" : {
-          "indexes" : {
-            "type" : "object",
-            "description" : "An object the *keys* of which are the *acronyms of the Bible versions as requested with the `versions` parameter*, and the corresponding *values* of which are objects with the index information associated with that Bible version.",
-            "additionalProperties" : {
-              "$ref" : "#/components/schemas/MetadataVersionIndexForVersion"
-            }
-          },
-          "errors" : {
-            "type" : "array",
-            "description" : "An array of any error messages that may have been generated indicating a badly formed `query` parameter, a bad value for the `version` parameter, or an API server error",
-            "items" : {
-              "type" : "string"
-            }
-          },
-          "info" : {
-            "type" : "object",
-            "description" : "An object containing metadata about the API endpoint",
-            "properties" : {
-              "ENDPOINT_VERSION" : {
-                "type" : "string"
-              }
-            }
-          }
-        },
-        "xml" : {
-          "name" : "BibleGetMetadata"
-        }
-      },
-      "MetadataBibleBooksResult" : {
-        "type" : "array",
-        "description" : "Each element of the `results` array will is an array whose implicit numbered index corresponds with the *LANGUAGES* supported by the main endoint, as can be found in the `languages` key of the returned data.",
-        "items" : {
-          "$ref" : "#/components/schemas/MetadataBibleBooksResultForLang"
-        }
-      },
-      "MetadataBibleBooksResultForLang" : {
-        "type" : "array",
-        "description" : "An array with a variable number of elements. The first two elements will always be present: 1. a pipe separated list of the possible Full names of the Bible book in the given language (if there are multiple possible forms that is; the pipe will be not be present if there is not a list of values) 2. a pipe separated list of the possible abbreviated forms of the Bible book in the given language (if there are multiple possible forms that is; the pipe will be not be present if there is not a list of values) 3. Any other elements will not be pipe separated lists but single strings of the possible alternate forms whether full or abbreviated ??? [note to myself: double check this, what was the reasoning behind this kind of structuring of the data?]",
-        "items" : {
-          "type" : "string"
-        }
-      },
-      "MetadataVersionIndexForVersion" : {
-        "type" : "object",
-        "description" : "",
-        "properties" : {
-          "abbreviations" : {
-            "type" : "array",
-            "description" : "An array containing the abbreviations of the books of the Bible as found in the published edition of this version of the Bible. These may not necessarily always be used as is for making requests to the main API endpoint because there is some possibility that they may conflict with other abbreviations used by other versions of the Bible in other languages for a different book of the Bible. These are only useful for displaying the exact abbreviations for that version of the Bible. For verification of the validity of a request made to the main API endpoint, the abbreviations produced from the request `query=biblebooks` should be used.",
-            "items" : {
-              "type" : "string"
-            }
-          },
-          "biblebooks" : {
-            "type" : "array",
-            "description" : "An array containing the full names of the books of the Bible as found in the published edition of this version of the Bible. The implicit numbered index of this array will not necessarily correspond with that of the Canon of the Scriptures as recognized by the Roman Catholic Church and as produced from the request `query=biblebooks`, because some evangelical versions for example may not have all of the books of the Bible as per the Canon recognized by the Roman Catholic Church.",
-            "items" : {
-              "type" : "string"
-            }
-          },
-          "chapter_limit" : {
-            "type" : "array",
-            "description" : "An array of number values which indicate the last possible chapter for each of the books listed in the above mentioned `biblebooks` array (or in the above mentioned `abbreviations` array). Again, the implicit numerical index of these values will not necessarily correspond with that of the Canon of Scriptures as recognized by the Roman Catholic Church, if the version of the Bible being quoted from does not have all of the books recognized by this same Canon. Each of these values is the actual last chapter of each of the books of the Bible in this version of the Bible, so it is not a zero based index number but it is the actual number of the last chapter of the book",
-            "items" : {
-              "type" : "integer"
-            }
-          },
-          "verse_limit" : {
-            "type" : "array",
-            "description" : "An array in which the implicit numerical index corresponds with the books listed in the above mentioned `biblebooks` array (or in the above mentioned `abbreviations` array). Each value of the array is another array which again contains numerical values; the total number of values found in each nested array corresponds with the number of chapters for each of these same books. So if the book of Genesis has 50 chapters (as we found out from the `chapter_limit` key), there will be 50 values in the first nested array within the `verse_limit` array. Each one of these 50 values indicates the verse limit (as in the last possible verse) for each of the 50 chapters in the book of Genesis. The same goes for each of the nested arrays contained herein. Again, the numbers in the nested arrays indicate the actual number of the last verse, it is not a zero based index.",
-            "items" : {
-              "type" : "array",
-              "description" : "An array of numerical values indicating the last possible verse in the corresponding chapter of the corresponding book of the Bible in the given Bible version. The total number of values in this array corresponds with the number of chapters in the corresponding book of the Bible. If we are dealing with the book of Genesis which has 50 chapters (as we found out from the `chapter_limit` key), there will be 50 values in this array. Each one of these 50 values indicates the verse limit (as in the last possible verse) for each of the 50 chapters in the book of Genesis. Again, the numbers in this array indicate the actual number of the last verse, it is not a zero based index.",
-              "items" : {
-                "type" : "integer"
-              }
-            }
-          },
-          "book_num" : {
-            "type" : "array",
-            "description" : "",
-            "items" : {
-              "type" : "array",
-              "description" : "An array containing the number of each book as it would be in the Canon of the Scriptures as recognized by the Roman Catholic Church. These numbers are not based on a zero based index. `1` = *Genesis*, `2` = *Exodus*, etc. This can be very helpful in trying to glue all of the metadata information together, between valid book names that can be used with their Roman Catholic Canon based index, and actual book names in a single version of the Bible where the number of elements might not be the same as those in the Roman Catholic Canon.",
-              "items" : {
-                "type" : "integer"
-              }
-            }
-          }
-        }
-      },
-      "KeywordSearchJSON" : {
-        "type" : "object",
-        "properties" : {
-          "results" : {
-            "type" : "array",
-            "description" : "Array of objects each of which represents a Bible verse with all associated information",
-            "items" : {
-              "type" : "object",
-              "properties" : {
-                "testament" : {
-                  "type" : "integer",
-                  "enum" : [ 1, 2 ],
-                  "description" : "`1` = *Old Testament*, `2` = *New Testament*",
-                  "xml" : {
-                    "attribute" : true
-                  }
+          "preferorigin": {
+              "name": "preferorigin",
+              "in": "query",
+              "description": "",
+              "required": false,
+              "schema": {
+                  "type": "string",
+                  "enum": [ "GREEK", "HEBREW" ]
+              },
+              "examples": {
+                "GREEK": {
+                  "value": "GREEK",
+                  "summary": "Request verses based on the original Greek text"
                 },
-                "section" : {
-                  "type" : "integer",
-                  "enum" : [ 1, 2, 3, 4, 5, 6, 7, 8, 9 ],
-                  "description" : "`1` = *Pentateuch*, `2` = *Historical Books*, `3` = *Wisdom Books*, `4` = *Prophets*, `5` = *Gospels*, `6` = *Acts of the Apostles*, `7` = *Letters of Saint Paul*, `8` = *Catholic Letters*, `9` = *Apocalypse*",
-                  "xml" : {
-                    "attribute" : true
-                  }
-                },
-                "book" : {
-                  "type" : "string",
-                  "description" : "Name of the book of the Bible in the language of the Bible version being quoted from",
-                  "xml" : {
-                    "attribute" : true
-                  }
-                },
-                "bookabbrev" : {
-                  "type" : "string",
-                  "description" : "Abbreviated form of the book of the Bible in the language of the Bible version being quoted from",
-                  "xml" : {
-                    "attribute" : true
-                  }
-                },
-                "booknum" : {
-                  "type" : "integer",
-                  "description" : "0 based index of the Book of the Bible in the Bible version being quoted from (not all versions have the same books in the same order, especially when considering differences between Catholic and evangelical versions). The value is returned as a number value ready to be used against index information for the Bible version being quoted from. The corresponding name of the Book of the Bible as used in the printed edition of the current Bible version can be retrieved using the `metadata.php` API endpoint, as can index information about the number of chapters in the book and the number of verses in each chapter.",
-                  "xml" : {
-                    "attribute" : true
-                  }
-                },
-                "univbooknum" : {
-                  "type" : "string",
-                  "description" : "A number identifying the Book of the Bible according to the universally recognized Catholic version of the Canon of the Sacred Scriptures (*i.e. universally recognized by the Roman Catholic Church*). This is not a 0 based index, but rather `1` = *Genesis*, `2` = *Exodus*, etc. Therefore it is returned as a string, but can be treated as a number.",
-                  "enum" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "55", "56", "57", "58", "59", "60", "61", "62", "63", "64", "65", "66", "67", "68", "69", "70", "71", "72", "73" ],
-                  "xml" : {
-                    "attribute" : true
-                  }
-                },
-                "chapter" : {
-                  "type" : "integer",
-                  "description" : "Chapter of the book of the Bible in the Bible version that the verse is being quoted from",
-                  "xml" : {
-                    "attribute" : true
-                  }
-                },
-                "versedescr" : {
-                  "type" : "string",
-                  "description" : "Not currently used, comes back as a `null` value. Could possible be used in the future for scholarly notes associated with a Bible verse",
-                  "nullable" : true,
-                  "xml" : {
-                    "attribute" : true
-                  }
-                },
-                "verse" : {
-                  "type" : "string",
-                  "description" : "Verse Number of the verse being quoted. *N.B. this is returned as a string because it will not always necessarily be a number value, there are verses that have letters in them. The value must be treated as a string and not as a number.*",
-                  "xml" : {
-                    "attribute" : true
-                  }
-                },
-                "verseequiv" : {
-                  "type" : "integer",
-                  "description" : "I'm not actually sure if this is currently being used or not, I believe the idea was to have a number value for those verses that have a letter in the verse number... Will mostly return a `null` value.",
-                  "nullable" : true,
-                  "xml" : {
-                    "attribute" : true
-                  }
-                },
-                "text" : {
-                  "type" : "string",
-                  "description" : "Contains the actual text of the verse being quoted. May contain `newline` characters that may need to be dealt with. The **NABRE** version will contain ***it's own formatting tags that need to be dealt with***, whether that means producing the proper formatting associated with these tags, or removing them to have a basic formatting. The legal requirements for usage of the NABRE version require the proper formatting to be used where possible. Please [contact the project author](mailto:admin@bibleget.io) for information on how to deal with these tags and their formatting.",
-                  "xml" : {
-                    "attribute" : true
-                  }
-                },
-                "version" : {
-                  "type" : "string",
-                  "description" : "the acronym of the Bible version being quoted from. For data associated with any given Bible version, for example index information, the `metadata.php` API endpoint can be used",
-                  "xml" : {
-                    "attribute" : true
-                  }
-                },
-                "title1" : {
-                  "type" : "string",
-                  "description" : "not currently used. The original idea (which may yet be implemented) was for this to contain any first-level title text preceding the given verse in the version of the Bible being quoted from.",
-                  "xml" : {
-                    "attribute" : true
-                  }
-                },
-                "title2" : {
-                  "type" : "string",
-                  "description" : "not currently used. The original idea (which may yet be implemented) was for this to contain any second-level title text preceding the given verse in the version of the Bible being quoted from.",
-                  "xml" : {
-                    "attribute" : true
-                  }
-                },
-                "title3" : {
-                  "type" : "string",
-                  "description" : "not currently used. The original idea (which may yet be implemented) was for this to contain any third-level title text preceding the given verse in the version of the Bible being quoted from.",
-                  "xml" : {
-                    "attribute" : true
-                  }
-                },
-                "originalquery" : {
-                  "type" : "string",
-                  "description" : "The reference to the single verse in this result (*{Book}{Chapter}*:*{Verse}*).",
-                  "xml" : {
-                    "attribute" : true
-                  }
+                "HEBREW": {
+                  "value": "HEBREW",
+                  "summary": "Request verses based on the original Hebrew text"
                 }
               }
-            },
-            "xml" : {
-              "wrapped" : true,
-              "name" : "results"
-            }
-          },
-          "errors" : {
-            "type" : "array",
-            "description" : "An array of any error messages that may have been generated indicating a badly formed `query` parameter, a bad value for the `version` parameter, or an API server error",
-            "items" : {
-              "type" : "string"
-            }
-          },
-          "info" : {
-            "type" : "object",
-            "description" : "An object containing metadata about the API endpoint",
-            "properties" : {
-              "ENDPOINT_VERSION" : {
-                "type" : "string",
-                "description" : "The current version of the API endpoint. This may be useful information because the data produced by the endpoint may change over time, it is useful to know which data is associated with which version of the endpoint. For example, if an application caches data returned by the endpoint, but there has been a change to the structure of the data in a new version of the API, the application would know how to deal with emptying the cache and requesting new data from the updated endpoint."
-              },
-              "keyword" : {
-                "type" : "string",
-                "description" : "The Bible version in which the search by keyword was performed, as indicated in the `version` parameter in the request"
-              },
-              "version" : {
-                "type" : "string",
-                "description" : "The keyword used to perform the search as indicated by the `keyword` parameter in the request"
-              }
-            }
           }
-        }
-      },
-      "KeywordSearchXML" : {
-        "type" : "object",
-        "properties" : {
-          "results" : {
-            "type" : "array",
-            "description" : "Array of objects each of which represents a Bible verse in which the searched keyword was found, with all associated information",
-            "items" : {
-              "$ref" : "#/components/schemas/BibleQuoteResult"
-            },
-            "xml" : {
-              "name" : "results",
-              "wrapped" : true
-            }
-          },
-          "errors" : {
-            "type" : "array",
-            "description" : "An array of any error messages that may have been generated indicating a badly formed `query` parameter, a bad value for the `version` parameter, or an API server error",
-            "items" : {
-              "type" : "string"
-            }
-          },
-          "info" : {
-            "type" : "object",
-            "description" : "An object containing metadata about the API endpoint",
-            "properties" : {
-              "ENDPOINT_VERSION" : {
-                "type" : "string",
-                "description" : "The current version of the API endpoint. This may be useful information because the data produced by the endpoint may change over time, it is useful to know which data is associated with which version of the endpoint. For example, if an application caches data returned by the endpoint, but there has been a change to the structure of the data in a new version of the API, the application would know how to deal with emptying the cache and requesting new data from the updated endpoint."
-              },
-              "keyword" : {
-                "type" : "string",
-                "description" : "The Bible version in which the search by keyword was performed, as indicated in the `version` parameter in the request"
-              },
-              "version" : {
-                "type" : "string",
-                "description" : "The keyword used to perform the search as indicated by the `keyword` parameter in the request"
-              }
-            }
-          }
-        },
-        "xml" : {
-          "name" : "BibleQuote"
-        }
       }
-    },
-    "parameters" : {
-      "query" : {
-        "name" : "query",
-        "in" : "query",
-        "description" : "Bible reference using standard Bible citation notation. ",
-        "required" : true,
-        "schema" : {
-          "type" : "string"
-        },
-        "examples" : {
-          "internationalNotation" : {
-            "value" : "Genesis1,1-5.7-9",
-            "summary" : "International style Bible citation notation"
-          },
-          "englishNotation" : {
-            "value" : "Genesis1:1-5,7-9",
-            "summary" : "English style Bible citation notation"
-          },
-          "chainedQueries" : {
-            "value" : "John3:16;1John4:7-8",
-            "summary" : "Chaining together multiple Bible quotes using a semicolon"
-          },
-          "chainedQueriesSameBook" : {
-            "value" : "Matthew1:1-5;2:6-8",
-            "summary" : "Chaining together multiple Bible quotes from the same book using a semicolon"
-          }
-        }
-      },
-      "version" : {
-        "name" : "version",
-        "in" : "query",
-        "description" : "Bible version or versions from which to retrieve the Bible quote. A list of valid versions can be retrieved from the `metadata.php` API using `query=bibleversions`",
-        "required" : true,
-        "schema" : {
-          "type" : "array",
-          "items" : {
-            "type" : "string"
-          }
-        },
-        "style" : "form",
-        "explode" : false,
-        "examples" : {
-          "multipleVersions" : {
-            "value" : [ "NABRE", "CEI2008" ],
-            "summary" : "retrieve Bible quote from multiple Bible versions"
-          },
-          "singleVersion" : {
-            "value" : [ "NVBSE" ],
-            "summary" : "retrieve Bible quote from a single Bible version"
-          }
-        }
-      },
-      "return" : {
-        "name" : "return",
-        "in" : "query",
-        "description" : "Type of data that should be returned in the response",
-        "required" : false,
-        "schema" : {
-          "type" : "string",
-          "enum" : [ "json", "xml", "html" ],
-          "default" : "json"
-        },
-        "examples" : {
-          "json" : {
-            "value" : "json",
-            "summary" : "return data in JSON format"
-          },
-          "xml" : {
-            "value" : "xml",
-            "summary" : "return data in XML format"
-          },
-          "html" : {
-            "value" : "html",
-            "summary" : "return data in HTML format"
-          }
-        }
-      },
-      "appid" : {
-        "name" : "appid",
-        "in" : "query",
-        "description" : "Unique identifier of the application making the request, to be agreed upon with the owner of the API endpoint",
-        "required" : true,
-        "schema" : {
-          "type" : "string"
-        },
-        "example" : "swaggerhub"
-      },
-      "pluginversion" : {
-        "name" : "pluginversion",
-        "in" : "query",
-        "description" : "Version number of the application making the request. Useful not only for statistics, to help understand which version of an application is being actively used, but also (especially in the case of the official applications) to help deal with possibly breaking changes between the application version and versions of the API endpoint",
-        "required" : false,
-        "schema" : {
-          "type" : "string"
-        },
-        "example" : "v1.0"
-      },
-      "domain" : {
-        "name" : "domain",
-        "in" : "query",
-        "description" : "In the case of web based applications, should indicate the domain from which the request is generated. Currently used by the official plugin for WordPress to better understand usage of the plugin and monitor requests. When the application or plugin making the request can be installed on different domains (as is the case with the WordPress plugin), this value should be generated dynamically from a server variable identifying the domain. If instead it will always be the same domain making the requests, the value can be hardcoded with the actual domain.",
-        "required" : false,
-        "schema" : {
-          "type" : "string"
-        },
-        "example" : "app.swaggerhub.com"
-      }
-    }
   }
 }

--- a/openapi.json
+++ b/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.3",
   "info": {
-      "version": "3.0",
+      "version": "v3.0.0",
       "title": "BibleGet",
       "description": "Get Bible quotes from different Bible versions either requesting by reference (book - chapter - verse) or searching by keyword",
       "license": {


### PR DESCRIPTION
## Summary

Brings \`master\` into agreement with the commit actually running at \`/query/v3/\` (\`9cbf764\`, 2024-05-31, tagged as [v3.0.0](https://github.com/BibleGet-I-O/endpoint/releases/tag/v3.0.0)). Master had drifted ~2.5 years behind the deployed lineage — its previous HEAD (\`585149c\`, *Update FUNDING.yml*) is from 2023-01-23.

### What's brought in (6 commits)

- \`66349c4\` manually update openapi.json (2021-11-15)
- \`cc964f5\` fix ref to BIBLEGET_QUOTE constants in index.php (2021-11-15)
- \`4297222\` fix quotes from Genesis (2021-11-27)
- \`9f9a30c\` fix clash with WordPress plugin (2021-11-27)
- \`d1786d3\` include validated variants when book is implied (2021-11-27)
- \`9cbf764\` fix for PHP >= 8.2 no dynamic properties (2024-05-31)

\`FUNDING.yml\` (master-only, post-divergence) is preserved by the 3-way merge.

### Side effect on merge

The \`Sync OAS to ReadMe\` workflow (\`readme.yaml\`) fires on push-to-master and resyncs ReadMe.io from the new master \`openapi.json\`. This is **a benefit, not a hazard**: ReadMe.io currently reflects \`585149c\`'s spec, which is older than what's deployed; merging brings public docs into agreement with the deployed reality.

## Test plan

- [ ] **Pre-merge**: verify the openapi.json on this branch matches what \`/query/v3/\` actually serves (sample endpoints + parameters)
- [ ] After merge, confirm \`readme.yaml\` triggers on the push and completes successfully
- [ ] Confirm ReadMe.io reflects the updated spec (manual eyeball)
- [ ] Confirm the v3.0.0 release on GitHub still points at \`9cbf764\` (now reachable via master too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)