### PR TITLE
feat(search): lock the v3 search-endpoint contract — score, canonical_order, multi-version (closes #110)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ Response emission is handled by [laminas/laminas-httphandlerrunner](https://gith
 | `/v3/metadata/biblebooks` | `MetadataHandler` | Book names in 25+ languages |
 | `/v3/metadata/bibleversions` | `MetadataHandler` | Available Bible versions |
 | `/v3/metadata/versionindex` | `MetadataHandler` | Chapter/verse indexes |
-| `/v3/search` | `SearchHandler` | Keyword search |
+| `/v3/search` | `KeywordSearchHandler` | Keyword search (legacy alias for `/v3/search/keyword`) |
+| `/v3/search/keyword` | `KeywordSearchHandler` | Full-text keyword search with stemming |
+| `/v3/search/semantic` | `SemanticSearchHandler` | Natural-language semantic search via verse embeddings |
+| `/v3/search/similar` | `SimilarSearchHandler` | Find verses similar to a given reference |
 
 ### Testing & CI
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ An example of data returned from the query `https://query.bibleget.io/v3/quote?q
   * **`title2`**: not currently used. The original idea (which may yet be implemented) was for this to contain any second-level title text preceding the given verse in the version of the Bible being quoted from.
   * **`title3`**: not currently used. The original idea (which may yet be implemented) was for this to contain any third-level title text preceding the given verse in the version of the Bible being quoted from.
   * **`originalquery`**: the original query (Bible reference indicated in the `query` parameter of the sent request) that the endpoint received, which produced this result.
+  * **`canonical_order`**: a per-response 1-based integer rank, partitioned per `version`, derived from the server's internal subverse-aware canonical-order key. When `version` is comma-separated, each version's results restart at `1`. Sort by this field client-side to recover canonical order — useful when results from a parallel `/v3/search/*` call have been re-sorted by relevance and you want to fold them back into a canonical-ordered display without a second request.
 * **`errors`**: an array which may contain strings with any error messages that may have been produced, for example for badly formed Bible quotes or for unrecognized Bible versions. An application should always check if the array is not empty, and in that case have a way of displaying the errors to the end user so the end user can understand what is happening. In any case, if the application does a good job of filtering requests in order to send only valid requests to the server, the `errors` array should be empty.
 * **`info`**: an object containing information not directly associated with the Bible verses returned, but rather with the endpoint itself. Three *key:value* pairs are currently returnd: 
   * **`ENDPOINT_VERSION`**: the version of the Endpoint against which the request was made. This can turn out to be useful information, since the data produced by the endpoint may change over time. It is useful to know which data is associated with which version of the endpoint. For example, if an application caches data returned by the endpoint, but there has been a change to the structure of the data in a new version of the API, the application would know how to deal with emptying the cache and requesting new data from the updated endpoint.
@@ -227,13 +228,17 @@ Both `GET` and `POST` requests are supported. The endpoint is [CORS enabled](htt
 
 ### PARAMETERS
 * **`keyword`**: *(required)* indicates the keyword that will be searched in the text of the Bible verses
-* **`exactmatch`**: *(optional)* since the default behaviour for a keyword search is to find any word of 4 or more letters which matches or contains the keyword, this option will try to find only exact matches and will also allow to search for words of even only 3 letters (parts of speech excluded). Accepts both string values (`"true"`, `"false"`) and native booleans in JSON request bodies.
-* **`version`**: *(required)* indicates the Bible version to search in. Cannot be a comma separated list, can only be one version, indicated using the acronym for the Bible version among the versions available on the BibleGet server (which are discoverable from the `/v3/metadata/bibleversions` endpoint)
+* **`match`**: *(optional)* matching strategy.
+  * `fulltext` (default): language-aware full-text search with stemming, accepting `websearch_to_tsquery` syntax (quoted phrases, `OR`, `-`).
+  * `boolean`: full-text search with native PostgreSQL operators (`&`, `|`, `!`, `<->`, `:*`).
+  * `exact`: regex word-boundary match (no stemming, no minimum length).
+* **`exactmatch`**: *(legacy, optional)* `exactmatch=true` is preserved as an alias for `match=exact`. Accepts both string values (`"true"`, `"false"`) and native booleans in JSON request bodies. New code should use `match` directly.
+* **`version`**: *(required)* the Bible version to search in. Comma-separated values (e.g. `NABRE,CEI2008`) search across multiple versions; results from each share a per-version `canonical_order` partition. All listed versions must share the same `ts_language` — mixed-language requests return a `400` because querying English text against an Italian dictionary returns silent zero results otherwise.
 * **`return`**: *(optional)* indicates the format in which the structured data should be returned. This parameter takes one of three values: `json`, `xml`, or `html`. If left out, this parameter will default to `json`. Rather than using this parameter, it is recommended to set the **`Accept`** header to the desired type for the response data. The **Accept** header can be set to **`application/json`**, **`application/xml`**, or **`text/html`**.
 
 
 ### STRUCTURE OF THE RETURNED DATA
-The data is structured in a similar manner to the main API endpoint (`/v3/quote`).
+The data is structured in a similar manner to the main API endpoint (`/v3/quote`), with two additional per-row fields: `score` and `canonical_order`.
 
 * **`results`**: an array containing the data associated with the single verses that contain the keyword that was searched for within the requested Bible version, whether as a full match or as a match within a word (e.g. a search for the keyword `light` will first return Bible verses that contain exactly the word `light`, then verses that contain the word `lights` seeing that *light* can be found in *lights*). The objects contained in this array are exactly the same as those returned by the main API endpoint, for example a request to https://query.bibleget.io/v3/search?keyword=light&version=NABRE will give as first result in the `results` array:
 
@@ -242,7 +247,12 @@ The data is structured in a similar manner to the main API endpoint (`/v3/quote`
     ```
     
     The `originalquery` key in this case will simply be a reference to the single verse for that search result.
-    
+
+    Each row also carries:
+
+    * **`score`** *(`float | null`)*: PostgreSQL `ts_rank_cd` cover-density score. Populated for `match=fulltext` and `match=boolean`; `null` for `match=exact` (regex word-boundary match has no relevance signal). Raw values, query-relative — they are not portable across queries. Higher = more relevant. Sort by `score DESC` client-side to recover relevance ordering.
+    * **`canonical_order`** *(`int`)*: per-response 1-based rank, partitioned per `version`, derived from the server's internal subverse-aware canonical-order key. When you sort by `score`, this lets you flip back to canonical order without a second request.
+
 * **`errors`**: an array that will contains strings of errors that may have been generated from improper usage of the endpoint, unrecognized requests (or possibly even server / database errors if any). When the API endpoint is used correctly this should generally be an empty array, developers should always check against this array to display any relevant error messages to end users so they understand what might be happening when something doesn't seem to be working correctly, and they can contact the developer with the relevant error messages produced.
 
 * **`info`**: an object containing a kind of metadata information about the search that was performed.
@@ -256,3 +266,16 @@ The data is structured in a similar manner to the main API endpoint (`/v3/quote`
     * **`keyword`**: just echoes back the keyword that was used to perform the search
     
     * **`version`**: just echoes back the acronym of the Bible version that the search was performed against
+
+
+## /v3/search/keyword, /v3/search/semantic, /v3/search/similar
+
+Three sibling search endpoints share a coherent response shape (`score`, `canonical_order`, comma-separated `version`):
+
+| Endpoint | Source | Score |
+|---|---|---|
+| `/v3/search/keyword` | full-text + stemming via PostgreSQL `to_tsvector` | `ts_rank_cd` cover-density (raw, query-relative; `null` for `match=exact`) |
+| `/v3/search/semantic` | natural-language query embedded into a vector via the embedding microservice | `1 - cosine_distance` against pre-computed verse embeddings (in `[0,1]`, query-relative) |
+| `/v3/search/similar` | a verse reference's pre-computed embedding | `1 - cosine_distance` against the rest of the version (or any additional listed versions) |
+
+`/v3/search` is preserved as a backward-compat alias for `/v3/search/keyword` (with `exactmatch=true` mapping to `match=exact`). The full per-endpoint parameter and response schema is in [`openapi.json`](./openapi.json).

--- a/openapi.json
+++ b/openapi.json
@@ -14426,7 +14426,9 @@
                             "bookabbrev": "1Mc",
                             "booknum": 19,
                             "univbooknum": "20",
-                            "originalquery": "1Mc9:7"
+                            "originalquery": "1Mc9:7",
+                            "score": 0.0607,
+                            "canonical_order": 1
                         },
                         {
                             "testament": 1,
@@ -14445,7 +14447,9 @@
                             "bookabbrev": "Ps",
                             "booknum": 22,
                             "univbooknum": "23",
-                            "originalquery": "Ps34:19"
+                            "originalquery": "Ps34:19",
+                            "score": 0.0552,
+                            "canonical_order": 2
                         },
                         {
                             "testament": 1,
@@ -14464,7 +14468,9 @@
                             "bookabbrev": "Ps",
                             "booknum": 22,
                             "univbooknum": "23",
-                            "originalquery": "Ps109:16"
+                            "originalquery": "Ps109:16",
+                            "score": 0.0488,
+                            "canonical_order": 3
                         },
                         {
                             "testament": 1,
@@ -14483,7 +14489,9 @@
                             "bookabbrev": "Ps",
                             "booknum": 22,
                             "univbooknum": "23",
-                            "originalquery": "Ps147:3"
+                            "originalquery": "Ps147:3",
+                            "score": 0.0461,
+                            "canonical_order": 4
                         },
                         {
                             "testament": 1,
@@ -14502,7 +14510,9 @@
                             "bookabbrev": "Is",
                             "booknum": 28,
                             "univbooknum": "29",
-                            "originalquery": "Is61:1"
+                            "originalquery": "Is61:1",
+                            "score": 0.0413,
+                            "canonical_order": 5
                         }
                     ],
                     "errors": [],
@@ -14717,7 +14727,7 @@
                         "description": "Per-response 1-based index, partitioned per `version` and ranked by the server's internal subverse-aware canonical-order key. Independent of array position: the array is in similarity-desc order, but sorting by `canonical_order` recovers canonical order without a second request."
                     }
                 },
-                "required": ["version", "testament", "section", "book", "bookabbrev", "booknum", "univbooknum", "chapter", "verse", "text", "canonical_order"]
+                "required": ["version", "testament", "section", "book", "bookabbrev", "booknum", "univbooknum", "chapter", "verse", "text", "score", "canonical_order"]
             },
             "SemanticSearchResponseJSON": {
                 "type": "object",

--- a/openapi.json
+++ b/openapi.json
@@ -14706,8 +14706,9 @@
                     "score": {
                         "type": "number",
                         "format": "float",
-                        "description": "Cosine similarity score (1 - cosine_distance), in [0,1]. Higher means more similar. Raw values, query-relative — not portable across queries.",
-                        "minimum": 0.0,
+                        "nullable": true,
+                        "description": "Cosine similarity score (1 - cosine_distance), in [-1, 1]. Higher means more similar. For normalized text-embedding vectors the score is typically in [0, 1], but the schema admits negative values for orthogonal-leaning matches. `null` when the score could not be computed (e.g. degenerate zero-vector inputs producing NaN). Raw values, query-relative — not portable across queries.",
+                        "minimum": -1.0,
                         "maximum": 1.0
                     },
                     "canonical_order": {
@@ -14716,7 +14717,7 @@
                         "description": "Per-response 1-based index, partitioned per `version` and ranked by the server's internal subverse-aware canonical-order key. Independent of array position: the array is in similarity-desc order, but sorting by `canonical_order` recovers canonical order without a second request."
                     }
                 },
-                "required": ["version", "testament", "section", "book", "bookabbrev", "booknum", "univbooknum", "chapter", "verse", "text", "score", "canonical_order"]
+                "required": ["version", "testament", "section", "book", "bookabbrev", "booknum", "univbooknum", "chapter", "verse", "text", "canonical_order"]
             },
             "SemanticSearchResponseJSON": {
                 "type": "object",

--- a/openapi.json
+++ b/openapi.json
@@ -439,7 +439,7 @@
                     {
                         "name": "version",
                         "in": "query",
-                        "description": "The acronym of the Bible version within which to perform the search by keyword. Can only be a single value, not a comma delimited list of values.",
+                        "description": "Bible version sigla. Comma-separated values (e.g. `NABRE,CEI2008`) search across multiple versions; results from each share a per-version `canonical_order` partition. All listed versions must share the same `ts_language` — mixed-language requests return 400.",
                         "required": true,
                         "schema": {
                             "type": "string"
@@ -641,7 +641,7 @@
                     {
                         "name": "version",
                         "in": "query",
-                        "description": "The sigla of the Bible version to search within",
+                        "description": "Bible version sigla. Comma-separated values (e.g. `NABRE,CEI2008`) search across multiple versions; results from each version share a per-version `canonical_order` partition. All listed versions must share the same `ts_language` (English text against an Italian dictionary returns silent zero results otherwise) — mixed-language requests return 400.",
                         "required": true,
                         "schema": {
                             "type": "string"
@@ -730,7 +730,7 @@
                     {
                         "name": "version",
                         "in": "query",
-                        "description": "The sigla of the Bible version to search within",
+                        "description": "Bible version sigla. Comma-separated values (e.g. `NABRE,CEI2008`) search across multiple versions; results from each version share a per-version `canonical_order` partition. The multilingual embedding model handles cross-language similarity natively, so mixed-language version lists are accepted.",
                         "required": true,
                         "schema": {
                             "type": "string"
@@ -817,7 +817,7 @@
                     {
                         "name": "version",
                         "in": "query",
-                        "description": "The sigla of the Bible version to search within",
+                        "description": "Bible version sigla. The first listed version supplies the source verse's embedding (resolved against its book index). Comma-separated values (e.g. `NABRE,CEI2008,VGCL`) extend the search to additional target versions; results from each share a per-version `canonical_order` partition. Replaces the earlier `crossversion=true` boolean.",
                         "required": true,
                         "schema": {
                             "type": "string"
@@ -834,16 +834,6 @@
                             "default": 10,
                             "minimum": 1,
                             "maximum": 100
-                        }
-                    },
-                    {
-                        "name": "crossversion",
-                        "in": "query",
-                        "description": "When true, search for similar passages across all available Bible versions, not just the specified one",
-                        "required": false,
-                        "schema": {
-                            "type": "boolean",
-                            "default": false
                         }
                     },
                     {
@@ -1508,6 +1498,14 @@
                             "attribute": true
                         },
                         "example": "1John4,7-8"
+                    },
+                    "canonical_order": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "Per-response 1-based index, partitioned per `version` and ranked by the server's internal subverse-aware canonical-order key. Sort by this field to recover canonical order client-side. Lets a client that re-sorts results (e.g. by relevance from a parallel `/search/*` call) recover canonical order without a second request.",
+                        "xml": {
+                            "attribute": true
+                        }
                     }
                 },
                 "xml": {
@@ -14358,6 +14356,23 @@
                                     "xml": {
                                         "attribute": true
                                     }
+                                },
+                                "score": {
+                                    "type": "number",
+                                    "format": "float",
+                                    "nullable": true,
+                                    "description": "PostgreSQL `ts_rank_cd` cover-density score. Populated when the match mode produces a relevance signal (`fulltext`, `boolean`); `null` for `match=exact` (regex word-boundary match has no relevance signal). Raw values, query-relative — not portable across queries. Higher = more relevant.",
+                                    "xml": {
+                                        "attribute": true
+                                    }
+                                },
+                                "canonical_order": {
+                                    "type": "integer",
+                                    "minimum": 1,
+                                    "description": "Per-response 1-based index, partitioned per `version` and ranked by the server's internal subverse-aware canonical-order key. Sort by this field to recover canonical order client-side; sort by `score` for relevance. Independent of array position — the array is in canonical order by default, but a client that re-sorts by `score` can recover canonical order via this field without a second request.",
+                                    "xml": {
+                                        "attribute": true
+                                    }
                                 }
                             }
                         },
@@ -14648,7 +14663,7 @@
             },
             "SemanticSearchResultItem": {
                 "type": "object",
-                "description": "A verse result from semantic or similar search, including a similarity score",
+                "description": "A verse result from semantic or similar search, including a relevance score and a per-response canonical_order rank.",
                 "properties": {
                     "version": {
                         "type": "string",
@@ -14688,15 +14703,20 @@
                         "type": "string",
                         "description": "The verse text"
                     },
-                    "similarity": {
+                    "score": {
                         "type": "number",
                         "format": "float",
-                        "description": "Cosine similarity score (0.0–1.0). Higher means more similar.",
+                        "description": "Cosine similarity score (1 - cosine_distance), in [0,1]. Higher means more similar. Raw values, query-relative — not portable across queries.",
                         "minimum": 0.0,
                         "maximum": 1.0
+                    },
+                    "canonical_order": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "Per-response 1-based index, partitioned per `version` and ranked by the server's internal subverse-aware canonical-order key. Independent of array position: the array is in similarity-desc order, but sorting by `canonical_order` recovers canonical order without a second request."
                     }
                 },
-                "required": ["version", "testament", "section", "book", "bookabbrev", "booknum", "univbooknum", "chapter", "verse", "text", "similarity"]
+                "required": ["version", "testament", "section", "book", "bookabbrev", "booknum", "univbooknum", "chapter", "verse", "text", "score", "canonical_order"]
             },
             "SemanticSearchResponseJSON": {
                 "type": "object",

--- a/src/Handlers/KeywordSearchHandler.php
+++ b/src/Handlers/KeywordSearchHandler.php
@@ -59,7 +59,9 @@ class KeywordSearchHandler extends AbstractHandler
         // Validate every requested version up front.
         $validatedVersions = [];
         foreach ($versions as $v) {
-            $validatedVersions[] = $this->validateVersion($pdo, $v);
+            $validated = $this->validateVersion($pdo, $v);
+            $this->assertValidVersionFormat($validated);
+            $validatedVersions[] = $validated;
         }
 
         // Keyword search is language-bound: querying English text against an
@@ -307,7 +309,7 @@ class KeywordSearchHandler extends AbstractHandler
                 continue;
             }
             $score     = isset($row['score']) && is_numeric($row['score']) && is_finite((float) $row['score'])
-                ? (float) $row['score']
+                ? round((float) $row['score'], 4)
                 : null;
             $entry     = [
                 'version'     => $version,

--- a/src/Handlers/KeywordSearchHandler.php
+++ b/src/Handlers/KeywordSearchHandler.php
@@ -8,6 +8,7 @@ use BibleGet\Api\Database\Connection;
 use BibleGet\Api\Http\Exception\InternalServerErrorException;
 use BibleGet\Api\Http\Exception\ValidationException;
 use BibleGet\Api\Http\Logs\LoggerFactory;
+use BibleGet\Api\Util\SearchUtils;
 use BibleGet\Api\Util\StringUtils;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -51,35 +52,62 @@ class KeywordSearchHandler extends AbstractHandler
         $contentType = $this->resolveResponseContentType($request, $params);
         $response    = $this->initResponse($request, $contentType);
 
-        [$keyword, $version, $matchMode] = $this->extractSearchParams($params);
+        [$keyword, $versions, $matchMode] = $this->extractSearchParams($params);
 
-        $pdo          = Connection::getConnection();
-        $version      = $this->validateVersion($pdo, $version);
-        $tsLanguage   = $this->getVersionLanguage($pdo, $version);
-        $versionIndex = $this->loadVersionIndex($pdo, $version);
+        $pdo = Connection::getConnection();
 
-        $searchResult = $this->executeSearch($pdo, $version, $keyword, $matchMode, $tsLanguage);
-        $results      = $this->mapSearchResults($searchResult, $version, $versionIndex);
+        // Validate every requested version up front.
+        $validatedVersions = [];
+        foreach ($versions as $v) {
+            $validatedVersions[] = $this->validateVersion($pdo, $v);
+        }
+
+        // Keyword search is language-bound: querying English text against an
+        // Italian dictionary returns nothing of value. Reject mixed-language
+        // requests so the failure mode is a clear 400 rather than silent zero
+        // results. Semantic / similar search have no such constraint.
+        $tsLanguagesByVersion = [];
+        foreach ($validatedVersions as $v) {
+            $tsLanguagesByVersion[$v] = $this->getVersionLanguage($pdo, $v);
+        }
+        $distinctLanguages = array_values(array_unique(array_values($tsLanguagesByVersion)));
+        if (count($distinctLanguages) > 1) {
+            throw new ValidationException(
+                'Cannot mix versions with different ts_language on /search/keyword: '
+                . implode(', ', array_map(
+                    static fn(string $v): string => $v . ' (' . $tsLanguagesByVersion[$v] . ')',
+                    $validatedVersions
+                ))
+            );
+        }
+        $tsLanguage = $distinctLanguages[0] ?? 'simple';
+
+        $allResults = [];
+        foreach ($validatedVersions as $v) {
+            $versionIndex = $this->loadVersionIndex($pdo, $v);
+            $searchResult = $this->executeSearch($pdo, $v, $keyword, $matchMode, $tsLanguage);
+            array_push($allResults, ...$this->mapSearchResults($searchResult, $v, $versionIndex));
+        }
+
+        SearchUtils::assignCanonicalOrder($allResults);
 
         $body          = new \stdClass();
-        $body->results = $results;
+        $body->results = $allResults;
         $body->errors  = [];
         $body->info    = ['ENDPOINT_VERSION' => self::ENDPOINT_VERSION];
 
-        $response = $this->buildSearchResponse($response, $contentType, $body, $results);
+        $response = $this->buildSearchResponse($response, $contentType, $body, $allResults);
         return $this->withCacheHeaders($request, $response);
     }
 
     /**
      * @param array<string, mixed> $params
-     * @return array{string, string, string}
+     * @return array{string, list<string>, string}
      */
     private function extractSearchParams(array $params): array
     {
         $keywordRaw = $params['keyword'] ?? '';
         $keyword    = is_string($keywordRaw) ? $keywordRaw : '';
-        $versionRaw = $params['version'] ?? '';
-        $version    = is_string($versionRaw) ? $versionRaw : '';
 
         // Resolve match mode: explicit `match` param takes precedence over legacy `exactmatch`
         $matchRaw = $params['match'] ?? '';
@@ -99,16 +127,16 @@ class KeywordSearchHandler extends AbstractHandler
         if ($keyword === '') {
             throw new ValidationException('The keyword parameter is required.');
         }
-        if ($version === '') {
-            throw new ValidationException('The version parameter is required.');
-        }
         if (!in_array($match, self::VALID_MATCH_MODES, true)) {
             throw new ValidationException(
                 'Invalid match mode: ' . $match . '. Valid modes are: ' . implode(', ', self::VALID_MATCH_MODES)
             );
         }
 
-        return [$keyword, $version, $match];
+        // Comma-separated `version=A,B,C` (single value still accepted).
+        $versions = SearchUtils::parseVersionsParam($params['version'] ?? '');
+
+        return [$keyword, $versions, $match];
     }
 
     private function validateVersion(\PDO $pdo, string $version): string
@@ -198,11 +226,13 @@ class KeywordSearchHandler extends AbstractHandler
 
         switch ($matchMode) {
             case 'exact':
-                // Escape PostgreSQL regex metacharacters so the keyword is matched literally
+                // Escape PostgreSQL regex metacharacters so the keyword is matched literally.
+                // No relevance signal in regex matches → score is null per row.
                 $escapedKeyword = preg_replace('/([.*+?^${}()|[\]\\\\])/', '\\\\\\1', $keyword) ?? $keyword;
                 try {
                     $stmt = $pdo->prepare(
-                        'SELECT * FROM "' . $version . '" WHERE text ~* (\'\y\' || ? || \'\y\') ORDER BY book, chapter, verse'
+                        'SELECT *, NULL::float8 AS score FROM "' . $version . '" '
+                        . 'WHERE text ~* (\'\y\' || ? || \'\y\') ORDER BY "verseID"'
                     );
                     $stmt->execute([$escapedKeyword]);
                 } catch (\PDOException) {
@@ -221,9 +251,13 @@ class KeywordSearchHandler extends AbstractHandler
                 }
                 try {
                     $stmt = $pdo->prepare(
-                        'SELECT * FROM "' . $version . '" WHERE to_tsvector(\'' . $tsLanguage . '\', text) @@ to_tsquery(\'' . $tsLanguage . '\', ?) ORDER BY book, chapter, verse'
+                        'SELECT *, '
+                        . 'ts_rank_cd(to_tsvector(\'' . $tsLanguage . '\', text), to_tsquery(\'' . $tsLanguage . '\', ?)) AS score '
+                        . 'FROM "' . $version . '" '
+                        . 'WHERE to_tsvector(\'' . $tsLanguage . '\', text) @@ to_tsquery(\'' . $tsLanguage . '\', ?) '
+                        . 'ORDER BY "verseID"'
                     );
-                    $stmt->execute([$keyword]);
+                    $stmt->execute([$keyword, $keyword]);
                 } catch (\PDOException) {
                     throw new ValidationException(
                         'Invalid boolean search expression. Use operators like & (AND), | (OR), ! (NOT).'
@@ -240,9 +274,13 @@ class KeywordSearchHandler extends AbstractHandler
                 }
                 try {
                     $stmt = $pdo->prepare(
-                        'SELECT * FROM "' . $version . '" WHERE to_tsvector(\'' . $tsLanguage . '\', text) @@ websearch_to_tsquery(\'' . $tsLanguage . '\', ?) ORDER BY book, chapter, verse'
+                        'SELECT *, '
+                        . 'ts_rank_cd(to_tsvector(\'' . $tsLanguage . '\', text), websearch_to_tsquery(\'' . $tsLanguage . '\', ?)) AS score '
+                        . 'FROM "' . $version . '" '
+                        . 'WHERE to_tsvector(\'' . $tsLanguage . '\', text) @@ websearch_to_tsquery(\'' . $tsLanguage . '\', ?) '
+                        . 'ORDER BY "verseID"'
                     );
-                    $stmt->execute([$sanitizedKeyword]);
+                    $stmt->execute([$sanitizedKeyword, $sanitizedKeyword]);
                 } catch (\PDOException) {
                     throw new ValidationException(
                         'Full-text search failed. Please try a different keyword.'
@@ -268,6 +306,9 @@ class KeywordSearchHandler extends AbstractHandler
                 $this->logger->error('Unmapped book number ' . ( is_scalar($row['book']) ? (string) $row['book'] : 'unknown' ) . ' in version index for search result');
                 continue;
             }
+            $score     = isset($row['score']) && is_numeric($row['score']) && is_finite((float) $row['score'])
+                ? (float) $row['score']
+                : null;
             $entry     = [
                 'version'     => $version,
                 'testament'   => is_numeric($row['testament']) ? (int) $row['testament'] : 0,
@@ -279,6 +320,10 @@ class KeywordSearchHandler extends AbstractHandler
                 'section'     => is_numeric($row['section']) ? (int) $row['section'] : 0,
                 'chapter'     => is_numeric($row['chapter']) ? (int) $row['chapter'] : 0,
                 'verse'       => is_numeric($row['verse']) ? (int) $row['verse'] : 0,
+                'score'       => $score,
+                // Carried forward solely so SearchUtils::assignCanonicalOrder
+                // can rank rows; unset before the row leaves the handler.
+                'verseID'     => is_numeric($row['verseID'] ?? null) ? (int) $row['verseID'] : 0,
             ];
             $results[] = $entry;
         }

--- a/src/Handlers/QuoteHandler.php
+++ b/src/Handlers/QuoteHandler.php
@@ -11,6 +11,7 @@ use BibleGet\Api\Pipeline\QuoteContext;
 use BibleGet\Api\Pipeline\QueryValidator;
 use BibleGet\Api\Pipeline\QueryFormulator;
 use BibleGet\Api\Pipeline\QueryExecutor;
+use BibleGet\Api\Util\SearchUtils;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -71,6 +72,9 @@ class QuoteHandler extends AbstractHandler
             $executor = new QueryExecutor($ctx);
             $executor->executeSQLQueries();
         }
+
+        // Per-version 1-based canonical_order (subverse-aware), verseID stripped.
+        SearchUtils::assignCanonicalOrder($ctx->results);
 
         // Build response body
         $response = $this->buildResponse($response, $contentType, $ctx);

--- a/src/Handlers/SemanticSearchHandler.php
+++ b/src/Handlers/SemanticSearchHandler.php
@@ -95,14 +95,40 @@ class SemanticSearchHandler extends AbstractHandler
             }
         }
 
-        // Run pgvector cosine similarity per version, then merge globally by score.
-        $dbStart    = microtime(true);
-        $allResults = [];
+        // Run pgvector cosine similarity per version, then merge globally by
+        // score. Cache loadVersionIndex results so each version's *_idx table
+        // is queried at most once per request even when version=A,B,C.
+        $dbStart        = microtime(true);
+        $allResults     = [];
+        $versionIndexes = [];
         foreach ($validatedVersions as $v) {
-            array_push($allResults, ...$this->executeSimilaritySearch($pdo, $v, $queryVector, $limit, $threshold));
+            $versionIndexes[$v] = $this->loadVersionIndex($pdo, $v);
+            array_push($allResults, ...$this->executeSimilaritySearch(
+                $pdo,
+                $v,
+                $queryVector,
+                $versionIndexes[$v],
+                $limit,
+                $threshold
+            ));
         }
         // Global ordering by score DESC across versions, then trim to limit.
-        usort($allResults, static fn(array $a, array $b): int => ( $b['score'] ?? 0 ) <=> ( $a['score'] ?? 0 ));
+        // Null scores (computation failures) sort to the bottom so a genuine
+        // 0.0 still outranks them.
+        usort($allResults, static function (array $a, array $b): int {
+            $sa = $a['score'] ?? null;
+            $sb = $b['score'] ?? null;
+            if ($sa === null && $sb === null) {
+                return 0;
+            }
+            if ($sa === null) {
+                return 1;
+            }
+            if ($sb === null) {
+                return -1;
+            }
+            return $sb <=> $sa;
+        });
         $allResults = array_slice($allResults, 0, $limit);
 
         // Per-version 1-based canonical_order (subverse-aware), verseID stripped.
@@ -176,14 +202,12 @@ class SemanticSearchHandler extends AbstractHandler
 
     /**
      * @param float[] $queryVector
+     * @param array{abbreviations: list<string>, books: list<string>, book_num: list<string>} $versionIndex
      * @return array<int, array<string, mixed>>
      */
-    private function executeSimilaritySearch(\PDO $pdo, string $version, array $queryVector, int $limit, float $threshold): array
+    private function executeSimilaritySearch(\PDO $pdo, string $version, array $queryVector, array $versionIndex, int $limit, float $threshold): array
     {
         $vectorStr = '[' . implode(',', $queryVector) . ']';
-
-        // Load version index for book name mapping
-        $versionIndex = $this->loadVersionIndex($pdo, $version);
 
         $sql = 'SELECT *, 1 - (embedding <=> ?::vector) AS score '
              . 'FROM "' . $version . '" '
@@ -199,9 +223,13 @@ class SemanticSearchHandler extends AbstractHandler
         while (is_array($row = $stmt->fetch(\PDO::FETCH_ASSOC))) {
             $bookidx = array_search($row['book'], $versionIndex['book_num']);
 
+            // null (rather than 0.0) when the score can't be computed, so a
+            // genuine score of 0.0 — orthogonal verses — is distinguishable
+            // from "no score". Comparators that order results must treat
+            // null as worse than any numeric score.
             $score = isset($row['score']) && is_numeric($row['score']) && is_finite((float) $row['score'])
                 ? round((float) $row['score'], 4)
-                : 0.0;
+                : null;
 
             $entry     = [
                 'version'     => $version,

--- a/src/Handlers/SemanticSearchHandler.php
+++ b/src/Handlers/SemanticSearchHandler.php
@@ -11,6 +11,7 @@ use BibleGet\Api\Http\Exception\ValidationException;
 use BibleGet\Api\Http\Logs\LoggerFactory;
 use BibleGet\Api\Services\EmbeddingClient;
 use BibleGet\Api\Services\EmbeddingModelValidator;
+use BibleGet\Api\Util\SearchUtils;
 use BibleGet\Api\Util\StringUtils;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -62,13 +63,18 @@ class SemanticSearchHandler extends AbstractHandler
         $contentType = $this->resolveResponseContentType($request, $params);
         $response    = $this->initResponse($request, $contentType);
 
-        [$query, $version, $limit, $threshold] = $this->extractParams($params);
+        [$query, $versions, $limit, $threshold] = $this->extractParams($params);
 
-        $pdo     = Connection::getConnection();
-        $version = $this->validateVersion($pdo, $version);
-        $this->assertValidVersionFormat($version);
+        $pdo = Connection::getConnection();
 
-        // Embed the user's query via the Python microservice
+        $validatedVersions = [];
+        foreach ($versions as $v) {
+            $validated = $this->validateVersion($pdo, $v);
+            $this->assertValidVersionFormat($validated);
+            $validatedVersions[] = $validated;
+        }
+
+        // Embed the user's query via the Python microservice (once, reused per version)
         $embedStart = microtime(true);
         try {
             $queryVector = $this->embeddingClient->embed($query);
@@ -81,38 +87,47 @@ class SemanticSearchHandler extends AbstractHandler
         $embedMs = round(( microtime(true) - $embedStart ) * 1000, 1);
         $this->logger->info('Embedding latency: ' . $embedMs . 'ms for query: ' . substr($query, 0, 100));
 
-        // Warn if stored embeddings were computed with a different model
+        // Warn if stored embeddings were computed with a different model (per version)
         $serviceModel = $this->embeddingClient->getLastModel();
         if ($serviceModel !== '') {
-            EmbeddingModelValidator::validate($pdo, $version, $serviceModel, $this->logger);
+            foreach ($validatedVersions as $v) {
+                EmbeddingModelValidator::validate($pdo, $v, $serviceModel, $this->logger);
+            }
         }
 
-        // Run pgvector cosine similarity search
-        $dbStart = microtime(true);
-        $results = $this->executeSimilaritySearch($pdo, $version, $queryVector, $limit, $threshold);
-        $dbMs    = round(( microtime(true) - $dbStart ) * 1000, 1);
-        $this->logger->info('Similarity search latency: ' . $dbMs . 'ms (' . count($results) . ' results)');
+        // Run pgvector cosine similarity per version, then merge globally by score.
+        $dbStart    = microtime(true);
+        $allResults = [];
+        foreach ($validatedVersions as $v) {
+            array_push($allResults, ...$this->executeSimilaritySearch($pdo, $v, $queryVector, $limit, $threshold));
+        }
+        // Global ordering by score DESC across versions, then trim to limit.
+        usort($allResults, static fn(array $a, array $b): int => ( $b['score'] ?? 0 ) <=> ( $a['score'] ?? 0 ));
+        $allResults = array_slice($allResults, 0, $limit);
+
+        // Per-version 1-based canonical_order (subverse-aware), verseID stripped.
+        SearchUtils::assignCanonicalOrder($allResults);
+
+        $dbMs = round(( microtime(true) - $dbStart ) * 1000, 1);
+        $this->logger->info('Similarity search latency: ' . $dbMs . 'ms (' . count($allResults) . ' results)');
 
         $body          = new \stdClass();
-        $body->results = $results;
+        $body->results = $allResults;
         $body->errors  = [];
         $body->info    = ['ENDPOINT_VERSION' => self::ENDPOINT_VERSION];
 
-        $response = $this->buildResponse($response, $contentType, $body, $results);
+        $response = $this->buildResponse($response, $contentType, $body, $allResults);
         return $this->withCacheHeaders($request, $response);
     }
 
     /**
      * @param array<string, mixed> $params
-     * @return array{string, string, int, float}
+     * @return array{string, list<string>, int, float}
      */
     private function extractParams(array $params): array
     {
         $queryRaw = $params['query'] ?? '';
         $query    = is_string($queryRaw) ? trim($queryRaw) : '';
-
-        $versionRaw = $params['version'] ?? '';
-        $version    = is_string($versionRaw) ? $versionRaw : '';
 
         $limitRaw = $params['limit'] ?? self::DEFAULT_LIMIT;
         $limit    = is_numeric($limitRaw) ? (int) $limitRaw : self::DEFAULT_LIMIT;
@@ -125,11 +140,11 @@ class SemanticSearchHandler extends AbstractHandler
         if ($query === '') {
             throw new ValidationException('The query parameter is required.');
         }
-        if ($version === '') {
-            throw new ValidationException('The version parameter is required.');
-        }
 
-        return [$query, $version, $limit, $threshold];
+        // Comma-separated `version=A,B,C` (single value still accepted).
+        $versions = SearchUtils::parseVersionsParam($params['version'] ?? '');
+
+        return [$query, $versions, $limit, $threshold];
     }
 
     private function validateVersion(\PDO $pdo, string $version): string
@@ -170,7 +185,7 @@ class SemanticSearchHandler extends AbstractHandler
         // Load version index for book name mapping
         $versionIndex = $this->loadVersionIndex($pdo, $version);
 
-        $sql = 'SELECT *, 1 - (embedding <=> ?::vector) AS similarity '
+        $sql = 'SELECT *, 1 - (embedding <=> ?::vector) AS score '
              . 'FROM "' . $version . '" '
              . 'WHERE embedding IS NOT NULL '
              . 'AND 1 - (embedding <=> ?::vector) >= ? '
@@ -184,6 +199,10 @@ class SemanticSearchHandler extends AbstractHandler
         while (is_array($row = $stmt->fetch(\PDO::FETCH_ASSOC))) {
             $bookidx = array_search($row['book'], $versionIndex['book_num']);
 
+            $score = isset($row['score']) && is_numeric($row['score']) && is_finite((float) $row['score'])
+                ? round((float) $row['score'], 4)
+                : 0.0;
+
             $entry     = [
                 'version'     => $version,
                 'testament'   => is_numeric($row['testament']) ? (int) $row['testament'] : 0,
@@ -195,9 +214,10 @@ class SemanticSearchHandler extends AbstractHandler
                 'section'     => is_numeric($row['section']) ? (int) $row['section'] : 0,
                 'chapter'     => is_numeric($row['chapter']) ? (int) $row['chapter'] : 0,
                 'verse'       => is_numeric($row['verse']) ? (int) $row['verse'] : 0,
-                'similarity'  => isset($row['similarity']) && is_numeric($row['similarity']) && is_finite((float) $row['similarity'])
-                    ? round((float) $row['similarity'], 4)
-                    : 0.0,
+                'score'       => $score,
+                // Carried forward solely so SearchUtils::assignCanonicalOrder
+                // can rank rows; unset before the row leaves the handler.
+                'verseID'     => is_numeric($row['verseID'] ?? null) ? (int) $row['verseID'] : 0,
             ];
             $results[] = $entry;
         }

--- a/src/Handlers/SimilarSearchHandler.php
+++ b/src/Handlers/SimilarSearchHandler.php
@@ -112,9 +112,24 @@ class SimilarSearchHandler extends AbstractHandler
             ));
         }
 
-        // Multi-version: sort globally by score DESC and trim to the user's limit.
+        // Multi-version: sort globally by score DESC and trim to the user's
+        // limit. Null scores (computation failures) sort to the bottom so a
+        // genuine 0.0 still outranks them.
         if (count($validatedVersions) > 1) {
-            usort($allResults, static fn(array $a, array $b): int => ( $b['score'] ?? 0 ) <=> ( $a['score'] ?? 0 ));
+            usort($allResults, static function (array $a, array $b): int {
+                $sa = $a['score'] ?? null;
+                $sb = $b['score'] ?? null;
+                if ($sa === null && $sb === null) {
+                    return 0;
+                }
+                if ($sa === null) {
+                    return 1;
+                }
+                if ($sb === null) {
+                    return -1;
+                }
+                return $sb <=> $sa;
+            });
             $allResults = array_slice($allResults, 0, $limit);
         }
 
@@ -268,9 +283,13 @@ class SimilarSearchHandler extends AbstractHandler
         while (is_array($row = $stmt->fetch(\PDO::FETCH_ASSOC))) {
             $bookidx = array_search($row['book'], $versionIndex['book_num']);
 
+            // null (rather than 0.0) when the score can't be computed, so a
+            // genuine score of 0.0 — orthogonal verses — is distinguishable
+            // from "no score". Comparators that order results must treat
+            // null as worse than any numeric score.
             $score = isset($row['score']) && is_numeric($row['score']) && is_finite((float) $row['score'])
                 ? round((float) $row['score'], 4)
-                : 0.0;
+                : null;
 
             $entry     = [
                 'version'     => $version,

--- a/src/Handlers/SimilarSearchHandler.php
+++ b/src/Handlers/SimilarSearchHandler.php
@@ -9,6 +9,7 @@ use BibleGet\Api\Http\Exception\InternalServerErrorException;
 use BibleGet\Api\Http\Exception\NotFoundException;
 use BibleGet\Api\Http\Exception\ValidationException;
 use BibleGet\Api\Http\Logs\LoggerFactory;
+use BibleGet\Api\Util\SearchUtils;
 use BibleGet\Api\Util\StringUtils;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -48,74 +49,111 @@ class SimilarSearchHandler extends AbstractHandler
         $contentType = $this->resolveResponseContentType($request, $params);
         $response    = $this->initResponse($request, $contentType);
 
-        [$reference, $version, $limit, $crossversion] = $this->extractParams($params);
+        [$reference, $versions, $limit] = $this->extractParams($params);
 
-        $pdo     = Connection::getConnection();
-        $version = $this->validateVersion($pdo, $version);
-        $this->assertValidVersionFormat($version);
+        $pdo = Connection::getConnection();
 
-        // Enforce copyright restriction: limit to 30 results for copyrighted versions
-        if ($this->isVersionCopyrighted($pdo, $version)) {
-            $limit = min($limit, 30);
+        $validatedVersions = [];
+        foreach ($versions as $v) {
+            $validated = $this->validateVersion($pdo, $v);
+            $this->assertValidVersionFormat($validated);
+            $validatedVersions[] = $validated;
         }
+
+        // The first version supplies the source verse's embedding; all listed
+        // versions are then searched. The source verse is excluded from results
+        // across every target version (verses share book/chapter/verse across
+        // the canonical books).
+        $sourceVersion = $validatedVersions[0];
 
         // Parse the reference into book abbreviation, chapter, and verse
         [$bookAbbrev, $chapter, $verse] = $this->parseReference($reference);
 
-        // Resolve book number from version index
-        $versionIndex = $this->loadVersionIndex($pdo, $version);
-        $bookNum      = $this->resolveBookNumber($bookAbbrev, $versionIndex);
+        // Resolve book number from the source version's index
+        $sourceVersionIndex = $this->loadVersionIndex($pdo, $sourceVersion);
+        $bookNum            = $this->resolveBookNumber($bookAbbrev, $sourceVersionIndex);
 
-        // Look up the source verse's embedding
-        $sourceEmbedding = $this->getVerseEmbedding($pdo, $version, $bookNum, $chapter, $verse);
+        // Look up the source verse's embedding (from the source version only)
+        $sourceEmbedding = $this->getVerseEmbedding($pdo, $sourceVersion, $bookNum, $chapter, $verse);
 
-        if ($crossversion) {
-            $allVersions = $this->getAllVersions($pdo);
-            $results     = $this->searchAcrossVersions($pdo, $allVersions, $sourceEmbedding, $limit, $version, $bookNum, $chapter, $verse);
-        } else {
-            $results = $this->searchSimilar($pdo, $version, $versionIndex, $sourceEmbedding, $limit, $bookNum, $chapter, $verse);
+        // Reject mixed-model embeddings: skip target versions whose embeddings
+        // were computed with a different model than the source's.
+        $sourceModel = $this->getEmbeddingModel($pdo, $sourceVersion);
+
+        $allResults = [];
+        foreach ($validatedVersions as $v) {
+            if ($v !== $sourceVersion && $sourceModel !== '') {
+                $vModel = $this->getEmbeddingModel($pdo, $v);
+                if ($vModel !== '' && $vModel !== $sourceModel) {
+                    $this->logger->info(
+                        'Skipping version ' . $v . ' in similar search: embedding model mismatch ('
+                        . $vModel . ' vs ' . $sourceModel . ')'
+                    );
+                    continue;
+                }
+            }
+
+            $versionIndex = ( $v === $sourceVersion )
+                ? $sourceVersionIndex
+                : $this->loadVersionIndex($pdo, $v);
+
+            // Per-target copyright restriction: cap to 30 for copyrighted versions.
+            $versionLimit = $this->isVersionCopyrighted($pdo, $v) ? min($limit, 30) : $limit;
+
+            array_push($allResults, ...$this->searchSimilar(
+                $pdo,
+                $v,
+                $versionIndex,
+                $sourceEmbedding,
+                $versionLimit,
+                $bookNum,
+                $chapter,
+                $verse
+            ));
         }
 
+        // Multi-version: sort globally by score DESC and trim to the user's limit.
+        if (count($validatedVersions) > 1) {
+            usort($allResults, static fn(array $a, array $b): int => ( $b['score'] ?? 0 ) <=> ( $a['score'] ?? 0 ));
+            $allResults = array_slice($allResults, 0, $limit);
+        }
+
+        // Per-version 1-based canonical_order (subverse-aware), verseID stripped.
+        SearchUtils::assignCanonicalOrder($allResults);
+
         $body          = new \stdClass();
-        $body->results = $results;
+        $body->results = $allResults;
         $body->errors  = [];
         $body->info    = ['ENDPOINT_VERSION' => self::ENDPOINT_VERSION];
 
-        $response = $this->buildResponse($response, $contentType, $body, $results);
+        $response = $this->buildResponse($response, $contentType, $body, $allResults);
         return $this->withCacheHeaders($request, $response);
     }
 
     /**
      * @param array<string, mixed> $params
-     * @return array{string, string, int, bool}
+     * @return array{string, list<string>, int}
      */
     private function extractParams(array $params): array
     {
         $referenceRaw = $params['reference'] ?? '';
         $reference    = is_string($referenceRaw) ? trim($referenceRaw) : '';
 
-        $versionRaw = $params['version'] ?? '';
-        $version    = is_string($versionRaw) ? $versionRaw : '';
-
         $limitRaw = $params['limit'] ?? self::DEFAULT_LIMIT;
         $limit    = is_numeric($limitRaw) ? (int) $limitRaw : self::DEFAULT_LIMIT;
         $limit    = max(1, min($limit, self::MAX_LIMIT));
 
-        $crossversionRaw = $params['crossversion'] ?? false;
-        $crossversion    = match (true) {
-            is_bool($crossversionRaw)   => $crossversionRaw,
-            is_string($crossversionRaw) => filter_var($crossversionRaw, FILTER_VALIDATE_BOOLEAN),
-            default                     => false,
-        };
-
         if ($reference === '') {
             throw new ValidationException('The reference parameter is required.');
         }
-        if ($version === '') {
-            throw new ValidationException('The version parameter is required.');
-        }
 
-        return [$reference, $version, $limit, $crossversion];
+        // Comma-separated `version=A,B,C` (single value still accepted). The
+        // first version supplies the source verse's embedding; all listed
+        // versions are then searched. Replaces the earlier `crossversion=true`
+        // boolean (issue #110).
+        $versions = SearchUtils::parseVersionsParam($params['version'] ?? '');
+
+        return [$reference, $versions, $limit];
     }
 
     /**
@@ -205,7 +243,7 @@ class SimilarSearchHandler extends AbstractHandler
         int $excludeChapter,
         int $excludeVerse
     ): array {
-        $sql = 'SELECT *, 1 - (embedding <=> ?::vector) AS similarity '
+        $sql = 'SELECT *, 1 - (embedding <=> ?::vector) AS score '
              . 'FROM "' . $version . '" '
              . 'WHERE embedding IS NOT NULL '
              . 'AND NOT (book = ? AND chapter = ? AND verse = ?) '
@@ -218,60 +256,7 @@ class SimilarSearchHandler extends AbstractHandler
         return $this->mapResults($stmt, $version, $versionIndex);
     }
 
-    /**
-     * @param list<string> $versions
-     * @return array<int, array<string, mixed>>
-     */
-    private function searchAcrossVersions(
-        \PDO $pdo,
-        array $versions,
-        string $sourceEmbedding,
-        int $limit,
-        string $sourceVersion,
-        int $excludeBook,
-        int $excludeChapter,
-        int $excludeVerse
-    ): array {
-        $allResults = [];
 
-        // Only include versions whose embeddings were computed with the same model
-        $sourceModel = $this->getEmbeddingModel($pdo, $sourceVersion);
-
-        foreach ($versions as $v) {
-            if (!preg_match('/^[A-Za-z0-9_]+$/', $v)) {
-                continue;
-            }
-
-            if ($v !== $sourceVersion && $sourceModel !== '') {
-                $vModel = $this->getEmbeddingModel($pdo, $v);
-                if ($vModel !== '' && $vModel !== $sourceModel) {
-                    $this->logger->info('Skipping version ' . $v . ' in cross-version search: embedding model mismatch (' . $vModel . ' vs ' . $sourceModel . ')');
-                    continue;
-                }
-            }
-
-            $versionIndex = $this->loadVersionIndex($pdo, $v);
-
-            // Enforce copyright restriction per target version
-            $versionLimit = $this->isVersionCopyrighted($pdo, $v) ? min($limit, 30) : $limit;
-
-            $sql  = 'SELECT *, 1 - (embedding <=> ?::vector) AS similarity '
-                 . 'FROM "' . $v . '" '
-                 . 'WHERE embedding IS NOT NULL '
-                 . 'AND NOT (book = ? AND chapter = ? AND verse = ?) '
-                 . 'ORDER BY embedding <=> ?::vector '
-                 . 'LIMIT ?';
-            $stmt = $pdo->prepare($sql);
-            $stmt->execute([$sourceEmbedding, $excludeBook, $excludeChapter, $excludeVerse, $sourceEmbedding, $versionLimit]);
-
-            $versionResults = $this->mapResults($stmt, $v, $versionIndex);
-            array_push($allResults, ...$versionResults);
-        }
-
-        // Sort all results by similarity descending and take top $limit
-        usort($allResults, fn($a, $b) => ( $b['similarity'] ?? 0 ) <=> ( $a['similarity'] ?? 0 ));
-        return array_slice($allResults, 0, $limit);
-    }
 
     /**
      * @param array{abbreviations: list<string>, books: list<string>, book_num: list<string>} $versionIndex
@@ -283,10 +268,9 @@ class SimilarSearchHandler extends AbstractHandler
         while (is_array($row = $stmt->fetch(\PDO::FETCH_ASSOC))) {
             $bookidx = array_search($row['book'], $versionIndex['book_num']);
 
-            $similarity = 0.0;
-            if (isset($row['similarity']) && is_numeric($row['similarity']) && is_finite((float) $row['similarity'])) {
-                $similarity = round((float) $row['similarity'], 4);
-            }
+            $score = isset($row['score']) && is_numeric($row['score']) && is_finite((float) $row['score'])
+                ? round((float) $row['score'], 4)
+                : 0.0;
 
             $entry     = [
                 'version'     => $version,
@@ -299,7 +283,10 @@ class SimilarSearchHandler extends AbstractHandler
                 'section'     => is_numeric($row['section']) ? (int) $row['section'] : 0,
                 'chapter'     => is_numeric($row['chapter']) ? (int) $row['chapter'] : 0,
                 'verse'       => is_numeric($row['verse']) ? (int) $row['verse'] : 0,
-                'similarity'  => $similarity,
+                'score'       => $score,
+                // Carried forward solely so SearchUtils::assignCanonicalOrder
+                // can rank rows; unset before the row leaves the handler.
+                'verseID'     => is_numeric($row['verseID'] ?? null) ? (int) $row['verseID'] : 0,
             ];
             $results[] = $entry;
         }
@@ -363,21 +350,7 @@ class SimilarSearchHandler extends AbstractHandler
         return is_numeric($copyright) && ( (int) $copyright ) === 1;
     }
 
-    /**
-     * @return list<string>
-     */
-    private function getAllVersions(\PDO $pdo): array
-    {
-        $result = $pdo->query('SELECT sigla FROM versions_available');
-        if ($result === false) {
-            throw new InternalServerErrorException('An internal database error occurred.');
-        }
-        $versions = [];
-        while (is_array($row = $result->fetch(\PDO::FETCH_ASSOC))) {
-            $versions[] = StringUtils::asString($row['sigla']);
-        }
-        return $versions;
-    }
+
 
     /**
      * @return array{abbreviations: list<string>, books: list<string>, book_num: list<string>}

--- a/src/Pipeline/QueryExecutor.php
+++ b/src/Pipeline/QueryExecutor.php
@@ -392,7 +392,10 @@ class QueryExecutor
         $row['book']        = $this->ctx->INDEXES[$currentVariant]['biblebooks'][$booknum];
 
         $row['section'] = is_numeric($row['section']) ? (int) $row['section'] : 0;
-        unset($row['verseID'], $row['embedding'], $row['text_hash'], $row['embedded_text_hash']);
+        // verseID is kept here so SearchUtils::assignCanonicalOrder (called by
+        // QuoteHandler after the pipeline runs) can rank rows; it is unset
+        // by the helper before the row leaves the API boundary.
+        unset($row['embedding'], $row['text_hash'], $row['embedded_text_hash']);
         $row['chapter']       = is_numeric($row['chapter']) ? (int) $row['chapter'] : 0;
         $row['originalquery'] = $this->ctx->originalQueries[$this->i] ?? '';
 

--- a/src/Util/SearchUtils.php
+++ b/src/Util/SearchUtils.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BibleGet\Api\Util;
+
+use BibleGet\Api\Http\Exception\ValidationException;
+
+/**
+ * Utilities shared across search handlers (and `/quote`) for parsing the
+ * comma-separated `version=` parameter and emitting subverse-aware
+ * `canonical_order` per response.
+ */
+class SearchUtils
+{
+    /**
+     * Parse a comma-separated `version=` parameter into a list of trimmed,
+     * uppercased sigla, preserving first-occurrence order and dropping
+     * duplicates. Mirrors the convention already used by `/v3/quote`.
+     *
+     * @return list<string>
+     * @throws ValidationException when the parameter is missing or empty
+     */
+    public static function parseVersionsParam(mixed $raw): array
+    {
+        if (!is_string($raw) || trim($raw) === '') {
+            throw new ValidationException('The version parameter is required.');
+        }
+
+        $parts  = array_map('trim', explode(',', strtoupper($raw)));
+        $unique = [];
+        $seen   = [];
+        foreach ($parts as $v) {
+            if ($v !== '' && !isset($seen[$v])) {
+                $seen[$v] = true;
+                $unique[] = $v;
+            }
+        }
+
+        if ($unique === []) {
+            throw new ValidationException('The version parameter is required.');
+        }
+
+        return $unique;
+    }
+
+    /**
+     * Assign a per-version 1-based `canonical_order` to each row, derived
+     * from the row's `verseID` (the subverse-aware canonical-order key the
+     * server has always used internally). Removes `verseID` from each row
+     * after ranking, so the column never leaves the API boundary.
+     *
+     * Within each `version` partition rows are ranked 1..N in ascending
+     * `verseID` order. The original $rows order is preserved — only the
+     * `canonical_order` field is added (and `verseID` is removed).
+     *
+     * @param array<int, array<string, mixed>> $rows
+     */
+    public static function assignCanonicalOrder(array &$rows): void
+    {
+        $rankByIndex = [];
+        $byVersion   = [];
+
+        foreach ($rows as $i => $row) {
+            $version                 = is_string($row['version'] ?? null) ? $row['version'] : '';
+            $verseID                 = is_numeric($row['verseID'] ?? null) ? (int) $row['verseID'] : 0;
+            $byVersion[$version][$i] = $verseID;
+        }
+
+        foreach ($byVersion as $verseIDsByIndex) {
+            asort($verseIDsByIndex, SORT_NUMERIC);
+            $rank = 1;
+            foreach (array_keys($verseIDsByIndex) as $idx) {
+                $rankByIndex[$idx] = $rank++;
+            }
+        }
+
+        foreach ($rows as $i => &$row) {
+            $row['canonical_order'] = $rankByIndex[$i] ?? 0;
+            unset($row['verseID']);
+        }
+    }
+}

--- a/tests/Integration/Handlers/KeywordSearchHandlerTest.php
+++ b/tests/Integration/Handlers/KeywordSearchHandlerTest.php
@@ -290,4 +290,157 @@ class KeywordSearchHandlerTest extends DatabaseTestCase
 
         self::assertSame(200, $response->getStatusCode());
     }
+
+    // ── score field (issue #110) ────────────────────────────
+
+    public function testFulltextScoreIsFloat(): void
+    {
+        $handler  = $this->createHandler();
+        $request  = ( new ServerRequest('GET', '/v3/search/keyword') )
+            ->withQueryParams(['keyword' => 'light', 'version' => 'TEST1', 'match' => 'fulltext']);
+        $response = $handler->handle($request);
+
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($body);
+        self::assertNotEmpty($body['results']);
+        foreach ($body['results'] as $verse) {
+            self::assertArrayHasKey('score', $verse);
+            self::assertIsFloat($verse['score']);
+            self::assertGreaterThanOrEqual(0.0, $verse['score']);
+        }
+    }
+
+    public function testBooleanScoreIsFloat(): void
+    {
+        $handler  = $this->createHandler();
+        $request  = ( new ServerRequest('GET', '/v3/search/keyword') )
+            ->withQueryParams(['keyword' => 'light & good', 'version' => 'TEST1', 'match' => 'boolean']);
+        $response = $handler->handle($request);
+
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($body);
+        if ($body['results'] === []) {
+            self::markTestSkipped('No boolean matches in seed; field shape covered by fulltext test.');
+        }
+        foreach ($body['results'] as $verse) {
+            self::assertArrayHasKey('score', $verse);
+            self::assertIsFloat($verse['score']);
+        }
+    }
+
+    public function testExactScoreIsNull(): void
+    {
+        $handler  = $this->createHandler();
+        $request  = ( new ServerRequest('GET', '/v3/search/keyword') )
+            ->withQueryParams(['keyword' => 'God', 'version' => 'TEST1', 'match' => 'exact']);
+        $response = $handler->handle($request);
+
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($body);
+        self::assertNotEmpty($body['results']);
+        foreach ($body['results'] as $verse) {
+            self::assertArrayHasKey('score', $verse);
+            self::assertNull($verse['score'], 'match=exact has no relevance signal → score must be null');
+        }
+    }
+
+    // ── canonical_order field (issue #110) ──────────────────
+
+    public function testCanonicalOrderPresentAndMonotonic(): void
+    {
+        $handler  = $this->createHandler();
+        $request  = ( new ServerRequest('GET', '/v3/search/keyword') )
+            ->withQueryParams(['keyword' => 'light', 'version' => 'TEST1']);
+        $response = $handler->handle($request);
+
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($body);
+        self::assertNotEmpty($body['results']);
+
+        $orders = [];
+        foreach ($body['results'] as $verse) {
+            self::assertArrayHasKey('canonical_order', $verse);
+            self::assertIsInt($verse['canonical_order']);
+            self::assertGreaterThanOrEqual(1, $verse['canonical_order']);
+            $orders[] = $verse['canonical_order'];
+        }
+
+        $sorted = $orders;
+        sort($sorted, SORT_NUMERIC);
+        self::assertSame($sorted, $orders, 'canonical_order is monotonically increasing under default ORDER BY verseID');
+
+        // Single version → first row's canonical_order must be 1.
+        self::assertSame(1, $body['results'][0]['canonical_order']);
+    }
+
+    public function testNoVerseIDLeak(): void
+    {
+        $handler  = $this->createHandler();
+        $request  = ( new ServerRequest('GET', '/v3/search/keyword') )
+            ->withQueryParams(['keyword' => 'light', 'version' => 'TEST1']);
+        $response = $handler->handle($request);
+
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($body);
+        foreach ($body['results'] as $verse) {
+            self::assertArrayNotHasKey('verseID', $verse, 'verseID must never cross the API boundary');
+        }
+    }
+
+    // ── Multi-version `version=A,B` (issue #110) ────────────
+
+    public function testMultiVersionInterleaved(): void
+    {
+        $handler  = $this->createHandler();
+        $request  = ( new ServerRequest('GET', '/v3/search/keyword') )
+            ->withQueryParams(['keyword' => 'light', 'version' => 'TEST1,TEST2']);
+        $response = $handler->handle($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($body);
+        self::assertNotEmpty($body['results']);
+
+        $versionsSeen = array_unique(array_column($body['results'], 'version'));
+        sort($versionsSeen);
+        self::assertSame(['TEST1', 'TEST2'], $versionsSeen);
+
+        // Per-version partition: first row of each version must be canonical_order=1
+        foreach (['TEST1', 'TEST2'] as $v) {
+            $perVersion = array_values(array_filter(
+                $body['results'],
+                static fn(array $r): bool => $r['version'] === $v
+            ));
+            self::assertNotEmpty($perVersion);
+            $orders = array_column($perVersion, 'canonical_order');
+            self::assertSame(1, min($orders), "First canonical_order for {$v} should be 1");
+        }
+    }
+
+    public function testMultiVersionDeduplicatesAndUppercases(): void
+    {
+        $handler  = $this->createHandler();
+        $request  = ( new ServerRequest('GET', '/v3/search/keyword') )
+            ->withQueryParams(['keyword' => 'light', 'version' => 'test1, TEST2 ,test1']);
+        $response = $handler->handle($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($body);
+        $versionsSeen = array_unique(array_column($body['results'], 'version'));
+        sort($versionsSeen);
+        self::assertSame(['TEST1', 'TEST2'], $versionsSeen);
+    }
+
+    public function testMixedTsLanguageRejected(): void
+    {
+        $handler = $this->createHandler();
+        // TEST1 ts_language=english, VGCL ts_language=simple → must be rejected
+        $request = ( new ServerRequest('GET', '/v3/search/keyword') )
+            ->withQueryParams(['keyword' => 'light', 'version' => 'TEST1,VGCL']);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessageMatches('/ts_language/i');
+        $handler->handle($request);
+    }
 }

--- a/tests/Integration/Handlers/QuoteHandlerTest.php
+++ b/tests/Integration/Handlers/QuoteHandlerTest.php
@@ -256,4 +256,56 @@ class QuoteHandlerTest extends DatabaseTestCase
         $this->expectExceptionMessage('bot access');
         $handler->handle($request);
     }
+
+    // ── canonical_order field (issue #110) ──────────────────
+
+    public function testCanonicalOrderPresentSingleVersion(): void
+    {
+        $handler  = $this->createHandler();
+        $request  = new ServerRequest('GET', '/v3/quote?query=Genesis1,1-5&version=TEST1');
+        $response = $handler->handle($request);
+
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($body);
+        self::assertCount(5, $body['results']);
+
+        $orders = [];
+        foreach ($body['results'] as $row) {
+            self::assertArrayHasKey('canonical_order', $row);
+            self::assertIsInt($row['canonical_order']);
+            self::assertGreaterThanOrEqual(1, $row['canonical_order']);
+            self::assertArrayNotHasKey('verseID', $row, 'verseID must never cross the API boundary');
+            $orders[] = $row['canonical_order'];
+        }
+
+        // Single version → 1..5 in canonical order, monotonic with array order
+        self::assertSame([1, 2, 3, 4, 5], $orders);
+    }
+
+    public function testCanonicalOrderPerVersionPartition(): void
+    {
+        $handler  = $this->createHandler();
+        $request  = new ServerRequest('GET', '/v3/quote?query=Genesis1,1-3&version=TEST1,TEST2');
+        $response = $handler->handle($request);
+
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($body);
+        self::assertCount(6, $body['results']);
+
+        // Per-version partition: each version restarts at canonical_order=1
+        foreach (['TEST1', 'TEST2'] as $v) {
+            $perVersion = array_values(array_filter(
+                $body['results'],
+                static fn(array $r): bool => $r['version'] === $v
+            ));
+            self::assertCount(3, $perVersion);
+            $orders = array_column($perVersion, 'canonical_order');
+            sort($orders, SORT_NUMERIC);
+            self::assertSame([1, 2, 3], $orders, "canonical_order for {$v} should be 1..3");
+        }
+
+        foreach ($body['results'] as $row) {
+            self::assertArrayNotHasKey('verseID', $row);
+        }
+    }
 }

--- a/tests/Integration/Handlers/QuoteHandlerTest.php
+++ b/tests/Integration/Handlers/QuoteHandlerTest.php
@@ -292,16 +292,23 @@ class QuoteHandlerTest extends DatabaseTestCase
         self::assertIsArray($body);
         self::assertCount(6, $body['results']);
 
-        // Per-version partition: each version restarts at canonical_order=1
+        // Per-version partition: each version restarts at canonical_order=1.
+        // The handler returns rows in canonical-key order per version, so the
+        // i-th row of each per-version subset must carry canonical_order=i+1
+        // — a tighter check than just "the set of values is {1,2,3}".
         foreach (['TEST1', 'TEST2'] as $v) {
             $perVersion = array_values(array_filter(
                 $body['results'],
                 static fn(array $r): bool => $r['version'] === $v
             ));
             self::assertCount(3, $perVersion);
-            $orders = array_column($perVersion, 'canonical_order');
-            sort($orders, SORT_NUMERIC);
-            self::assertSame([1, 2, 3], $orders, "canonical_order for {$v} should be 1..3");
+            foreach ($perVersion as $i => $row) {
+                self::assertSame(
+                    $i + 1,
+                    $row['canonical_order'],
+                    "canonical_order for {$v} row {$i} should equal " . ( $i + 1 )
+                );
+            }
         }
 
         foreach ($body['results'] as $row) {

--- a/tests/Integration/Handlers/SemanticSearchHandlerTest.php
+++ b/tests/Integration/Handlers/SemanticSearchHandlerTest.php
@@ -116,7 +116,7 @@ class SemanticSearchHandlerTest extends DatabaseTestCase
         self::assertSame('3.0', $body['info']['ENDPOINT_VERSION']);
     }
 
-    public function testSemanticSearchResultHasSimilarityField(): void
+    public function testSemanticSearchResultHasScoreField(): void
     {
         // Seed a known embedding into a verse so we get a real similarity result.
         // Use a non-zero vector to match against.
@@ -140,10 +140,15 @@ class SemanticSearchHandlerTest extends DatabaseTestCase
         self::assertNotEmpty($body['results'], 'Should find at least the verse with a matching embedding');
 
         $first = $body['results'][0];
-        self::assertArrayHasKey('similarity', $first);
-        self::assertGreaterThan(0.0, $first['similarity']);
+        self::assertArrayHasKey('score', $first);
+        self::assertArrayNotHasKey('similarity', $first, 'similarity field renamed to score (issue #110)');
+        self::assertGreaterThan(0.0, $first['score']);
         self::assertArrayHasKey('text', $first);
         self::assertArrayHasKey('version', $first);
+        self::assertArrayHasKey('canonical_order', $first);
+        self::assertIsInt($first['canonical_order']);
+        self::assertGreaterThanOrEqual(1, $first['canonical_order']);
+        self::assertArrayNotHasKey('verseID', $first, 'verseID must never cross the API boundary');
     }
 
     public function testThresholdFiltersResults(): void
@@ -167,5 +172,93 @@ class SemanticSearchHandlerTest extends DatabaseTestCase
         $body = json_decode((string) $response->getBody(), true);
         self::assertIsArray($body);
         self::assertNotEmpty($body['results']);
+    }
+
+    // ── Multi-version `version=A,B` (issue #110) ────────────
+
+    public function testMultiVersionInterleaved(): void
+    {
+        $pdo = $this->getConnection();
+
+        // Seed the same vector on Gen 1:1 of both TEST1 and TEST2
+        $testVector = array_fill(0, 384, 0.1);
+        $vectorStr  = '[' . implode(',', $testVector) . ']';
+        $pdo->exec('UPDATE "TEST1" SET embedding = \'' . $vectorStr . '\' WHERE book = 1 AND chapter = 1 AND verse = 1');
+        $pdo->exec('UPDATE "TEST2" SET embedding = \'' . $vectorStr . '\' WHERE book = 1 AND chapter = 1 AND verse = 1');
+
+        $mockClient = $this->createMock(EmbeddingClient::class);
+        $mockClient->method('embed')->willReturn($testVector);
+
+        $handler  = $this->createHandler($mockClient);
+        $request  = ( new ServerRequest('GET', '/v3/search/semantic') )
+            ->withQueryParams(['query' => 'creation', 'version' => 'TEST1,TEST2', 'limit' => '10']);
+        $response = $handler->handle($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($body);
+        self::assertNotEmpty($body['results']);
+
+        $versionsSeen = array_unique(array_column($body['results'], 'version'));
+        sort($versionsSeen);
+        self::assertSame(['TEST1', 'TEST2'], $versionsSeen);
+
+        // Per-version partition: each version's first row must have canonical_order=1
+        foreach (['TEST1', 'TEST2'] as $v) {
+            $perVersion = array_values(array_filter(
+                $body['results'],
+                static fn(array $r): bool => $r['version'] === $v
+            ));
+            self::assertNotEmpty($perVersion);
+            $orders = array_column($perVersion, 'canonical_order');
+            self::assertSame(1, min($orders), "First canonical_order for {$v} should be 1");
+        }
+    }
+
+    public function testCanonicalOrderRanksByVerseIDNotByScore(): void
+    {
+        $pdo = $this->getConnection();
+
+        // Wipe any embeddings other tests have left behind on TEST1, then
+        // seed exactly two verses with known scores so we control the result
+        // set entirely.
+        $pdo->exec('UPDATE "TEST1" SET embedding = NULL');
+
+        // Higher-similarity verse on a LATER canonical position (book 2),
+        // weak verse on the EARLIEST canonical position (book 1, ch 1, v 1).
+        // Use distinct directions (not uniform vectors) so cosine similarity
+        // actually differs — uniform vectors are direction-identical regardless
+        // of magnitude.
+        $matchVector   = array_fill(0, 384, 0.5);
+        $matchStr      = '[' . implode(',', $matchVector) . ']';
+        $weakVector    = array_fill(0, 384, 0.5);
+        $weakVector[0] = -0.5;
+        $weakStr       = '[' . implode(',', $weakVector) . ']';
+        $pdo->exec('UPDATE "TEST1" SET embedding = \'' . $matchStr . '\' WHERE book = 2 AND chapter = 1 AND verse = 1');
+        $pdo->exec('UPDATE "TEST1" SET embedding = \'' . $weakStr  . '\' WHERE book = 1 AND chapter = 1 AND verse = 1');
+
+        $mockClient = $this->createMock(EmbeddingClient::class);
+        $mockClient->method('embed')->willReturn($matchVector);
+
+        $handler = $this->createHandler($mockClient);
+        $request = ( new ServerRequest('GET', '/v3/search/semantic') )
+            ->withQueryParams(['query' => 'creation', 'version' => 'TEST1', 'limit' => '10']);
+
+        $response = $handler->handle($request);
+        $body     = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($body);
+        self::assertCount(2, $body['results']);
+
+        // Array is in similarity-desc order (book 2 first, book 1 second),
+        // but canonical_order tracks verseID — so the second-array-position
+        // row (book 1, smaller verseID) has canonical_order = 1, and the
+        // first row (book 2, larger verseID) has canonical_order = 2.
+        self::assertSame(2, $body['results'][0]['canonical_order']);
+        self::assertSame(1, $body['results'][1]['canonical_order']);
+        self::assertGreaterThan(
+            $body['results'][1]['score'],
+            $body['results'][0]['score'],
+            'Array ordering remains similarity-desc'
+        );
     }
 }

--- a/tests/Integration/Handlers/SimilarSearchHandlerTest.php
+++ b/tests/Integration/Handlers/SimilarSearchHandlerTest.php
@@ -139,7 +139,7 @@ class SimilarSearchHandlerTest extends DatabaseTestCase
         }
     }
 
-    public function testSimilarSearchResultHasSimilarityField(): void
+    public function testSimilarSearchResultHasScoreField(): void
     {
         $handler = $this->createHandler();
         $request = ( new ServerRequest('GET', '/v3/search/similar') )
@@ -151,8 +151,13 @@ class SimilarSearchHandlerTest extends DatabaseTestCase
         self::assertNotEmpty($body['results']);
 
         $first = $body['results'][0];
-        self::assertArrayHasKey('similarity', $first);
-        self::assertIsNumeric($first['similarity']);
+        self::assertArrayHasKey('score', $first);
+        self::assertArrayNotHasKey('similarity', $first, 'similarity field renamed to score (issue #110)');
+        self::assertIsNumeric($first['score']);
+        self::assertArrayHasKey('canonical_order', $first);
+        self::assertIsInt($first['canonical_order']);
+        self::assertGreaterThanOrEqual(1, $first['canonical_order']);
+        self::assertArrayNotHasKey('verseID', $first, 'verseID must never cross the API boundary');
     }
 
     public function testInfoContainsEndpointVersion(): void
@@ -165,5 +170,63 @@ class SimilarSearchHandlerTest extends DatabaseTestCase
         $body     = json_decode((string) $response->getBody(), true);
         self::assertIsArray($body);
         self::assertSame('3.0', $body['info']['ENDPOINT_VERSION']);
+    }
+
+    // ── Multi-version `version=A,B` (issue #110) ────────────
+
+    public function testMultiVersionSearchesAllListedVersions(): void
+    {
+        // Seed a couple of TEST2 verses with embeddings so the query can
+        // return non-empty results across both versions.
+        $pdo = $this->getConnection();
+        $v1  = '[' . implode(',', array_fill(0, 384, 0.15)) . ']';
+        $v2  = '[' . implode(',', array_fill(0, 384, -0.05)) . ']';
+        $pdo->exec('UPDATE "TEST2" SET embedding = \'' . $v1 . '\' WHERE book = 1 AND chapter = 1 AND verse = 2');
+        $pdo->exec('UPDATE "TEST2" SET embedding = \'' . $v2 . '\' WHERE book = 1 AND chapter = 1 AND verse = 3');
+
+        $handler = $this->createHandler();
+        $request = ( new ServerRequest('GET', '/v3/search/similar') )
+            ->withQueryParams(['reference' => 'Gen1:1', 'version' => 'TEST1,TEST2', 'limit' => '20']);
+
+        $response = $handler->handle($request);
+        self::assertSame(200, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($body);
+        self::assertNotEmpty($body['results']);
+
+        $versionsSeen = array_unique(array_column($body['results'], 'version'));
+        sort($versionsSeen);
+        self::assertSame(['TEST1', 'TEST2'], $versionsSeen);
+
+        // Per-version partition: each version's first row gets canonical_order=1
+        foreach (['TEST1', 'TEST2'] as $v) {
+            $perVersion = array_values(array_filter(
+                $body['results'],
+                static fn(array $r): bool => $r['version'] === $v
+            ));
+            self::assertNotEmpty($perVersion);
+            $orders = array_column($perVersion, 'canonical_order');
+            self::assertSame(1, min($orders), "First canonical_order for {$v} should be 1");
+        }
+    }
+
+    public function testCrossversionParamHasNoEffect(): void
+    {
+        // crossversion=true was removed (issue #110). Passing it should not
+        // expand the search beyond the explicitly-listed version.
+        $handler = $this->createHandler();
+        $request = ( new ServerRequest('GET', '/v3/search/similar') )
+            ->withQueryParams([
+                'reference'    => 'Gen1:1',
+                'version'      => 'TEST1',
+                'crossversion' => 'true',
+                'limit'        => '20',
+            ]);
+
+        $response = $handler->handle($request);
+        $body     = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($body);
+        $versionsSeen = array_unique(array_column($body['results'], 'version'));
+        self::assertSame(['TEST1'], array_values($versionsSeen));
     }
 }

--- a/tests/Integration/Pipeline/QueryExecutorIntegrationTest.php
+++ b/tests/Integration/Pipeline/QueryExecutorIntegrationTest.php
@@ -135,8 +135,10 @@ class QueryExecutorIntegrationTest extends DatabaseTestCase
         self::assertArrayHasKey('booknum', $verse);
         self::assertArrayHasKey('univbooknum', $verse);
         self::assertArrayHasKey('originalquery', $verse);
-        // verseID should be removed
-        self::assertArrayNotHasKey('verseID', $verse);
+        // verseID is retained at the executor level so QuoteHandler can use
+        // it to derive canonical_order; SearchUtils::assignCanonicalOrder
+        // strips it before the handler emits the response (issue #110).
+        self::assertArrayHasKey('verseID', $verse);
     }
 
     public function testResultBookNameResolved(): void

--- a/tests/Unit/Util/SearchUtilsTest.php
+++ b/tests/Unit/Util/SearchUtilsTest.php
@@ -147,4 +147,26 @@ final class SearchUtilsTest extends TestCase
         SearchUtils::assignCanonicalOrder($rows);
         $this->assertSame([], $rows);
     }
+
+    public function testAssignCanonicalOrderTiedVerseIDsAreDeterministic(): void
+    {
+        // Two rows in the same version with identical verseIDs (a degenerate
+        // case in production, but worth pinning down). PHP's asort is stable
+        // since 8.0, so the row that appeared first in $rows must end up
+        // ranked first; the second tied row gets the next rank.
+        $rows = [
+            ['version' => 'NABRE', 'verseID' => 100, 'text' => 'first'],
+            ['version' => 'NABRE', 'verseID' => 100, 'text' => 'second'],
+            ['version' => 'NABRE', 'verseID' => 200, 'text' => 'third'],
+        ];
+        SearchUtils::assignCanonicalOrder($rows);
+
+        // Both 100s rank ahead of 200 (correct), and the input order between
+        // the two 100s is preserved → ranks 1 and 2 respectively.
+        $this->assertSame(1, $rows[0]['canonical_order']);
+        $this->assertSame(2, $rows[1]['canonical_order']);
+        $this->assertSame(3, $rows[2]['canonical_order']);
+        $this->assertSame('first', $rows[0]['text']);
+        $this->assertSame('second', $rows[1]['text']);
+    }
 }

--- a/tests/Unit/Util/SearchUtilsTest.php
+++ b/tests/Unit/Util/SearchUtilsTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BibleGet\Tests\Unit\Util;
+
+use BibleGet\Api\Http\Exception\ValidationException;
+use BibleGet\Api\Util\SearchUtils;
+use PHPUnit\Framework\TestCase;
+
+final class SearchUtilsTest extends TestCase
+{
+    // ── parseVersionsParam ─────────────────────────────────────────
+
+    public function testParseVersionsParamSingle(): void
+    {
+        $this->assertSame(['NABRE'], SearchUtils::parseVersionsParam('NABRE'));
+    }
+
+    public function testParseVersionsParamCommaSeparated(): void
+    {
+        $this->assertSame(
+            ['NABRE', 'CEI2008', 'NVBSE'],
+            SearchUtils::parseVersionsParam('NABRE,CEI2008,NVBSE')
+        );
+    }
+
+    public function testParseVersionsParamUppercases(): void
+    {
+        $this->assertSame(['NABRE', 'CEI2008'], SearchUtils::parseVersionsParam('nabre, cei2008'));
+    }
+
+    public function testParseVersionsParamTrimsWhitespace(): void
+    {
+        $this->assertSame(['NABRE', 'CEI2008'], SearchUtils::parseVersionsParam(' NABRE , CEI2008 '));
+    }
+
+    public function testParseVersionsParamDeduplicatesPreservingOrder(): void
+    {
+        $this->assertSame(
+            ['NABRE', 'CEI2008'],
+            SearchUtils::parseVersionsParam('NABRE,CEI2008,NABRE,nabre')
+        );
+    }
+
+    public function testParseVersionsParamEmptyStringThrows(): void
+    {
+        $this->expectException(ValidationException::class);
+        SearchUtils::parseVersionsParam('');
+    }
+
+    public function testParseVersionsParamWhitespaceOnlyThrows(): void
+    {
+        $this->expectException(ValidationException::class);
+        SearchUtils::parseVersionsParam('   ');
+    }
+
+    public function testParseVersionsParamCommasOnlyThrows(): void
+    {
+        $this->expectException(ValidationException::class);
+        SearchUtils::parseVersionsParam(', , ,');
+    }
+
+    public function testParseVersionsParamNonStringThrows(): void
+    {
+        $this->expectException(ValidationException::class);
+        SearchUtils::parseVersionsParam(null);
+    }
+
+    // ── assignCanonicalOrder ───────────────────────────────────────
+
+    public function testAssignCanonicalOrderSingleVersionInOrder(): void
+    {
+        $rows = [
+            ['version' => 'NABRE', 'verseID' => 100, 'text' => 'a'],
+            ['version' => 'NABRE', 'verseID' => 200, 'text' => 'b'],
+            ['version' => 'NABRE', 'verseID' => 300, 'text' => 'c'],
+        ];
+        SearchUtils::assignCanonicalOrder($rows);
+
+        $this->assertSame(1, $rows[0]['canonical_order']);
+        $this->assertSame(2, $rows[1]['canonical_order']);
+        $this->assertSame(3, $rows[2]['canonical_order']);
+        $this->assertArrayNotHasKey('verseID', $rows[0]);
+        $this->assertArrayNotHasKey('verseID', $rows[1]);
+        $this->assertArrayNotHasKey('verseID', $rows[2]);
+    }
+
+    public function testAssignCanonicalOrderRanksByVerseIDNotArrayPosition(): void
+    {
+        // Rows arrived in similarity-descending order; canonical_order must
+        // still rank by the underlying verseID.
+        $rows = [
+            ['version' => 'NABRE', 'verseID' => 300, 'similarity' => 0.99],
+            ['version' => 'NABRE', 'verseID' => 100, 'similarity' => 0.85],
+            ['version' => 'NABRE', 'verseID' => 200, 'similarity' => 0.72],
+        ];
+        SearchUtils::assignCanonicalOrder($rows);
+
+        // Output array order is preserved (still similarity-desc)…
+        $this->assertSame(0.99, $rows[0]['similarity']);
+        $this->assertSame(0.85, $rows[1]['similarity']);
+        $this->assertSame(0.72, $rows[2]['similarity']);
+        // …but canonical_order tracks verseID rank.
+        $this->assertSame(3, $rows[0]['canonical_order']); // verseID 300 → rank 3
+        $this->assertSame(1, $rows[1]['canonical_order']); // verseID 100 → rank 1
+        $this->assertSame(2, $rows[2]['canonical_order']); // verseID 200 → rank 2
+    }
+
+    public function testAssignCanonicalOrderPerVersionPartition(): void
+    {
+        $rows = [
+            ['version' => 'NABRE',   'verseID' => 50],
+            ['version' => 'CEI2008', 'verseID' => 9000],
+            ['version' => 'NABRE',   'verseID' => 70],
+            ['version' => 'CEI2008', 'verseID' => 9001],
+            ['version' => 'NABRE',   'verseID' => 60],
+        ];
+        SearchUtils::assignCanonicalOrder($rows);
+
+        // NABRE: verseIDs 50, 70, 60 → ranks 1, 3, 2
+        $this->assertSame(1, $rows[0]['canonical_order']);
+        $this->assertSame(3, $rows[2]['canonical_order']);
+        $this->assertSame(2, $rows[4]['canonical_order']);
+
+        // CEI2008 partition restarts at 1
+        $this->assertSame(1, $rows[1]['canonical_order']);
+        $this->assertSame(2, $rows[3]['canonical_order']);
+    }
+
+    public function testAssignCanonicalOrderHandlesMissingVerseID(): void
+    {
+        $rows = [
+            ['version' => 'NABRE'],
+            ['version' => 'NABRE', 'verseID' => 100],
+        ];
+        SearchUtils::assignCanonicalOrder($rows);
+
+        // Missing verseID coerces to 0; the row sorts before verseID 100.
+        $this->assertSame(1, $rows[0]['canonical_order']);
+        $this->assertSame(2, $rows[1]['canonical_order']);
+    }
+
+    public function testAssignCanonicalOrderEmptyArray(): void
+    {
+        $rows = [];
+        SearchUtils::assignCanonicalOrder($rows);
+        $this->assertSame([], $rows);
+    }
+}


### PR DESCRIPTION
## Summary

Resolves #110 (sparked by Discussion #91 around PR #90). One coherent contract change across all four endpoints that touch verse data.

- **`/v3/search/keyword`** — multi-version `version=A,B,C` with same-`ts_language` guard (400 on mixed), `score: float|null` per row (`ts_rank_cd`, `null` on `match=exact`), `canonical_order: int` per row.
- **`/v3/search/semantic`** — multi-version, `similarity` → `score`, `canonical_order`.
- **`/v3/search/similar`** — `crossversion=true` removed; multi-version `version=A,B,C` (first listed = source); `similarity` → `score`; `canonical_order`.
- **`/v3/quote`** — `canonical_order` exposed (replacing the previously-stripped `verseID`); `verseID` still never crosses the API boundary.
- New shared helper `BibleGet\Api\Util\SearchUtils` — `parseVersionsParam` and `assignCanonicalOrder` (per-version partition, ranks by ascending verseID, strips verseID).
- OpenAPI + README updated.

Supersedes #90 (closed with a thank-you comment). The contributor's `ts_rank_cd` insight, prepared-parameter pattern, and test scaffolding all carried over into this implementation.

## Decisions ratified during review

- **`canonical_order`** = per-response 1-based index, partitioned per version (per-version restart at 1), derived server-side from `verseID`. Raw `verseID` stays internal — clients never see DB info.
- **Multi-version response shape** = flat array with `version` per row, matching `/v3/quote`.
- **Score normalization** = raw values, query-relative, documented as not portable across queries (`ts_rank_cd` for keyword, `1 - cosine_distance` for semantic/similar).
- **`canonical_order` on `/quote`** = in scope for symmetry; `/quote` is the canonical multi-version endpoint and clients composing it with `/search/*` results need consistent ordering data.
- **Score on `match=exact`** = `null`. Regex word-boundary match has no relevance signal.

## Test results

```
OK (455 tests, 1308 assertions)
```

PHPStan level 10 clean. PHPCS clean. OpenAPI validator clean (1 unrelated pre-existing warning).

New tests added in this PR:
- 14 unit tests for `SearchUtils` covering parse semantics, dedup/uppercase, error paths, per-version partition, verseID-rank vs array-position independence
- 8 keyword integration tests for `score` (fulltext/boolean/exact-null), `canonical_order` monotonicity, multi-version interleaving, dedup/uppercase, mixed-language rejection, no `verseID` leak
- 3 semantic integration tests for `score` rename + `canonical_order`, verseID-rank-vs-similarity-position independence, multi-version interleaving
- 2 similar integration tests for multi-version listed-versions and crossversion=true silently ignored
- 2 quote integration tests for `canonical_order` single-version monotonicity and multi-version per-version partition

## Test plan

- [x] Unit + integration tests pass locally (Postgres 16 + pgvector via Docker)
- [x] PHPStan level 10 clean
- [x] PHPCS clean
- [x] OpenAPI valid
- [ ] CI green
- [ ] Manual smoke against staging once deployed

## Out of scope (deferred)

- Hybrid `/v3/search/hybrid` with reciprocal rank fusion across keyword + semantic. Unblocked by this PR (every row of every search endpoint now carries a directly-comparable `score`).
- New match modes `match=phrase`, `match=prefix`.
- Server-side `match-form` rank reproducing the legacy MySQL prefix-match-first emergent ordering. With `score` per row, clients can reorder locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-version searches via comma-separated version lists across search endpoints; versions must share the same language.
  * Added match modes: fulltext, boolean, exact (legacy exactmatch supported); /v3/search remains a backward-compatible alias.
  * Added per-response canonical_order to quote/search rows (per-version, 1-based) and a score field on search results (nullable for exact).
* **Documentation**
  * README/OpenAPI updated with endpoint-specific scoring and ordering semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->