### PR TITLE
fix(embedding): per-model revision pin; stop defaulting MiniLM to LaBSE SHA

### DIFF
--- a/services/embedding/bibleget-embedding.service
+++ b/services/embedding/bibleget-embedding.service
@@ -25,7 +25,14 @@ WorkingDirectory=%h/embedding
 
 # Model cached under the user's HuggingFace cache; pre-warmed during one-time
 # bootstrap so cold starts don't pay the ~470 MB download cost.
+#
+# Pinned MiniLM revision — must be set explicitly. main.py defaults the
+# revision to None (no pin) when EMBEDDING_MODEL_REVISION is unset, so
+# omitting this line would silently drop the deterministic pin required by
+# issue #71. Bump in lockstep with the SHA used to populate the
+# `embedding` column via compute_embeddings.py.
 Environment=EMBEDDING_MODEL=paraphrase-multilingual-MiniLM-L12-v2
+Environment=EMBEDDING_MODEL_REVISION=e8f8c211226b894fcb81acc59f3b34ba3efd5f42
 Environment=HF_HOME=%h/.cache/huggingface
 
 ExecStart=%h/embedding/venv/bin/uvicorn main:app --host 127.0.0.1 --port 8000

--- a/services/embedding/main.py
+++ b/services/embedding/main.py
@@ -21,10 +21,14 @@ from pydantic import BaseModel, Field, field_validator
 from sentence_transformers import SentenceTransformer
 
 MODEL_NAME = os.environ.get("EMBEDDING_MODEL", "sentence-transformers/LaBSE")
-MODEL_REVISION = os.environ.get(
-    "EMBEDDING_MODEL_REVISION",
-    "836121a0533e5664b21c7aacc5d22951f2b8b25b",
-)
+# Revision pin is per-model and must be supplied via EMBEDDING_MODEL_REVISION
+# (set in the systemd unit alongside EMBEDDING_MODEL). Defaulting to a
+# specific SHA here is unsafe because the same default would be applied to
+# every model name, silently poisoning any model whose unit forgot to
+# override it (e.g. trying to load MiniLM at LaBSE's SHA fails with an
+# "Unrecognized model" error). Treat empty/unset as "no pin".
+_revision_env = os.environ.get("EMBEDDING_MODEL_REVISION", "").strip()
+MODEL_REVISION: str | None = _revision_env or None
 
 MAX_TEXT_LENGTH = 10000
 MAX_BATCH_SIZE = 128
@@ -69,7 +73,8 @@ def load_model():
     start = time.time()
     model = SentenceTransformer(MODEL_NAME, revision=MODEL_REVISION)
     elapsed = time.time() - start
-    print(f"Model '{MODEL_NAME}' @ {MODEL_REVISION[:8]} loaded in {elapsed:.1f}s")
+    rev_label = MODEL_REVISION[:8] if MODEL_REVISION else "unpinned"
+    print(f"Model '{MODEL_NAME}' @ {rev_label} loaded in {elapsed:.1f}s")
 
 
 @app.get("/health")


### PR DESCRIPTION
## Summary

Hot-fix for a regression introduced by #120 that prevented the MiniLM embedding service from starting after deploy.

`services/embedding/main.py` was changed in #120 to read `MODEL_REVISION` from the `EMBEDDING_MODEL_REVISION` env var, defaulting to LaBSE's commit SHA `836121a0…`. The MiniLM unit (`bibleget-embedding.service`) sets `EMBEDDING_MODEL=paraphrase-multilingual-MiniLM-L12-v2` but never set `EMBEDDING_MODEL_REVISION`, so on the first restart MiniLM tried to load itself at LaBSE's SHA and crashed at startup:

```
ValueError: Unrecognized model in sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2.
Should have a `model_type` key in its config.json.
```

`deploy-embedding.yaml` then timed out its 30 s `:8000/health` probe and the embedding deploy failed.

## Fix

Two layers — both needed.

1. **`services/embedding/main.py`**: treat empty/unset `EMBEDDING_MODEL_REVISION` as "no pin" (`revision=None`) instead of silently inheriting LaBSE's SHA. Removes the foot-gun for any future model added without thinking to override the env var.
2. **`services/embedding/bibleget-embedding.service`**: pin MiniLM to `e8f8c211226b894fcb81acc59f3b34ba3efd5f42` (current `main` of `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2` on HF Hub) so the deterministic-revision discipline from #71 is preserved for MiniLM.

LaBSE keeps its existing pin in `bibleget-embedding-labse.service`.

## Test plan

- [ ] CI green
- [ ] After merge: re-run `deploy-embedding.yaml` and verify both services healthy (`:8000/health` + `:8002/health` → `"ready":true`)
- [ ] Then run `deploy.yaml` (target `staging`) and smoke-test:
  - `https://query.bibleget.io/dev/search/semantic?query=love&version=NABRE` → `model: "labse"`
  - `https://query.bibleget.io/dev/search/semantic?query=love&version=NABRE&model=minilm` → `model: "minilm"`

---
_Generated by [Claude Code](https://claude.ai/code/session_015YdsXfArn3Dgrp4rfj8XM2)_