### PR TITLE
fix(migrate): use 'NULL' as COPY null marker (what MariaDB actually emits)

### DIFF
--- a/migrations/migrate-mariadb-to-pgsql.sh
+++ b/migrations/migrate-mariadb-to-pgsql.sh
@@ -167,7 +167,17 @@ pg_sql_file() {
 pg_copy_from_stdin() {
     local table="$1"
     local columns="$2"
-    pg_exec_stdin -c "\\copy $table ($columns) FROM STDIN WITH (FORMAT text, NULL '\\N')"
+    # NULL marker is the literal four-letter string "NULL" because MariaDB's
+    # batch mode (-B -N, with or without --raw) emits NULL values as exactly
+    # that string. The default Postgres COPY-text NULL marker (\N) does NOT
+    # match what MariaDB actually outputs, so any nullable column from MariaDB
+    # was previously round-tripping as the literal text "NULL" — silent data
+    # corruption for nullable text columns, and a loud `invalid input syntax
+    # for type inet: "NULL"` for the requests_log* WHO_IP column.
+    # Trade-off: a legitimate text value of literally "NULL" would now be
+    # imported as SQL NULL. Acceptable for this dataset (Bible texts and
+    # request logs don't contain that string).
+    pg_exec_stdin -c "\\copy $table ($columns) FROM STDIN WITH (FORMAT text, NULL 'NULL')"
 }
 
 log() {
@@ -272,8 +282,9 @@ migrate_bible_version() {
     pg_sql "SELECT setval(pg_get_serial_sequence('\"$version\"', 'verseID'), COALESCE((SELECT MAX(\"verseID\") FROM \"$version\"), 1));" > /dev/null
 }
 
-# MariaDB -B -N mode outputs \N for NULL, which is PostgreSQL COPY's NULL marker.
-# Do NOT use IFNULL - let NULLs pass through as \N.
+# MariaDB -B -N mode outputs the literal string "NULL" for NULL values.
+# Our pg_copy_from_stdin sets the COPY NULL marker to match (see comment
+# in that helper). So passing NULLs through unchanged is correct.
 FULL_MARIA_SELECT="testament,section,book,chapter,versedescr,verse,verseequiv,verseorigin,text,title1,title2,title3,verseID"
 FULL_PG_COLS='testament,section,book,chapter,versedescr,verse,verseequiv,verseorigin,text,title1,title2,title3,"verseID"'
 STD_IDX_MARIA="book,chapters,verses_count,verses_last,fullname,abbrev"


### PR DESCRIPTION
## Summary

The migration script (`migrations/migrate-mariadb-to-pgsql.sh`) assumed MariaDB batch mode emits `\N` for SQL NULL — matching PostgreSQL `COPY ... FORMAT text`'s default NULL marker. Empirical verification on the production server shows otherwise: MariaDB emits the literal four-character string `NULL`, with or without `--raw`.

```
$ mariadb -N -B -e "SELECT 'a', NULL, INET6_NTOA(NULL);" | od -c
0000000   a  \t   N   U   L   L  \t   N   U   L   L  \n
```

This was discovered while running the migration on the staging VPS. The script appeared to succeed for most tables, but two failure modes surfaced:

### Silent data corruption

Every nullable text column from MariaDB round-tripped as the literal four-character text `NULL` instead of SQL NULL. Sample after the partial migration on staging:

| Table.column | NULLs in PG | Rows with text `'NULL'` |
|---|---|---|
| `CEI2008.verseorigin` | 0 | **35,250** |

Same pattern would apply to every other table with a nullable text column.

### Loud abort on `inet` columns

Halfway through migrating the yearly request-log tables:

```
21:56:16 [migrate] Migrating requests_log__2021 (36562 rows)...
ERROR:  invalid input syntax for type inet: "NULL"
CONTEXT:  COPY requests_log__2021, line 1, column WHO_IP: "NULL"
```

`requests_log__2021+` use a `varbinary(16)` for WHO_IP that the script converts via `INET6_NTOA(WHO_IP)`. For some rows, `INET6_NTOA` returns NULL (likely from invalid binary content — confirmed there are zero true-NULL `WHO_IP` values in the source), MariaDB outputs `NULL` literal, Postgres rejects it on the typed column.

## Fix

Single-line behavioral change inside `pg_copy_from_stdin`:

```diff
- pg_exec_stdin -c "\\copy $table ($columns) FROM STDIN WITH (FORMAT text, NULL '\\N')"
+ pg_exec_stdin -c "\\copy $table ($columns) FROM STDIN WITH (FORMAT text, NULL 'NULL')"
```

Plus comments updated to reflect the new contract.

The `versions_available` block (which uses `FORMAT csv` with `--raw` and explicit `\N` emission via `CASE WHEN canon IS NULL`) is untouched — it works correctly.

## Trade-off

A legitimate text value of literally `NULL` would now be imported as SQL NULL. Acceptable for this dataset — Bible texts, biblebook abbreviations, IP addresses, JSON request headers, etc. don't contain that string.

## Test plan

- [ ] Drop and recreate `bibleget_dev` on the staging VPS
- [ ] Re-run the migration with this patch applied
- [ ] Verify no silent corruption: `SELECT COUNT(*) FROM "CEI2008" WHERE verseorigin = 'NULL'` should be 0; `SELECT COUNT(*) FROM "CEI2008" WHERE verseorigin IS NULL` should be ~35,250
- [ ] Verify `requests_log__2021+` migration completes without inet errors
- [ ] Local docker-compose regression: re-running the migration locally still passes the verification table at the end (no row-count mismatches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)