### PR TITLE
chore: add .github/FUNDING.yml on development

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,13 @@
+# These are supported funding model platforms
+
+github: [bibleget-i-o, johnrdorazio]
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+otechie: # Replace with a single Otechie username
+lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+custom: ["https://paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=HDS7XQKGFHJ58"]


### PR DESCRIPTION
## Summary

Copies `.github/FUNDING.yml` verbatim from `master` (commit 585149c) onto `development`. The file was already on master but never carried over to the modern PSR-based codebase. Since development was recently made the default branch, GitHub's "Sponsor" button reads FUNDING.yml from there — without this, the github-sponsors links (`bibleget-i-o`, `johnrdorazio`) and the custom PayPal URL would no longer surface on the repo.

## Test plan

- [ ] After merge, confirm the "Sponsor" button appears on the repo home page and links to the configured platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled multiple funding platforms, allowing community members to support the project through their preferred channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->