### PR TITLE
feat(deploy): add parallel deploy lane for the embedding service

### DIFF
--- a/.github/workflows/deploy-embedding.yaml
+++ b/.github/workflows/deploy-embedding.yaml
@@ -1,0 +1,183 @@
+name: Deploy Embedding Service
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-embedding
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy embedding service
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout development
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: development
+          persist-credentials: false
+
+      - name: Verify expected files exist
+        run: |
+          set -euo pipefail
+          for f in services/embedding/main.py \
+                   services/embedding/requirements.txt \
+                   services/embedding/bibleget-embedding.service; do
+            if [ ! -f "$f" ]; then
+              echo "::error::Required file missing: $f" >&2
+              exit 1
+            fi
+          done
+
+      - name: Configure SSH
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.VPS_EMBED_SSH_PRIVATE_KEY }}
+          SSH_KNOWN_HOSTS: ${{ secrets.VPS_SSH_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SSH_KNOWN_HOSTS}" ]; then
+            echo "::error::Secret VPS_SSH_KNOWN_HOSTS is empty. Refusing to deploy without a pinned host key." >&2
+            exit 1
+          fi
+          install -d -m 700 ~/.ssh
+          printf '%s\n' "${SSH_PRIVATE_KEY}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          printf '%s\n' "${SSH_KNOWN_HOSTS}" > ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Sanity-check pinned host key against DNS SSHFP records
+        env:
+          SSH_KNOWN_HOSTS: ${{ secrets.VPS_SSH_KNOWN_HOSTS }}
+          SSHFP_HOST: ${{ secrets.VPS_HOST }}
+        run: |
+          set -euo pipefail
+          if ! command -v dig >/dev/null; then
+            echo "::warning::dig not available; skipping SSHFP drift check."
+            exit 0
+          fi
+          PIN_FPS=$(printf '%s\n' "${SSH_KNOWN_HOSTS}" \
+            | awk '$2 ~ /^(ssh-|ecdsa-)/' \
+            | while read -r _host _alg keyb64 _; do
+                printf '%s' "$keyb64" | base64 -d 2>/dev/null | sha256sum | awk '{print toupper($1)}'
+              done \
+            | sort -u)
+          DNS_FPS=$(dig +short SSHFP "${SSHFP_HOST}" \
+            | awk '$2 == "2" {for (i=3; i<=NF; i++) printf "%s", $i; print ""}' \
+            | tr -d ' ' \
+            | tr 'a-f' 'A-F' \
+            | sort -u)
+          if [ -z "${DNS_FPS}" ]; then
+            echo "::warning::No SHA-256 SSHFP records found for the configured host; skipping drift check."
+            exit 0
+          fi
+          if [ -z "${PIN_FPS}" ]; then
+            echo "::warning::Could not derive any fingerprints from VPS_SSH_KNOWN_HOSTS; skipping drift check."
+            exit 0
+          fi
+          PIN_NOT_IN_DNS=$(comm -23 <(echo "${PIN_FPS}") <(echo "${DNS_FPS}"))
+          DNS_NOT_IN_PIN=$(comm -13 <(echo "${PIN_FPS}") <(echo "${DNS_FPS}"))
+          if [ -n "${PIN_NOT_IN_DNS}" ]; then
+            while IFS= read -r fp; do
+              echo "::warning::Pinned key SHA256:${fp} not in DNS SSHFP. DNS may lag reality, or VPS_SSH_KNOWN_HOSTS is stale."
+            done <<< "${PIN_NOT_IN_DNS}"
+          fi
+          if [ -n "${DNS_NOT_IN_PIN}" ]; then
+            while IFS= read -r fp; do
+              echo "::warning::DNS SSHFP advertises SHA256:${fp} not present in VPS_SSH_KNOWN_HOSTS. Server may have rotated; consider re-pinning."
+            done <<< "${DNS_NOT_IN_PIN}"
+          fi
+          if [ -z "${PIN_NOT_IN_DNS}" ] && [ -z "${DNS_NOT_IN_PIN}" ]; then
+            echo "Pin matches DNS SSHFP records."
+          fi
+
+      - name: Ensure remote directories exist
+        env:
+          VPS_USER: ${{ secrets.VPS_EMBED_USER }}
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_PORT: ${{ vars.VPS_SSH_PORT || '22' }}
+        run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/deploy_key -p "${VPS_PORT}" \
+            -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile=~/.ssh/known_hosts \
+            -o ConnectTimeout=10 \
+            -o ServerAliveInterval=15 \
+            -o ServerAliveCountMax=2 \
+            "${VPS_USER}@${VPS_HOST}" \
+            'mkdir -p ~/embedding ~/.config/systemd/user'
+
+      - name: Rsync embedding sources
+        env:
+          VPS_USER: ${{ secrets.VPS_EMBED_USER }}
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_PORT: ${{ vars.VPS_SSH_PORT || '22' }}
+        run: |
+          set -euo pipefail
+          # --delete keeps the remote dir mirrored to source.
+          # Excludes protect server-only state (venv, model cache) and dev-only
+          # files (Dockerfile, README, __pycache__) from being shipped or wiped.
+          rsync \
+            --archive --no-owner --no-group \
+            --compress --human-readable --verbose \
+            --delete --protect-args \
+            --exclude=Dockerfile \
+            --exclude=README.md \
+            --exclude=__pycache__ \
+            --exclude=.cache \
+            --exclude=venv \
+            -e "ssh -i ~/.ssh/deploy_key -p ${VPS_PORT} -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts -o ConnectTimeout=10 -o ServerAliveInterval=15 -o ServerAliveCountMax=2" \
+            services/embedding/ "${VPS_USER}@${VPS_HOST}:embedding/"
+
+      - name: Sync systemd unit, refresh venv, restart, health check
+        env:
+          VPS_USER: ${{ secrets.VPS_EMBED_USER }}
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_PORT: ${{ vars.VPS_SSH_PORT || '22' }}
+        run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/deploy_key -p "${VPS_PORT}" \
+            -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile=~/.ssh/known_hosts \
+            -o ConnectTimeout=10 \
+            -o ServerAliveInterval=15 \
+            -o ServerAliveCountMax=2 \
+            "${VPS_USER}@${VPS_HOST}" \
+            'set -euo pipefail
+             if [ ! -x ~/embedding/venv/bin/pip ]; then
+               echo "::error::Python venv not found at ~/embedding/venv/. Run the one-time bootstrap from services/embedding/README.md first." >&2
+               exit 1
+             fi
+             SRC=~/embedding/bibleget-embedding.service
+             DST=~/.config/systemd/user/bibleget-embedding.service
+             if ! cmp -s "$SRC" "$DST" 2>/dev/null; then
+               echo "== installing/updating systemd user unit =="
+               cp "$SRC" "$DST"
+               systemctl --user daemon-reload
+               systemctl --user enable bibleget-embedding >/dev/null
+             fi
+             echo "== refreshing venv deps (idempotent) =="
+             ~/embedding/venv/bin/pip install --quiet --upgrade --upgrade-strategy only-if-needed -r ~/embedding/requirements.txt
+             echo "== restarting bibleget-embedding =="
+             systemctl --user restart bibleget-embedding
+             for i in 1 2 3 4 5 6 7 8 9 10; do
+               if curl -sS --max-time 3 http://127.0.0.1:8000/health 2>/dev/null | grep -q "\"ready\":true"; then
+                 echo "== health OK =="
+                 exit 0
+               fi
+               sleep 3
+             done
+             echo "::error::Service failed to become healthy within 30s" >&2
+             systemctl --user status bibleget-embedding --no-pager | head -40
+             journalctl --user -u bibleget-embedding -n 40 --no-pager
+             exit 1'
+
+      - name: Clean up SSH key
+        if: always()
+        run: rm -f ~/.ssh/deploy_key

--- a/services/embedding/README.md
+++ b/services/embedding/README.md
@@ -1,0 +1,115 @@
+# BibleGet Embedding Service
+
+Long-running FastAPI app that vectorises text via the
+`paraphrase-multilingual-MiniLM-L12-v2` sentence-transformers model. The PHP
+endpoint calls it at request time (via `EMBEDDING_SERVICE_URL`) for semantic
+and similar-verse search.
+
+## How it's deployed
+
+The chrooted PHP deploy lane (see `.github/workflows/deploy.yaml`) **does not**
+ship this service — different runtime model (long-lived FastAPI vs stateless
+PHP-FPM), different deps (Python venv vs Composer), and different lifecycle
+(needs explicit restart on code change).
+
+Instead, this service has its own deploy lane:
+
+- Runs as a dedicated unprivileged user `bibleget-embed` on the VPS
+  (non-chrooted, separate from the PHP deploy user).
+- Managed by systemd at the user level (`systemctl --user`).
+- Source under `~bibleget-embed/embedding/`, venv at
+  `~bibleget-embed/embedding/venv`, model cache at
+  `~bibleget-embed/.cache/huggingface/`.
+- Workflow `.github/workflows/deploy-embedding.yaml` rsyncs the sources,
+  refreshes the venv (`pip install -r requirements.txt`, idempotent),
+  reloads + restarts the systemd unit, and probes `/health`.
+
+A single instance serves all environments (dev / v3 / v4); the service is
+stateless and the model is the same regardless of which Bible version is
+being queried.
+
+## One-time server-side provisioning
+
+### As root
+
+```bash
+# 1. Create the dedicated user and enable user-level systemd at boot.
+sudo useradd -m -s /bin/bash bibleget-embed
+sudo loginctl enable-linger bibleget-embed
+
+# 2. Make sure the python3-venv apt package is installed.
+sudo apt-get install -y python3-venv
+```
+
+### As `bibleget-embed`
+
+```bash
+# 1. Set up the venv and cache the model (one-time, ~470 MB download).
+mkdir -p ~/embedding
+cd ~/embedding
+python3 -m venv venv
+. venv/bin/activate
+pip install --upgrade pip
+# Install the runtime deps (matches services/embedding/requirements.txt).
+# The deploy workflow will keep this in sync going forward.
+pip install fastapi uvicorn sentence-transformers
+# Pre-warm the model cache so cold starts are fast.
+python -c "from sentence_transformers import SentenceTransformer; \
+           SentenceTransformer('paraphrase-multilingual-MiniLM-L12-v2')"
+deactivate
+
+# 2. Set up SSH for the deploy keypair.
+mkdir -p ~/.ssh && chmod 700 ~/.ssh
+# Append the GitHub deploy keypair PUBLIC half to ~/.ssh/authorized_keys
+# (generate locally with:
+#   ssh-keygen -t ed25519 -C bibleget-embed-deploy -f bibleget-embed-deploy -N ''
+# put the .pub here, store the private half as the GitHub secret
+# VPS_EMBED_SSH_PRIVATE_KEY).
+# Then:
+chmod 600 ~/.ssh/authorized_keys
+
+# 3. Install the systemd user unit.
+mkdir -p ~/.config/systemd/user
+# The first deploy from CI will rsync bibleget-embedding.service into
+# ~/embedding/ and copy it here. For the very first start before CI runs,
+# you can install it manually from this repo:
+#
+#   cp /tmp/bibleget-embedding.service ~/.config/systemd/user/
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now bibleget-embedding
+#   systemctl --user status bibleget-embedding
+#   curl -sS http://127.0.0.1:8000/health
+```
+
+## GitHub repo configuration
+
+| Kind | Name | Value |
+|---|---|---|
+| Secret | `VPS_EMBED_USER` | `bibleget-embed` |
+| Secret | `VPS_EMBED_SSH_PRIVATE_KEY` | private half of the deploy keypair |
+| *(reused)* | `VPS_HOST`, `VPS_SSH_KNOWN_HOSTS` | already configured for the PHP deploy lane |
+| *(optional)* | `VPS_SSH_PORT` | only if SSH is not on 22 |
+
+## Wiring it up
+
+Once the service is healthy, set `EMBEDDING_SERVICE_URL=http://127.0.0.1:8000`
+in each environment's `.env` (or `.env.staging`) on the server. The PHP app
+will pick it up on the next request.
+
+## Operational commands
+
+```bash
+# Status / restart / logs (as bibleget-embed):
+systemctl --user status bibleget-embedding
+systemctl --user restart bibleget-embedding
+journalctl --user -u bibleget-embedding -f
+
+# Health probe:
+curl -sS http://127.0.0.1:8000/health
+# → {"status":"ok","model":"paraphrase-multilingual-MiniLM-L12-v2","ready":true}
+
+# Manual embed test:
+curl -sS -X POST http://127.0.0.1:8000/embed \
+  -H 'Content-Type: application/json' \
+  -d '{"text":"Blessed is the man"}' | head -c 200
+```

--- a/services/embedding/bibleget-embedding.service
+++ b/services/embedding/bibleget-embedding.service
@@ -1,0 +1,42 @@
+# Systemd user unit for the BibleGet embedding service.
+#
+# Install location: ~/.config/systemd/user/bibleget-embedding.service
+# (the deploy workflow rsyncs this file into ~/embedding/ and copies it
+# into ~/.config/systemd/user/ when it changes.)
+#
+# Operational notes:
+#   - Runs as the unprivileged `bibleget-embed` user, started by user-level
+#     systemd. Requires `loginctl enable-linger bibleget-embed` so the
+#     service runs without an active login session.
+#   - Binds 127.0.0.1:8000 only — never reachable from outside the VPS.
+#   - Loads the sentence-transformers model at startup (~30-60s on cold
+#     start), so TimeoutStartSec is generous.
+#   - Logs go to the user journal: `journalctl --user -u bibleget-embedding`
+
+[Unit]
+Description=BibleGet Embedding Service (FastAPI + sentence-transformers)
+Documentation=https://github.com/BibleGet-I-O/endpoint/tree/development/services/embedding
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/embedding
+
+# Model cached under the user's HuggingFace cache; pre-warmed during one-time
+# bootstrap so cold starts don't pay the ~470 MB download cost.
+Environment=EMBEDDING_MODEL=paraphrase-multilingual-MiniLM-L12-v2
+Environment=HF_HOME=%h/.cache/huggingface
+
+ExecStart=%h/embedding/venv/bin/uvicorn main:app --host 127.0.0.1 --port 8000
+
+Restart=on-failure
+RestartSec=5
+TimeoutStartSec=120
+
+LimitNOFILE=4096
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary

Implements the embedding-service deploy lane planned in [discussion #95](https://github.com/orgs/BibleGet-I-O/discussions/95).

The PHP rsync deploy (`deploy.yaml`) excludes `services/` because the embedding service has a fundamentally different runtime model (long-lived FastAPI vs stateless PHP-FPM), different deps (Python venv vs Composer), and different lifecycle (needs explicit restart on code change). This PR lands the parallel lane.

## Architecture (per #95)

- **Dedicated unprivileged user `bibleget-embed`** on the VPS — non-chrooted, separate from the PHP deploy user. Lingering enabled so user-level systemd runs without an active login.
- **systemd user-level unit** (`systemctl --user`) — keeps everything under the user's home, no root needed in CI.
- **Source at `~/embedding/`**, venv at `~/embedding/venv`, model cache at `~/.cache/huggingface`. Service binds `127.0.0.1:8000` only.
- **One shared instance** for all environments (dev, v3 future, v4 future). The embedding API is stateless and the model is the same regardless of which Bible version is being queried.

## Files

| Path | Purpose |
|---|---|
| `services/embedding/bibleget-embedding.service` | systemd user unit. `Type=simple`, `Restart=on-failure`, `TimeoutStartSec=120` (cold start loads the model, takes ~30–60s). Hardening: `NoNewPrivileges`, `PrivateTmp`, `LimitNOFILE=4096`. |
| `services/embedding/README.md` | One-time server-side bootstrap (useradd, lingering, venv + model warm-up, deploy keypair, initial unit install). Plus GitHub secret config and operational commands. |
| `.github/workflows/deploy-embedding.yaml` | `workflow_dispatch`-only. Rsyncs `services/embedding/` → `~/embedding/` with `--delete` (venv/Dockerfile/README/__pycache__ excluded), syncs the unit file to `~/.config/systemd/user/` when changed (daemon-reload + enable), refreshes the venv via `pip install -r requirements.txt` (idempotent), restarts the service, probes `/health` for up to 30s. |

## Required GitHub configuration

Reuses existing `VPS_HOST`, `VPS_SSH_KNOWN_HOSTS`, `VPS_SSH_PORT`. Two new secrets needed:

- `VPS_EMBED_USER` = `bibleget-embed`
- `VPS_EMBED_SSH_PRIVATE_KEY` = private half of a fresh deploy keypair (separate from the chrooted user's key)

## Required server-side bootstrap

Walked through in `services/embedding/README.md`. TL;DR:

```bash
# As root
sudo useradd -m -s /bin/bash bibleget-embed
sudo loginctl enable-linger bibleget-embed
sudo apt-get install -y python3-venv

# As bibleget-embed
mkdir -p ~/embedding
cd ~/embedding && python3 -m venv venv
. venv/bin/activate
pip install --upgrade pip fastapi uvicorn sentence-transformers
python -c "from sentence_transformers import SentenceTransformer; \
           SentenceTransformer('paraphrase-multilingual-MiniLM-L12-v2')"   # warm cache
deactivate

# (Then add deploy key public half to ~/.ssh/authorized_keys.)
```

## Test plan

- [ ] Provision `bibleget-embed` user; bootstrap venv + model cache
- [ ] Generate deploy keypair; install public half on server, store private half as `VPS_EMBED_SSH_PRIVATE_KEY`
- [ ] Add `VPS_EMBED_USER` secret
- [ ] Trigger `Deploy Embedding Service` workflow manually
- [ ] Confirm: rsync output, daemon-reload (on first run), pip install, systemd restart, `/health` returns `{"status":"ok","ready":true}` within 30s
- [ ] On the server: `curl -sS http://127.0.0.1:8000/health` and a sample `/embed` call return expected shape
- [ ] Update `.env.staging` on the server: uncomment `EMBEDDING_SERVICE_URL=http://127.0.0.1:8000`
- [ ] Smoke-test `/dev/search?q=...` (modern PSR semantic search route) — should now return real embeddings

🤖 Generated with [Claude Code](https://claude.com/claude-code)