### PR TITLE
fix(migrations): make migration 005 idempotent — DO block around CREATE AGGREGATE (closes #104)

### DIFF
--- a/migrations/005-add-verse-text-hash.sql
+++ b/migrations/005-add-verse-text-hash.sql
@@ -54,10 +54,24 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql IMMUTABLE STRICT;
 
-CREATE AGGREGATE IF NOT EXISTS bytea_xor_agg(BYTEA) (
-    SFUNC = bytea_xor,
-    STYPE = BYTEA
-);
+-- CREATE AGGREGATE has no IF NOT EXISTS clause in any released PostgreSQL.
+-- Wrap in a DO block that looks up pg_aggregate by name + signature to make
+-- the migration idempotent (safe to re-run on a database that already has it).
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_aggregate a
+        JOIN pg_proc p ON p.oid = a.aggfnoid
+        WHERE p.proname = 'bytea_xor_agg'
+          AND pg_get_function_identity_arguments(p.oid) = 'bytea'
+    ) THEN
+        CREATE AGGREGATE bytea_xor_agg(BYTEA) (
+            SFUNC = bytea_xor,
+            STYPE = BYTEA
+        );
+    END IF;
+END;
+$$;
 
 -- ── 3. Add columns and triggers to each version table ───────────────────────
 DO $$


### PR DESCRIPTION
## Summary

Closes #104.

`CREATE AGGREGATE IF NOT EXISTS` is not valid SQL in any released PostgreSQL version, so `migrations/005-add-verse-text-hash.sql` failed to apply against any fresh database with:

```
psql:migrations/005-add-verse-text-hash.sql:60: ERROR:  syntax error at or near "NOT"
LINE 1: CREATE AGGREGATE IF NOT EXISTS bytea_xor_agg(BYTEA) (
                            ^
```

This blocked the staging migration earlier today and would have blocked the eventual `v4` production cutover.

## Fix

Replace the bare `CREATE AGGREGATE IF NOT EXISTS …` with a DO block that looks up `pg_aggregate` by name and identity arguments first:

```sql
DO $$
BEGIN
    IF NOT EXISTS (
        SELECT 1 FROM pg_aggregate a
        JOIN pg_proc p ON p.oid = a.aggfnoid
        WHERE p.proname = 'bytea_xor_agg'
          AND pg_get_function_identity_arguments(p.oid) = 'bytea'
    ) THEN
        CREATE AGGREGATE bytea_xor_agg(BYTEA) (
            SFUNC = bytea_xor,
            STYPE = BYTEA
        );
    END IF;
END;
$$;
```

The check matches the exact signature `bytea_xor_agg(bytea)` so it doesn't false-positive on a hypothetical same-named aggregate with different argument types.

The other parts of the migration were already idempotent: `CREATE OR REPLACE FUNCTION` for the trigger function and `bytea_xor`, plus a per-table `DO` block that uses `IF NOT EXISTS` lookups against `information_schema`/`pg_trigger`. Only the aggregate was broken.

## Verification

Applied the patched file twice in sequence against the live staging `bibleget_dev` (Postgres 18.3) which already had the aggregate from the workaround used during the original migration:

```
--- First run ---
CREATE FUNCTION
DO
DO
NOTICE:  column "content_xor" of relation "embedding_metadata" already exists, skipping
ALTER TABLE

--- Second run ---
CREATE FUNCTION
DO
DO
NOTICE:  column "content_xor" of relation "embedding_metadata" already exists, skipping
ALTER TABLE

--- pg_aggregate state ---
bytea_xor_agg(bytea)   ← exactly one row
```

No errors, fully idempotent, single instance of the aggregate preserved.

## Test plan

- [ ] Apply against a fresh database that does *not* have `bytea_xor_agg` — DO block creates it
- [ ] Apply twice in sequence — second run is a no-op (already verified live)
- [ ] CI suite still green (no schema drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced backend infrastructure for tracking verse text changes, improving version management and data consistency for embedded content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->